### PR TITLE
chore(deps): update Swift dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a8e036cb8628fcc1ff67dfec6ce8168617172c9b",
-        "version" : "2.101.1"
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
       }
     },
     {


### PR DESCRIPTION
## Summary

- update `swift-log` 1.13.2 → 1.14.0 ([release](https://github.com/apple/swift-log/releases/tag/1.14.0))
- update `swift-atomics` 1.3.0 → 1.3.1 ([release](https://github.com/apple/swift-atomics/releases/tag/1.3.1))
- update `swift-async-algorithms` 1.1.4 → 1.1.5 ([release](https://github.com/apple/swift-async-algorithms/releases/tag/1.1.5))
- update `swift-nio` 2.101.1 → 2.101.2 ([release](https://github.com/apple/swift-nio/releases/tag/2.101.2))

All four are current stable upstream releases from active Apple repositories and remain within the existing package constraints. This is a lockfile-only maintenance update; no source, API, model identifier, or release metadata changes.

## Risk

Low. Atomics and NIO are narrow fixes; swift-log is additive; async-algorithms is a broader additive release but is transitive here. Tachikoma's full test and production-build paths pass with the resolved graph.

## Validation

- `swift package update --dry-run` — 0 remaining updates
- `TACHIKOMA_TEST_MODE=mock swift test --no-parallel` — 773 tests, 103 suites passed
- `swift build -c release`
- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- `swift package dump-package`
- `swift package show-dependencies --format json`
- `git diff --check`
- autoreview — clean, no accepted/actionable findings
- Public Model Identifier Gate — pass; lockfile-only, no model-bearing surfaces
