### PR TITLE
fix: allow compatible reasoning model identity

### DIFF
--- a/Sources/Tachikoma/Providers/Compatible/AnthropicCompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/AnthropicCompatibleProvider.swift
@@ -11,6 +11,7 @@ public final class AnthropicCompatibleProvider: ModelProvider {
     private let configuration: TachikomaConfiguration
     private let auth: TKAuthValue?
     private let reasoningProvider: String
+    private let reasoningModelId: String
     private let reasoningBaseURL: String?
 
     public init(
@@ -22,6 +23,7 @@ public final class AnthropicCompatibleProvider: ModelProvider {
         auth: TKAuthValue? = nil,
         capabilities: ModelCapabilities? = nil,
         reasoningProvider: String = "anthropic-compatible",
+        reasoningModelId: String? = nil,
         reasoningBaseURL: String? = nil,
         includeReasoningBaseURL: Bool = true,
     ) throws {
@@ -30,6 +32,7 @@ public final class AnthropicCompatibleProvider: ModelProvider {
         self.configuration = configuration
         self.additionalHeaders = additionalHeaders
         self.reasoningProvider = reasoningProvider
+        self.reasoningModelId = reasoningModelId ?? modelId
         self.reasoningBaseURL = includeReasoningBaseURL ? (reasoningBaseURL ?? baseURL) : nil
 
         // Try explicit provider key, then configuration, then common environment variable patterns.
@@ -109,7 +112,7 @@ public final class AnthropicCompatibleProvider: ModelProvider {
             additionalHeaders: self.additionalHeaders,
             authOverride: self.auth,
             reasoningProvider: self.reasoningProvider,
-            reasoningModelId: self.modelId,
+            reasoningModelId: self.reasoningModelId,
             reasoningBaseURL: self.reasoningBaseURL,
         )
     }


### PR DESCRIPTION
## Summary
- let Anthropic-compatible providers override the reasoning model id used in signed thinking metadata
- keep existing behavior as the default when no override is supplied
- supports wrappers that expose provider-qualified custom model ids while sending bare upstream model ids

## Tests
- swift test --filter 'Anthropic-compatible provider tags native thinking with wrapper identity'