### PR TITLE
fix: align Claude refusal streaming aliases

### DIFF
--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -860,13 +860,16 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         if case let .anthropicCompatible(modelId, _) = self {
             return !Anthropic.hasStreamingRefusalRisk(modelId: modelId)
         }
-        if case let .openRouter(modelId) = self, modelId.lowercased().hasPrefix("anthropic/") {
+        if case let .openRouter(modelId) = self {
             return !Anthropic.hasStreamingRefusalRisk(modelId: modelId)
         }
-        if case let .together(modelId) = self, modelId.lowercased().hasPrefix("anthropic/") {
+        if case let .together(modelId) = self {
             return !Anthropic.hasStreamingRefusalRisk(modelId: modelId)
         }
         if case let .openaiCompatible(modelId, _) = self {
+            guard !Anthropic.hasStreamingRefusalRisk(modelId: modelId) else {
+                return false
+            }
             let normalized = modelId.lowercased()
             guard
                 normalized.contains("claude") ||
@@ -875,7 +878,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             {
                 return true
             }
-            return !Anthropic.hasStreamingRefusalRisk(modelId: modelId)
+            return true
         }
         if
             case let .custom(provider) = self,

--- a/Tests/TachikomaTests/Providers/Integration/ProviderSystemTests.swift
+++ b/Tests/TachikomaTests/Providers/Integration/ProviderSystemTests.swift
@@ -175,9 +175,15 @@ struct ProviderSystemTests {
         #expect(Model.anthropic(.opus48).supportsStreaming == false)
         #expect(Model.anthropic(.fable5).supportsStreaming == false)
         #expect(Model.openRouter(modelId: "anthropic/claude-fable-5").supportsStreaming == false)
+        #expect(Model.openRouter(modelId: "fable5").supportsStreaming == false)
         #expect(Model.openRouter(modelId: "anthropic/claude-opus-4-8").supportsStreaming == false)
+        #expect(Model.together(modelId: "claude-fable-5").supportsStreaming == false)
         #expect(Model.openaiCompatible(
             modelId: "anthropic/claude-fable-5",
+            baseURL: "https://example.test",
+        ).supportsStreaming == false)
+        #expect(Model.openaiCompatible(
+            modelId: "fable5",
             baseURL: "https://example.test",
         ).supportsStreaming == false)
         #expect(Model.openaiCompatible(


### PR DESCRIPTION
## Summary
- apply Claude Fable 5 / Opus 4.8 refusal-streaming detection to unqualified OpenRouter, Together, and OpenAI-compatible model aliases
- keep non-Claude OpenAI-compatible models streaming as before
- add capability regressions for unqualified Fable aliases

## Tests
- swift test --filter 'Model Capabilities - Streaming Support'