### PR TITLE
feat(models): add Sonnet 5 and GPT-5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added first-class Claude Sonnet 5 and OpenAI GPT-5.6 Sol/Terra/Luna support with parsing aliases, capabilities, provider routing, and usage estimates.
 - Added `MiniMax-M3` with 1M context, image input, provider/model parsing, and Anthropic-compatible routing. Thanks @Tugser.
 - Added first-class OpenAI `chat-latest` support with parsing aliases, Responses API routing, model capabilities, and usage estimates.
 - Added first-class MiniMax support with the `MiniMax-M2.7` catalog models, `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` configuration, bearer-token Anthropic-compatible transport, model parsing shortcuts, usage estimates, and provider tests.

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ print(result.text)
 ## Models
 
 Common picks:
-- Anthropic: `claude-opus-4-8` (`LanguageModel.default`, non-streaming), `claude-fable-5` (explicit opt-in)
-- OpenAI: `gpt-5.5` (`LanguageModel.defaultStreaming`), `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-nano`, `gpt-5`
+- Anthropic: `claude-opus-4-8` (`LanguageModel.default`, non-streaming), `claude-sonnet-5`, `claude-fable-5` (explicit opt-in)
+- OpenAI: `gpt-5.5` (`LanguageModel.defaultStreaming`), `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` (preview), `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-nano`, `gpt-5`
 - Google: `gemini-3.1-pro-preview`, `gemini-3-flash`
 - Grok: `grok-4.3`
 - MiniMax: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`

--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -157,6 +157,9 @@ public final class AnthropicProvider: ModelProvider {
         guard let mode else { return nil }
         switch mode {
         case .disabled:
+            if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
+                return AnthropicThinking(type: "disabled", budgetTokens: nil)
+            }
             return nil
         case .adaptive:
             if Self.isFable(model: model) { return nil }
@@ -165,6 +168,9 @@ public final class AnthropicProvider: ModelProvider {
         case let .enabled(budgetTokens):
             if Self.isFable(model: model) {
                 return nil
+            }
+            if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
+                return AnthropicThinking(type: "adaptive", budgetTokens: nil)
             }
             if case .opus48 = model {
                 return AnthropicThinking(type: "adaptive", budgetTokens: nil)
@@ -181,11 +187,16 @@ public final class AnthropicProvider: ModelProvider {
         settings: GenerationSettings,
         model: LanguageModel.Anthropic,
     )
-        -> AnthropicOutputConfig?
+        throws -> AnthropicOutputConfig?
     {
         guard self.supportsEffort(model: model) else { return nil }
-        if let effort = settings.reasoningEffort?.rawValue {
-            return AnthropicOutputConfig(effort: effort)
+        if let effort = settings.reasoningEffort {
+            if !self.supports(effort: effort, model: model) {
+                throw TachikomaError.invalidConfiguration(
+                    "Reasoning effort '\(effort.rawValue)' is not supported by \(model.modelId)",
+                )
+            }
+            return AnthropicOutputConfig(effort: effort.rawValue)
         }
         if case .disabled = mode { return nil }
 
@@ -193,8 +204,24 @@ public final class AnthropicProvider: ModelProvider {
         return effort.map { AnthropicOutputConfig(effort: $0) }
     }
 
+    private func supports(effort: ReasoningEffort, model: LanguageModel.Anthropic) -> Bool {
+        switch effort {
+        case .low, .medium, .high:
+            true
+        case .xhigh:
+            Self.isFable(model: model) ||
+                LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) ||
+                model == .opus48 || model == .opus47
+        case .max:
+            Self.isFable(model: model) ||
+                LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) ||
+                model == .opus48 || model == .opus47 || model == .sonnet46
+        }
+    }
+
     private func usesAdaptiveThinking(model: LanguageModel.Anthropic) -> Bool {
         if Self.isFable(model: model) { return true }
+        if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) { return true }
         if case .opus48 = model { return true }
         if case .opus47 = model { return true }
         if case .sonnet46 = model { return true }
@@ -203,6 +230,7 @@ public final class AnthropicProvider: ModelProvider {
 
     private func supportsEffort(model: LanguageModel.Anthropic) -> Bool {
         if Self.isFable(model: model) { return true }
+        if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) { return true }
         switch model {
         case .opus48, .opus47, .opus45, .sonnet46:
             return true
@@ -250,37 +278,43 @@ public final class AnthropicProvider: ModelProvider {
         }
 
         let validatedSettings = request.settings.validated(for: .anthropic(self.model))
+        let thinkingMode = validatedSettings.providerOptions.anthropic?.thinking
         if
             Self.isFable(model: self.model),
-            case .disabled = validatedSettings.providerOptions.anthropic?.thinking
+            case .disabled = thinkingMode
         {
             throw TachikomaError.invalidConfiguration(
                 "Claude Fable 5 always uses adaptive thinking; disabled thinking is not supported",
             )
         }
-        if Self.isFable(model: self.model), request.messages.last?.role == .assistant {
+        if
+            LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: self.model.modelId),
+            request.messages.last?.role == .assistant
+        {
             throw TachikomaError.invalidConfiguration(
-                "Claude Fable 5 does not support assistant prefill requests",
+                "This Claude model does not support assistant prefill requests",
             )
         }
         let requestedThinking = self.anthropicThinking(
-            from: validatedSettings.providerOptions.anthropic?.thinking,
+            from: thinkingMode,
             model: self.model,
         )
-        let outputConfig = self.anthropicOutputConfig(
-            from: validatedSettings.providerOptions.anthropic?.thinking,
+        let outputConfig = try self.anthropicOutputConfig(
+            from: thinkingMode,
             settings: validatedSettings,
             model: self.model,
         )
         var thinking: AnthropicThinking?
         let systemMessage: String?
         let messages: [AnthropicMessage]
-        let preserveSignedThinking = requestedThinking != nil || self.requiresSignedThinkingReplay(model: self.model)
+        let thinkingDisabled = if case .disabled = thinkingMode { true } else { false }
+        let requiresSignedThinkingReplay = self.requiresSignedThinkingReplay(model: self.model)
+        let preserveSignedThinking = !thinkingDisabled && (requestedThinking != nil || requiresSignedThinkingReplay)
         let reasoningTarget = AnthropicReasoningReplayTarget(
             provider: self.reasoningProvider,
             modelId: self.reasoningModelId,
             endpointIdentity: self.reasoningBaseURL,
-            allowsLegacyUnknown: !Self.isFable(model: self.model),
+            allowsLegacyUnknown: !requiresSignedThinkingReplay,
         )
         do {
             thinking = requestedThinking
@@ -291,7 +325,7 @@ public final class AnthropicProvider: ModelProvider {
             )
         } catch {
             // If we can't provide signed thinking blocks for a cached/history session, fall back to non-thinking mode.
-            if requestedThinking != nil {
+            if requestedThinking != nil, !requiresSignedThinkingReplay {
                 thinking = nil
                 (systemMessage, messages) = try AnthropicMessageConversion.convertMessagesToAnthropic(
                     request.messages,
@@ -496,11 +530,13 @@ public final class AnthropicProvider: ModelProvider {
     }
 
     private func requiresSignedThinkingReplay(model: LanguageModel.Anthropic) -> Bool {
-        Self.isFable(model: model)
+        LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: model.modelId)
     }
 
     private func defaultMaxTokens(for model: LanguageModel.Anthropic) -> Int {
-        if Self.isFable(model: model) { return min(128_000, 16384) }
+        if LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: model.modelId) {
+            return min(model.maxOutputTokens, 16384)
+        }
         return 1024
     }
 
@@ -513,7 +549,7 @@ public final class AnthropicProvider: ModelProvider {
     }
 
     private static func requiresExtendedNonStreamingTimeout(model: LanguageModel.Anthropic, maxTokens: Int) -> Bool {
-        self.isFable(model: model) || maxTokens >= 64000
+        LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: model.modelId) || maxTokens >= 64000
     }
 
     static func mapFinishReason(_ stopReason: String?) -> FinishReason? {

--- a/Sources/Tachikoma/Core/Generation.swift
+++ b/Sources/Tachikoma/Core/Generation.swift
@@ -1092,14 +1092,14 @@ extension LanguageModel {
                 provider: "anthropic",
                 modelId: model.modelId,
                 baseURL: configuration.getBaseURL(for: .anthropic) ?? Provider.anthropic.defaultBaseURL,
-                allowsLegacyUnknown: !LanguageModel.Anthropic.isFable(modelId: model.modelId),
+                allowsLegacyUnknown: !LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: model.modelId),
             )
         case let .anthropicCompatible(modelId, baseURL):
             return ReasoningReplayTarget(
                 provider: "anthropic-compatible",
                 modelId: modelId,
                 baseURL: baseURL,
-                allowsLegacyUnknown: !LanguageModel.Anthropic.isFable(modelId: modelId),
+                allowsLegacyUnknown: !LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: modelId),
             )
         case let .minimax(model):
             return ReasoningReplayTarget(
@@ -1121,7 +1121,8 @@ extension LanguageModel {
                     provider: "anthropic",
                     modelId: directAnthropicProvider.modelId,
                     baseURL: directAnthropicProvider.baseURL ?? Provider.anthropic.defaultBaseURL,
-                    allowsLegacyUnknown: !LanguageModel.Anthropic.isFable(modelId: directAnthropicProvider.modelId),
+                    allowsLegacyUnknown: !LanguageModel.Anthropic
+                        .hasDefaultAdaptiveThinking(modelId: directAnthropicProvider.modelId),
                 )
             }
             if let compatibleProvider = provider as? AnthropicCompatibleProvider {
@@ -1129,7 +1130,8 @@ extension LanguageModel {
                     provider: "anthropic-compatible",
                     modelId: compatibleProvider.modelId,
                     baseURL: compatibleProvider.baseURL,
-                    allowsLegacyUnknown: !LanguageModel.Anthropic.isFable(modelId: compatibleProvider.modelId),
+                    allowsLegacyUnknown: !LanguageModel.Anthropic
+                        .hasDefaultAdaptiveThinking(modelId: compatibleProvider.modelId),
                 )
             }
             guard
@@ -1142,7 +1144,8 @@ extension LanguageModel {
                         provider: "custom-anthropic",
                         modelId: provider.modelId,
                         baseURL: provider.baseURL,
-                        allowsLegacyUnknown: !LanguageModel.Anthropic.isFable(modelId: provider.modelId),
+                        allowsLegacyUnknown: !LanguageModel.Anthropic
+                            .hasDefaultAdaptiveThinking(modelId: provider.modelId),
                     )
                     : nil
             }
@@ -1150,7 +1153,7 @@ extension LanguageModel {
                 provider: "custom-anthropic",
                 modelId: parsed.model,
                 baseURL: registeredProvider.baseURL,
-                allowsLegacyUnknown: !LanguageModel.Anthropic.isFable(modelId: parsed.model),
+                allowsLegacyUnknown: !LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: parsed.model),
             )
         default:
             return nil

--- a/Sources/Tachikoma/Core/ModelCapabilities.swift
+++ b/Sources/Tachikoma/Core/ModelCapabilities.swift
@@ -242,9 +242,14 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
             ),
             excludedParameters: ["temperature", "topP", "frequencyPenalty", "presencePenalty"],
         )
+        var gpt56Capabilities = gpt5Capabilities
+        gpt56Capabilities.supportedProviderOptions.supportsReasoningEffort = true
 
         self.capabilities["openai:chat-latest"] = gpt5Capabilities
         self.capabilities["openai:gpt-5-chat-latest"] = gpt5Capabilities
+        self.capabilities["openai:gpt-5.6-sol"] = gpt56Capabilities
+        self.capabilities["openai:gpt-5.6-terra"] = gpt56Capabilities
+        self.capabilities["openai:gpt-5.6-luna"] = gpt56Capabilities
         self.capabilities["openai:gpt-5.5"] = gpt5Capabilities
         self.capabilities["openai:gpt-5.4"] = gpt5Capabilities
         self.capabilities["openai:gpt-5.4-mini"] = gpt5Capabilities
@@ -262,7 +267,7 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
             ),
         )
 
-        // Fable 5 and Opus 4.7+ map requested thinking to Anthropic's adaptive thinking request shape.
+        // Current Claude models map requested thinking to Anthropic's adaptive thinking request shape.
         let claudeAdaptiveThinkingCapabilities = ModelParameterCapabilities(
             supportsTemperature: false,
             supportsTopP: false,
@@ -274,6 +279,7 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
             excludedParameters: ["temperature", "topP", "topK"],
         )
         self.capabilities["anthropic:claude-fable-5"] = claudeAdaptiveThinkingCapabilities
+        self.capabilities["anthropic:claude-sonnet-5"] = claudeAdaptiveThinkingCapabilities
         self.capabilities["anthropic:claude-opus-4-8"] = claudeAdaptiveThinkingCapabilities
         self.capabilities["anthropic:claude-opus-4-7"] = claudeAdaptiveThinkingCapabilities
         self.capabilities["anthropic:claude-opus-4-5"] = claude4Capabilities
@@ -361,7 +367,7 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
             return registered
         }
 
-        if self.isAnthropicFableCompatible(model) {
+        if self.isAnthropicAdaptiveThinkingModel(model) {
             return ModelParameterCapabilities(
                 supportsTemperature: false,
                 supportsTopP: false,
@@ -413,20 +419,25 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
         }
     }
 
-    private func isAnthropicFableCompatible(_ model: LanguageModel) -> Bool {
+    private func isAnthropicAdaptiveThinkingModel(_ model: LanguageModel) -> Bool {
+        func matches(_ modelId: String) -> Bool {
+            LanguageModel.Anthropic.isFable(modelId: modelId) ||
+                LanguageModel.Anthropic.isSonnet5(modelId: modelId)
+        }
+
         switch model {
         case let .anthropic(anthropic):
-            return LanguageModel.Anthropic.isFable(modelId: anthropic.modelId)
+            return matches(anthropic.modelId)
         case let .anthropicCompatible(modelId, _):
-            return LanguageModel.Anthropic.isFable(modelId: modelId)
+            return matches(modelId)
         case let .openRouter(modelId),
              let .openaiCompatible(modelId, _),
              let .together(modelId):
-            return LanguageModel.Anthropic.isFable(modelId: modelId)
+            return matches(modelId)
         case let .custom(provider):
             guard
                 let parsed = ProviderParser.parse(provider.modelId),
-                LanguageModel.Anthropic.isFable(modelId: parsed.model),
+                matches(parsed.model),
                 CustomProviderRegistry.shared.get(parsed.provider)?.kind == .anthropic else
             {
                 return false

--- a/Sources/Tachikoma/Core/ProviderOptions.swift
+++ b/Sources/Tachikoma/Core/ProviderOptions.swift
@@ -120,6 +120,8 @@ public struct OpenAIOptions: Sendable, Codable {
         case low
         case medium
         case high
+        case xhigh
+        case max
     }
 }
 

--- a/Sources/Tachikoma/Core/Types.swift
+++ b/Sources/Tachikoma/Core/Types.swift
@@ -187,6 +187,7 @@ public enum OpenAIAPIMode: String, Sendable, CaseIterable {
         // Determine default API mode for a given model
         switch model {
         case .chatLatest, .gpt5ChatLatest,
+             .gpt56Sol, .gpt56Terra, .gpt56Luna,
              .gpt5, .gpt5Pro, .gpt5Mini, .gpt5Nano, .gpt54, .gpt54Mini, .gpt54Nano, .gpt55:
             .responses // GPT-5 defaults to Responses API
         default:
@@ -650,6 +651,8 @@ public enum ReasoningEffort: String, Sendable, Codable, CaseIterable {
     case low
     case medium
     case high
+    case xhigh
+    case max
 }
 
 /// Metadata for messages (conversation context, etc.)

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -41,6 +41,11 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         /// GPT-5.5 Series
         case gpt55 // Flagship GPT-5.5
 
+        /// GPT-5.6 preview series
+        case gpt56Sol
+        case gpt56Terra
+        case gpt56Luna
+
         /// GPT-5.4 Series
         case gpt54
         case gpt54Mini
@@ -59,6 +64,9 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             [
                 .chatLatest,
                 .gpt5ChatLatest,
+                .gpt56Sol,
+                .gpt56Terra,
+                .gpt56Luna,
                 .gpt55,
                 .gpt54,
                 .gpt54Mini,
@@ -75,6 +83,9 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             case let .custom(id): id
             case .chatLatest: "chat-latest"
             case .gpt5ChatLatest: "gpt-5-chat-latest"
+            case .gpt56Sol: "gpt-5.6-sol"
+            case .gpt56Terra: "gpt-5.6-terra"
+            case .gpt56Luna: "gpt-5.6-luna"
             case .gpt55: "gpt-5.5"
             case .gpt54: "gpt-5.4"
             case .gpt54Mini: "gpt-5.4-mini"
@@ -90,6 +101,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             switch self {
             case .chatLatest,
                  .gpt5ChatLatest,
+                 .gpt56Sol, .gpt56Terra, .gpt56Luna,
                  .gpt55,
                  .gpt54, .gpt54Mini, .gpt54Nano,
                  .gpt5, .gpt5Pro, .gpt5Mini, .gpt5Nano: true // GPT-5+ supports multimodal
@@ -101,6 +113,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             switch self {
             case .chatLatest,
                  .gpt5ChatLatest,
+                 .gpt56Sol, .gpt56Terra, .gpt56Luna,
                  .gpt55,
                  .gpt54, .gpt54Mini, .gpt54Nano,
                  .gpt5, .gpt5Pro, .gpt5Mini, .gpt5Nano: true // GPT-5+ excels at tool calling
@@ -135,6 +148,8 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             switch self {
             case .gpt5ChatLatest:
                 128_000
+            case .gpt56Sol, .gpt56Terra, .gpt56Luna:
+                372_000
             case .chatLatest, .gpt55,
                  .gpt54, .gpt54Mini, .gpt54Nano,
                  .gpt5, .gpt5Pro, .gpt5Mini, .gpt5Nano: 400_000 // 272k input + 128k output
@@ -158,6 +173,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
     public enum Anthropic: Sendable, Hashable, CaseIterable {
         // Claude 5 / 4.x Series
         case fable5
+        case sonnet5
         case opus48
         case opus47
         case opus45
@@ -172,6 +188,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         public static var allCases: [Anthropic] {
             [
                 .fable5,
+                .sonnet5,
                 .opus48,
                 .opus47,
                 .opus45,
@@ -186,6 +203,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             switch self {
             case let .custom(id): id
             case .fable5: "claude-fable-5"
+            case .sonnet5: "claude-sonnet-5"
             case .opus48: "claude-opus-4-8"
             case .opus47: "claude-opus-4-7"
             case .opus45: "claude-opus-4-5"
@@ -198,7 +216,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public var supportsVision: Bool {
             switch self {
-            case .fable5, .opus48, .opus47, .opus45, .opus4, .sonnet46, .sonnet45, .haiku45:
+            case .fable5, .sonnet5, .opus48, .opus47, .opus45, .opus4, .sonnet46, .sonnet45, .haiku45:
                 true
             case .custom: true // Assume custom models support vision
             }
@@ -220,20 +238,20 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public var contextLength: Int {
             switch self {
-            case .fable5, .opus48, .opus47, .sonnet46: 1_000_000
+            case .fable5, .sonnet5, .opus48, .opus47, .sonnet46: 1_000_000
             case .haiku45: 200_000
             case .opus45, .opus4, .sonnet45: 500_000
             case let .custom(id):
-                Self.isFable(modelId: id) ? 1_000_000 : 200_000 // Default assumption
+                Self.hasMillionTokenContext(modelId: id) ? 1_000_000 : 200_000 // Default assumption
             }
         }
 
         public var maxOutputTokens: Int {
             switch self {
-            case .fable5, .opus48, .opus47: 128_000
+            case .fable5, .sonnet5, .opus48, .opus47: 128_000
             case .sonnet46, .haiku45: 64000
             case let .custom(id):
-                Self.isFable(modelId: id) ? 128_000 : 8192
+                Self.has128KOutput(modelId: id) ? 128_000 : 8192
             case .opus45, .opus4, .sonnet45: 4096
             }
         }
@@ -266,6 +284,41 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             }
         }
 
+        public static func isSonnet5(modelId: String) -> Bool {
+            let normalized = modelId.lowercased()
+            let pathSegments = normalized
+                .components(separatedBy: CharacterSet(charactersIn: "/:@"))
+                .filter { !$0.isEmpty }
+            let dotSegments = pathSegments.flatMap { $0.components(separatedBy: ".") }
+                .filter { !$0.isEmpty }
+            let segments = pathSegments + dotSegments
+            let canonicalSegments: Set = [
+                "claude-sonnet-5",
+                "sonnet-5",
+                "sonnet5",
+            ]
+            return normalized == Self.sonnet5.modelId || segments.contains { segment in
+                if canonicalSegments.contains(segment) { return true }
+                let compactSegment = segment
+                    .replacingOccurrences(of: "-", with: "")
+                    .replacingOccurrences(of: "_", with: "")
+                    .replacingOccurrences(of: ".", with: "")
+                return compactSegment == "claudesonnet5" || compactSegment == "sonnet5"
+            }
+        }
+
+        public static func hasMillionTokenContext(modelId: String) -> Bool {
+            self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId)
+        }
+
+        public static func hasDefaultAdaptiveThinking(modelId: String) -> Bool {
+            self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId)
+        }
+
+        public static func has128KOutput(modelId: String) -> Bool {
+            self.hasMillionTokenContext(modelId: modelId)
+        }
+
         public static func isOpus48(modelId: String) -> Bool {
             let normalized = modelId.lowercased()
             let compactExact = normalized
@@ -294,7 +347,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         }
 
         public static func hasStreamingRefusalRisk(modelId: String) -> Bool {
-            self.isFable(modelId: modelId) || self.isOpus48(modelId: modelId)
+            self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId) || self.isOpus48(modelId: modelId)
         }
     }
 
@@ -1131,13 +1184,13 @@ extension LanguageModel {
         case .azureOpenAI:
             128_000 // conservative default matching OpenAI tier
         case let .openRouter(modelId), let .together(modelId):
-            Anthropic.isFable(modelId: modelId) ? 1_000_000 : 128_000
+            Anthropic.hasMillionTokenContext(modelId: modelId) ? 1_000_000 : 128_000
         case .replicate:
             128_000 // Common default
         case let .openaiCompatible(modelId, _):
-            Anthropic.isFable(modelId: modelId) ? 1_000_000 : 128_000
+            Anthropic.hasMillionTokenContext(modelId: modelId) ? 1_000_000 : 128_000
         case let .anthropicCompatible(modelId, _):
-            Anthropic.isFable(modelId: modelId) ? 1_000_000 : 128_000
+            Anthropic.hasMillionTokenContext(modelId: modelId) ? 1_000_000 : 128_000
         case let .custom(provider):
             provider.capabilities.contextLength
         }
@@ -1372,6 +1425,20 @@ extension LanguageModel {
             return .openai(.gpt5ChatLatest)
         }
 
+        switch compact {
+        case "gpt56", "gpt56sol":
+            return .openai(.gpt56Sol)
+        case "gpt56terra":
+            return .openai(.gpt56Terra)
+        case "gpt56luna":
+            return .openai(.gpt56Luna)
+        default:
+            break
+        }
+        if compact.contains("gpt56") {
+            return nil
+        }
+
         if dashed == "gpt-5-pro" || compact == "gpt5pro" {
             return .openai(.gpt5Pro)
         }
@@ -1435,6 +1502,20 @@ extension LanguageModel {
             )
         {
             return .anthropic(.fable5)
+        }
+
+        if
+            matchesExactAlias(
+                [
+                    "claude-sonnet-5",
+                    "sonnet-5",
+                    "sonnet.5",
+                    "sonnet5",
+                ],
+                compactAliases: ["claudesonnet5", "sonnet5"],
+            )
+        {
+            return .anthropic(.sonnet5)
         }
 
         if

--- a/Sources/Tachikoma/Models/ModelSelection.swift
+++ b/Sources/Tachikoma/Models/ModelSelection.swift
@@ -123,6 +123,14 @@ public struct ModelSelector {
             return .chatLatest
         case "gpt-5-chat-latest", "gpt5-chat-latest", "gpt5chatlatest":
             return .gpt5ChatLatest
+        // GPT-5.6 preview models
+        case "gpt-5.6", "gpt5.6", "gpt-5-6", "gpt5-6", "gpt56",
+             "gpt-5.6-sol", "gpt5.6-sol", "gpt-5-6-sol", "gpt5-6-sol", "gpt56-sol", "gpt56sol":
+            return .gpt56Sol
+        case "gpt-5.6-terra", "gpt5.6-terra", "gpt-5-6-terra", "gpt5-6-terra", "gpt56-terra", "gpt56terra":
+            return .gpt56Terra
+        case "gpt-5.6-luna", "gpt5.6-luna", "gpt-5-6-luna", "gpt5-6-luna", "gpt56-luna", "gpt56luna":
+            return .gpt56Luna
         // GPT-5.5 models
         case "gpt-5.5", "gpt5.5", "gpt-5-5", "gpt5-5", "gpt55":
             return .gpt55
@@ -168,6 +176,8 @@ public struct ModelSelector {
         // Direct matches
         case "claude-fable-5", "claude-fable-5-latest", "fable-5", "fable.5", "fable5", "fable":
             return .fable5
+        case "claude-sonnet-5", "sonnet-5", "sonnet.5", "sonnet5":
+            return .sonnet5
         case "claude-opus-4-8", "claude-opus-4.8", "opus-4-8", "opus-4.8", "opus48",
              "claude-opus-4-8-latest":
             return .opus48
@@ -185,7 +195,7 @@ public struct ModelSelector {
         case "claude-opus", "opus":
             return .opus48
         case "claude-sonnet", "sonnet":
-            return .sonnet46
+            return .sonnet5
         case "claude-haiku", "haiku":
             return .haiku45
         case "anthropic":

--- a/Sources/Tachikoma/Providers/Compatible/AnthropicCompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/AnthropicCompatibleProvider.swift
@@ -61,14 +61,14 @@ public final class AnthropicCompatibleProvider: ModelProvider {
             self.auth = nil
         }
 
-        let isFable = LanguageModel.Anthropic.isFable(modelId: modelId)
+        let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
         let supportsSafeStreaming = !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId)
         let baseCapabilities = capabilities ?? ModelCapabilities(
             supportsVision: true,
             supportsTools: true,
             supportsStreaming: supportsSafeStreaming,
-            contextLength: isFable ? 1_000_000 : 200_000,
-            maxOutputTokens: isFable ? 128_000 : 8192,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : 200_000,
+            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 8192,
         )
         self.capabilities = supportsSafeStreaming ? baseCapabilities : ModelCapabilities(
             supportsVision: baseCapabilities.supportsVision,

--- a/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
@@ -40,13 +40,13 @@ public final class OpenAICompatibleProvider: ModelProvider {
             self.apiKey = nil // Some compatible APIs don't require keys
         }
 
-        let isFable = LanguageModel.Anthropic.isFable(modelId: modelId)
+        let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
         self.capabilities = ModelCapabilities(
             supportsVision: false,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),
-            contextLength: isFable ? 1_000_000 : 128_000,
-            maxOutputTokens: isFable ? 128_000 : 4096,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : 128_000,
+            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 4096,
         )
     }
 

--- a/Sources/Tachikoma/Providers/LMStudioProvider.swift
+++ b/Sources/Tachikoma/Providers/LMStudioProvider.swift
@@ -308,7 +308,7 @@ public actor LMStudioProvider: ModelProvider {
 
     private func mapReasoningEffortToParams(_ effort: ReasoningEffort) -> [String: Any] {
         switch effort {
-        case .high:
+        case .high, .xhigh, .max:
             [
                 "repeat_penalty": 1.1,
                 "presence_penalty": 0.1,
@@ -340,7 +340,7 @@ public actor LMStudioProvider: ModelProvider {
         guard let effort else { return base }
 
         switch effort {
-        case .high:
+        case .high, .xhigh, .max:
             return min(base * 1.2, 1.5) // Increase temperature for exploration
         case .medium:
             return base

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -508,11 +508,17 @@ public final class OpenAIResponsesProvider: ModelProvider {
         // Determine reasoning configuration
         let reasoning: ReasoningConfig?
         if Self.isReasoningModel(self.model) || Self.isGPT5Model(self.model) {
-            let effort: OpenAIReasoningEffort = if let optionEffort = openaiOptions?.reasoningEffort {
+            let effort: OpenAIReasoningEffort
+            if let optionEffort = openaiOptions?.reasoningEffort {
+                if Self.isGPT56Model(self.model), optionEffort == .minimal {
+                    throw TachikomaError.invalidConfiguration(
+                        "GPT-5.6 does not support 'minimal' reasoning effort; use 'low' or higher",
+                    )
+                }
                 // Convert from public API to internal type
-                OpenAIReasoningEffort(rawValue: optionEffort.rawValue) ?? .medium
+                effort = OpenAIReasoningEffort(rawValue: optionEffort.rawValue) ?? .medium
             } else {
-                .medium // Default
+                effort = .medium // Default
             }
             reasoning = ReasoningConfig(
                 effort: effort,
@@ -1043,7 +1049,10 @@ public final class OpenAIResponsesProvider: ModelProvider {
 
     private static func isGPT5Model(_ model: LanguageModel.OpenAI) -> Bool {
         switch model {
-        case .gpt55,
+        case .gpt56Sol,
+             .gpt56Terra,
+             .gpt56Luna,
+             .gpt55,
              .gpt54,
              .gpt54Mini,
              .gpt54Nano,
@@ -1051,6 +1060,15 @@ public final class OpenAIResponsesProvider: ModelProvider {
              .gpt5Pro,
              .gpt5Mini,
              .gpt5Nano:
+            true
+        default:
+            false
+        }
+    }
+
+    private static func isGPT56Model(_ model: LanguageModel.OpenAI) -> Bool {
+        switch model {
+        case .gpt56Sol, .gpt56Terra, .gpt56Luna:
             true
         default:
             false

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesTypes.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesTypes.swift
@@ -75,6 +75,8 @@ enum OpenAIReasoningEffort: String, Codable {
     case low
     case medium
     case high
+    case xhigh
+    case max
 }
 
 /// Reasoning summary modes for reasoning models

--- a/Sources/Tachikoma/Providers/OpenRouter/OpenRouterProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenRouter/OpenRouterProvider.swift
@@ -33,13 +33,13 @@ public final class OpenRouterProvider: ModelProvider {
             throw TachikomaError.authenticationFailed("OPENROUTER_API_KEY not found")
         }
 
-        let isFable = LanguageModel.Anthropic.isFable(modelId: modelId)
+        let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
         self.capabilities = ModelCapabilities(
             supportsVision: true,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),
-            contextLength: isFable ? 1_000_000 : 128_000,
-            maxOutputTokens: isFable ? 128_000 : 4096,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : 128_000,
+            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 4096,
         )
 
         self.defaultHeaders = [

--- a/Sources/Tachikoma/Providers/ProviderFactory.swift
+++ b/Sources/Tachikoma/Providers/ProviderFactory.swift
@@ -19,6 +19,9 @@ public struct ProviderFactory {
             switch openaiModel {
             case .chatLatest,
                  .gpt5ChatLatest,
+                 .gpt56Sol,
+                 .gpt56Terra,
+                 .gpt56Luna,
                  .gpt55,
                  .gpt54,
                  .gpt54Mini,

--- a/Sources/Tachikoma/Providers/ProviderParser.swift
+++ b/Sources/Tachikoma/Providers/ProviderParser.swift
@@ -244,6 +244,13 @@ public enum ProviderParser {
             .openai(.chatLatest)
         case "gpt-5-chat-latest", "gpt5-chat-latest", "gpt5chatlatest":
             .openai(.gpt5ChatLatest)
+        case "gpt-5.6", "gpt5.6", "gpt-5-6", "gpt5-6", "gpt56",
+             "gpt-5.6-sol", "gpt5.6-sol", "gpt-5-6-sol", "gpt5-6-sol", "gpt56-sol", "gpt56sol":
+            .openai(.gpt56Sol)
+        case "gpt-5.6-terra", "gpt5.6-terra", "gpt-5-6-terra", "gpt5-6-terra", "gpt56-terra", "gpt56terra":
+            .openai(.gpt56Terra)
+        case "gpt-5.6-luna", "gpt5.6-luna", "gpt-5-6-luna", "gpt5-6-luna", "gpt56-luna", "gpt56luna":
+            .openai(.gpt56Luna)
         case "gpt-5.5", "gpt5.5", "gpt-5-5", "gpt5-5", "gpt55": .openai(.gpt55)
         case "gpt-5.5-mini", "gpt5.5-mini", "gpt-5-5-mini", "gpt5-5-mini", "gpt55-mini", "gpt55mini":
             .openai(.gpt5Mini)
@@ -279,6 +286,8 @@ public enum ProviderParser {
         return switch normalized {
         case "claude-fable-5", "claude-fable-5-latest", "fable-5", "fable.5", "fable5", "fable":
             .anthropic(.fable5)
+        case "claude-sonnet-5", "sonnet-5", "sonnet.5", "sonnet5", "sonnet":
+            .anthropic(.sonnet5)
         case "claude-opus-4-8", "claude-opus-4.8", "claude-opus-4-8-latest", "opus-4-8", "opus-4.8",
              "opus48", "claude", "claude-latest", "claude_latest", "claudelatest", "claude-default", "claude_default":
             .anthropic(.opus48)

--- a/Sources/Tachikoma/Providers/Together/TogetherProvider.swift
+++ b/Sources/Tachikoma/Providers/Together/TogetherProvider.swift
@@ -27,13 +27,13 @@ public final class TogetherProvider: ModelProvider {
             throw TachikomaError.authenticationFailed("TOGETHER_API_KEY not found")
         }
 
-        let isFable = LanguageModel.Anthropic.isFable(modelId: modelId)
+        let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
         self.capabilities = ModelCapabilities(
             supportsVision: true,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),
-            contextLength: isFable ? 1_000_000 : 128_000,
-            maxOutputTokens: isFable ? 128_000 : 4096,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : 128_000,
+            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 4096,
         )
     }
 

--- a/Sources/Tachikoma/Utilities/RetryHandler.swift
+++ b/Sources/Tachikoma/Utilities/RetryHandler.swift
@@ -215,7 +215,7 @@ extension RetryHandler {
     /// Create a retry handler based on generation settings
     public static func from(settings: GenerationSettings) -> RetryHandler {
         // Use aggressive retry for high reasoning effort (important queries)
-        if settings.reasoningEffort == .high {
+        if let effort = settings.reasoningEffort, [.high, .xhigh, .max].contains(effort) {
             RetryHandler(policy: .aggressive)
         } else if settings.reasoningEffort == .low {
             RetryHandler(policy: .conservative)

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -530,6 +530,9 @@ public struct ModelCostCalculator: Sendable {
             switch openaiModel {
             case .chatLatest: (5.00, 30.00) // ChatGPT Instant alias pricing estimate
             case .gpt5ChatLatest: (1.25, 10.00)
+            case .gpt56Sol: (5.00, 30.00)
+            case .gpt56Terra: (2.50, 15.00)
+            case .gpt56Luna: (1.00, 6.00)
             case .gpt55: (5.00, 20.00) // GPT-5.5 pricing estimate
             case .gpt54: (5.00, 20.00) // GPT-5.4 pricing estimate
             case .gpt54Mini: (1.00, 4.00)
@@ -538,12 +541,19 @@ public struct ModelCostCalculator: Sendable {
             case .gpt5Pro: (12.00, 48.00) // Higher reasoning budget
             case .gpt5Mini: (1.00, 4.00) // GPT-5 Mini pricing estimate
             case .gpt5Nano: (0.50, 2.00) // GPT-5 Nano pricing estimate
-            case .custom: (2.50, 10.00) // Default estimate
+            case let .custom(id):
+                switch LanguageModel.parse(from: id) {
+                case .openai(.gpt56Sol): (5.00, 30.00)
+                case .openai(.gpt56Terra): (2.50, 15.00)
+                case .openai(.gpt56Luna): (1.00, 6.00)
+                default: (2.50, 10.00) // Default estimate
+                }
             }
         // Anthropic Pricing (as of 2026)
         case let .anthropic(anthropicModel):
             switch anthropicModel {
             case .fable5: (10.00, 50.00)
+            case .sonnet5: (2.00, 10.00) // Introductory pricing through August 31, 2026
             case .opus48: (5.00, 25.00)
             case .opus47: (5.00, 25.00)
             case .opus45: (5.00, 25.00)
@@ -552,7 +562,13 @@ public struct ModelCostCalculator: Sendable {
             case .sonnet45: (4.00, 18.00)
             case .haiku45: (1.20, 6.00)
             case let .custom(id):
-                id.lowercased().contains("claude-fable-5") ? (10.00, 50.00) : (3.00, 15.00)
+                if LanguageModel.Anthropic.isFable(modelId: id) {
+                    (10.00, 50.00)
+                } else if LanguageModel.Anthropic.isSonnet5(modelId: id) {
+                    (2.00, 10.00)
+                } else {
+                    (3.00, 15.00)
+                }
             }
         // Google Pricing (standard tier, as of 2026)
         case let .google(googleModel):

--- a/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
+++ b/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
@@ -7,6 +7,9 @@ struct LanguageModelCoverageTests {
         let models = LanguageModel.OpenAI.allCases
         #expect(!models.isEmpty)
         #expect(models.contains(.gpt5ChatLatest))
+        #expect(models.contains(.gpt56Sol))
+        #expect(models.contains(.gpt56Terra))
+        #expect(models.contains(.gpt56Luna))
         for model in models {
             #expect(!model.modelId.isEmpty)
             _ = model.supportsVision
@@ -19,7 +22,19 @@ struct LanguageModelCoverageTests {
     }
 
     @Test
+    func `GPT-5.6 models default to Responses API`() {
+        for model in [
+            LanguageModel.OpenAI.gpt56Sol,
+            .gpt56Terra,
+            .gpt56Luna,
+        ] {
+            #expect(OpenAIAPIMode.defaultMode(for: model) == .responses)
+        }
+    }
+
+    @Test
     func `Anthropic enum exposes properties`() {
+        #expect(LanguageModel.Anthropic.allCases.contains(.sonnet5))
         for model in LanguageModel.Anthropic.allCases {
             #expect(!model.modelId.isEmpty)
             _ = model.supportsVision

--- a/Tests/TachikomaTests/Core/ModelCapabilitiesTests.swift
+++ b/Tests/TachikomaTests/Core/ModelCapabilitiesTests.swift
@@ -65,6 +65,7 @@ enum ModelCapabilitiesTests {
         func `Claude models support thinking`() {
             let models: [LanguageModel] = [
                 .anthropic(.fable5),
+                .anthropic(.sonnet5),
                 .anthropic(.opus47),
                 .anthropic(.opus4),
                 .anthropic(.sonnet46),
@@ -81,8 +82,14 @@ enum ModelCapabilitiesTests {
         }
 
         @Test
-        func `Claude Fable 5 and Opus 4_7 plus 4_8 advertise adaptive thinking without sampling options`() {
-            for model in [LanguageModel.anthropic(.fable5), .anthropic(.opus47), .anthropic(.opus48)] {
+        func `Current adaptive Claude models reject sampling options`() {
+            for model in [
+                LanguageModel.anthropic(.fable5),
+                .anthropic(.sonnet5),
+                .anthropic(.opus47),
+                .anthropic(.opus48),
+                .openRouter(modelId: "anthropic/claude-sonnet-5"),
+            ] {
                 let capabilities = ModelCapabilityRegistry.shared.capabilities(for: model)
 
                 #expect(!capabilities.supportsTemperature)
@@ -230,6 +237,23 @@ enum ModelCapabilitiesTests {
             #expect(validated.topP == nil) // Excluded
             #expect(validated.providerOptions.openai?.reasoningEffort == nil) // Removed
             #expect(validated.providerOptions.openai?.verbosity == .medium) // Kept
+        }
+
+        @Test
+        func `Validate settings preserves GPT-5_6 reasoning effort`() {
+            for model in [
+                LanguageModel.OpenAI.gpt56Sol,
+                .gpt56Terra,
+                .gpt56Luna,
+            ] {
+                let settings = GenerationSettings(
+                    providerOptions: .init(openai: .init(reasoningEffort: .max)),
+                )
+
+                let validated = settings.validated(for: .openai(model))
+
+                #expect(validated.providerOptions.openai?.reasoningEffort == .max)
+            }
         }
 
         @Test

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -15,6 +15,19 @@ struct ModelParsingTests {
     }
 
     @Test
+    func `parse GPT-5.6 preview models`() throws {
+        #expect(LanguageModel.parse(from: "gpt-5.6") == .openai(.gpt56Sol))
+        #expect(LanguageModel.parse(from: "gpt-5.6-sol") == .openai(.gpt56Sol))
+        #expect(LanguageModel.parse(from: "openai/gpt-5.6-terra") == .openai(.gpt56Terra))
+        #expect(LanguageModel.parse(from: "gpt56luna") == .openai(.gpt56Luna))
+        #expect(LanguageModel.parse(from: "my-gpt56-distill") == nil)
+        #expect(LanguageModel.parse(from: "gpt-5.60") == nil)
+        #expect(LanguageModel.parse(from: "vendor-gpt-5-6-model") == nil)
+        #expect(try ModelSelector.parseModel("gpt-5.6-sol") == .openai(.gpt56Sol))
+        #expect(try ModelSelector.parseModel("openai/gpt-5.6-terra") == .openai(.gpt56Terra))
+    }
+
+    @Test
     func `parse chat latest OpenAI alias`() throws {
         #expect(LanguageModel.parse(from: "chat-latest") == .openai(.chatLatest))
         #expect(LanguageModel.parse(from: "gpt-5-chat-latest") == .openai(.gpt5ChatLatest))
@@ -49,6 +62,16 @@ struct ModelParsingTests {
         #expect(LanguageModel.parse(from: "fable") == .anthropic(.fable5))
         #expect(try ModelSelector.parseModel("fable5") == .anthropic(.fable5))
         #expect(LanguageModel.parse(from: "my-fable5-7b") == nil)
+    }
+
+    @Test
+    func `parse Claude Sonnet 5 model id`() throws {
+        #expect(LanguageModel.parse(from: "claude-sonnet-5") == .anthropic(.sonnet5))
+        #expect(LanguageModel.parse(from: "anthropic/claude-sonnet-5") == .anthropic(.sonnet5))
+        #expect(try ModelSelector.parseModel("sonnet5") == .anthropic(.sonnet5))
+        #expect(try ModelSelector.parseModel("sonnet") == .anthropic(.sonnet5))
+        #expect(LanguageModel.parse(from: "claude-sonnet-5-latest") == nil)
+        #expect(LanguageModel.parse(from: "my-sonnet5-distill") == nil)
     }
 
     @Test
@@ -215,6 +238,25 @@ struct ModelParsingTests {
             )
 
             #expect(model == .google(.gemini31ProPreview))
+        }
+    }
+
+    @Test
+    func `ProviderParser accepts GPT-5.6 and Claude Sonnet 5`() {
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            let openAI = ProviderParser.determineDefaultModel(
+                from: "openai/gpt-5.6-luna",
+                hasOpenAI: true,
+                hasAnthropic: false,
+            )
+            let anthropic = ProviderParser.determineDefaultModel(
+                from: "anthropic/claude-sonnet-5",
+                hasOpenAI: false,
+                hasAnthropic: true,
+            )
+
+            #expect(openAI == .openai(.gpt56Luna))
+            #expect(anthropic == .anthropic(.sonnet5))
         }
     }
 

--- a/Tests/TachikomaTests/Core/ProviderOptionsTests.swift
+++ b/Tests/TachikomaTests/Core/ProviderOptionsTests.swift
@@ -284,6 +284,8 @@ enum ProviderOptionsTests {
             #expect(OpenAIOptions.ReasoningEffort.low.rawValue == "low")
             #expect(OpenAIOptions.ReasoningEffort.medium.rawValue == "medium")
             #expect(OpenAIOptions.ReasoningEffort.high.rawValue == "high")
+            #expect(OpenAIOptions.ReasoningEffort.xhigh.rawValue == "xhigh")
+            #expect(OpenAIOptions.ReasoningEffort.max.rawValue == "max")
         }
 
         @Test

--- a/Tests/TachikomaTests/HarmonyFeatures/ReasoningEffortTests.swift
+++ b/Tests/TachikomaTests/HarmonyFeatures/ReasoningEffortTests.swift
@@ -5,10 +5,12 @@ struct ReasoningEffortTests {
     @Test
     func `ReasoningEffort enum has all expected cases`() {
         let allCases = ReasoningEffort.allCases
-        #expect(allCases.count == 3)
+        #expect(allCases.count == 5)
         #expect(allCases.contains(.low))
         #expect(allCases.contains(.medium))
         #expect(allCases.contains(.high))
+        #expect(allCases.contains(.xhigh))
+        #expect(allCases.contains(.max))
     }
 
     @Test
@@ -16,6 +18,8 @@ struct ReasoningEffortTests {
         #expect(ReasoningEffort.low.rawValue == "low")
         #expect(ReasoningEffort.medium.rawValue == "medium")
         #expect(ReasoningEffort.high.rawValue == "high")
+        #expect(ReasoningEffort.xhigh.rawValue == "xhigh")
+        #expect(ReasoningEffort.max.rawValue == "max")
     }
 
     @Test
@@ -124,12 +128,14 @@ struct ReasoningEffortTests {
     @Test
     func `All reasoning effort levels properly ordered`() {
         // Ensure we have the expected reasoning levels
-        let levels: [ReasoningEffort] = [.low, .medium, .high]
+        let levels: [ReasoningEffort] = [.low, .medium, .high, .xhigh, .max]
 
         // Just verify the levels are in the expected order
         #expect(levels[0] == .low)
         #expect(levels[1] == .medium)
         #expect(levels[2] == .high)
+        #expect(levels[3] == .xhigh)
+        #expect(levels[4] == .max)
 
         // Verify all cases are covered
         #expect(Set(levels) == Set(ReasoningEffort.allCases))

--- a/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
+++ b/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
@@ -401,6 +401,150 @@ struct AnthropicInterleavedDefaultsTests {
     }
 
     @Test
+    func `Sonnet 5 request keeps adaptive thinking payload`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .sonnet5, configuration: config)
+
+        let settings = GenerationSettings(
+            maxTokens: 64,
+            temperature: 0.7,
+            reasoningEffort: .high,
+            providerOptions: .init(anthropic: .init(thinking: .adaptive)),
+        )
+
+        let request = ProviderRequest(
+            messages: [.user("hi")],
+            settings: settings,
+        )
+
+        let urlRequest = try provider.makeURLRequest(for: request, stream: false)
+        let body = try #require(urlRequest.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let thinking = try #require(json["thinking"] as? [String: Any])
+        let outputConfig = try #require(json["output_config"] as? [String: Any])
+
+        #expect(json["model"] as? String == "claude-sonnet-5")
+        #expect(json["temperature"] == nil)
+        #expect(thinking["type"] as? String == "adaptive")
+        #expect(outputConfig["effort"] as? String == "high")
+    }
+
+    @Test
+    func `Sonnet 5 encodes extended effort levels`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .sonnet5, configuration: config)
+
+        for effort in [ReasoningEffort.xhigh, .max] {
+            let request = ProviderRequest(
+                messages: [.user("hi")],
+                settings: GenerationSettings(maxTokens: 64, reasoningEffort: effort),
+            )
+            let body = try #require(provider.makeURLRequest(for: request, stream: false).httpBody)
+            let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let outputConfig = try #require(json["output_config"] as? [String: Any])
+
+            #expect(outputConfig["effort"] as? String == effort.rawValue)
+        }
+    }
+
+    @Test
+    func `Extended effort levels follow the Anthropic model support matrix`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        for (model, effort) in [
+            (LanguageModel.Anthropic.fable5, ReasoningEffort.xhigh),
+            (.opus48, .xhigh),
+            (.opus47, .xhigh),
+            (.sonnet46, .max),
+        ] {
+            let provider = try AnthropicProvider(model: model, configuration: config)
+            let request = ProviderRequest(
+                messages: [.user("hi")],
+                settings: GenerationSettings(maxTokens: 64, reasoningEffort: effort),
+            )
+            let body = try #require(provider.makeURLRequest(for: request, stream: false).httpBody)
+            let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let outputConfig = try #require(json["output_config"] as? [String: Any])
+
+            #expect(outputConfig["effort"] as? String == effort.rawValue)
+        }
+
+        for (model, effort) in [
+            (LanguageModel.Anthropic.sonnet46, ReasoningEffort.xhigh),
+            (.opus45, .max),
+        ] {
+            let provider = try AnthropicProvider(model: model, configuration: config)
+            let request = ProviderRequest(
+                messages: [.user("hi")],
+                settings: GenerationSettings(maxTokens: 64, reasoningEffort: effort),
+            )
+
+            #expect(throws: TachikomaError.self) {
+                _ = try provider.makeURLRequest(for: request, stream: false)
+            }
+        }
+    }
+
+    @Test
+    func `Sonnet 5 maps manual thinking to adaptive and encodes disabled thinking`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .sonnet5, configuration: config)
+
+        let enabledRequest = ProviderRequest(
+            messages: [.user("hi")],
+            settings: GenerationSettings(
+                maxTokens: 64,
+                providerOptions: .init(anthropic: .init(thinking: .enabled(budgetTokens: 12000))),
+            ),
+        )
+        let disabledRequest = ProviderRequest(
+            messages: [.user("hi")],
+            settings: GenerationSettings(
+                maxTokens: 64,
+                reasoningEffort: .max,
+                providerOptions: .init(anthropic: .init(thinking: .disabled)),
+            ),
+        )
+
+        let enabledBody = try #require(provider.makeURLRequest(for: enabledRequest, stream: false).httpBody)
+        let enabledJSON = try #require(try JSONSerialization.jsonObject(with: enabledBody) as? [String: Any])
+        let enabledThinking = try #require(enabledJSON["thinking"] as? [String: Any])
+        #expect(enabledThinking["type"] as? String == "adaptive")
+        #expect(enabledThinking["budget_tokens"] == nil)
+
+        let disabledBody = try #require(provider.makeURLRequest(for: disabledRequest, stream: false).httpBody)
+        let disabledJSON = try #require(try JSONSerialization.jsonObject(with: disabledBody) as? [String: Any])
+        let disabledThinking = try #require(disabledJSON["thinking"] as? [String: Any])
+        let disabledOutputConfig = try #require(disabledJSON["output_config"] as? [String: Any])
+        #expect(disabledThinking["type"] as? String == "disabled")
+        #expect(disabledOutputConfig["effort"] as? String == "max")
+    }
+
+    @Test
+    func `Sonnet 5 uses an adaptive-thinking output budget by default`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .sonnet5, configuration: config)
+        let request = ProviderRequest(messages: [.user("hi")])
+
+        let urlRequest = try provider.makeURLRequest(for: request, stream: false)
+        let body = try #require(urlRequest.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        #expect(json["max_tokens"] as? Int == 16384)
+        #expect(urlRequest.timeoutInterval == 1800)
+    }
+
+    @Test
+    func `Sonnet 5 rejects assistant prefill requests`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .sonnet5, configuration: config)
+        let request = ProviderRequest(messages: [.user("hi"), .assistant("prefix")])
+
+        #expect(throws: TachikomaError.self) {
+            _ = try provider.makeURLRequest(for: request, stream: false)
+        }
+    }
+
+    @Test
     func `Custom Anthropic request keeps thinking payload`() throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
         let provider = try AnthropicProvider(model: .custom("claude-opus-4-5-latest"), configuration: config)
@@ -567,6 +711,42 @@ struct AnthropicInterleavedDefaultsTests {
         #expect(assistant.first?["type"] as? String == "thinking")
         #expect(assistant.first?["thinking"] as? String == "fable thinking")
         #expect(assistant.first?["signature"] as? String == "sig-fable")
+    }
+
+    @Test
+    func `Sonnet 5 preserves default adaptive thinking history`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .sonnet5, configuration: config)
+        let signedThinking = try ModelMessage(
+            role: .assistant,
+            content: [.text("")],
+            channel: .thinking,
+            metadata: .init(customData: [
+                "anthropic.thinking.model": "claude-sonnet-5",
+                "anthropic.thinking.signature": "sig-sonnet",
+                "anthropic.thinking.type": "thinking",
+                "tachikoma.reasoning.provider": "anthropic",
+                "tachikoma.reasoning.model": "claude-sonnet-5",
+                "tachikoma.reasoning.base_url": #require(ReasoningEndpointIdentity
+                    .canonical("https://api.anthropic.com")),
+            ]),
+        )
+
+        let request = ProviderRequest(
+            messages: [.user("hi"), signedThinking, .assistant("hello"), .user("continue")],
+            settings: GenerationSettings(maxTokens: 64),
+        )
+
+        let urlRequest = try provider.makeURLRequest(for: request, stream: false)
+        let body = try #require(urlRequest.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let assistant = try #require(messages[1]["content"] as? [[String: Any]])
+
+        #expect(json["thinking"] == nil)
+        #expect(assistant.first?["type"] as? String == "thinking")
+        #expect((assistant.first?["thinking"] as? String)?.isEmpty == true)
+        #expect(assistant.first?["signature"] as? String == "sig-sonnet")
     }
 
     @Test
@@ -759,6 +939,7 @@ struct AnthropicInterleavedDefaultsTests {
     @Test
     func `Current Anthropic models expose documented output caps`() {
         #expect(LanguageModel.Anthropic.fable5.maxOutputTokens == 128_000)
+        #expect(LanguageModel.Anthropic.sonnet5.maxOutputTokens == 128_000)
         #expect(LanguageModel.Anthropic.opus47.maxOutputTokens == 128_000)
         #expect(LanguageModel.Anthropic.opus48.maxOutputTokens == 128_000)
         #expect(LanguageModel.Anthropic.sonnet46.maxOutputTokens == 64000)
@@ -766,21 +947,27 @@ struct AnthropicInterleavedDefaultsTests {
     }
 
     @Test
-    func `Fable and Opus 4_8 streaming are disabled until rollback is supported`() async throws {
+    func `Refusal-prone Anthropic streaming is disabled until rollback is supported`() async throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
         let provider = try AnthropicProvider(model: .fable5, configuration: config)
+        let sonnetProvider = try AnthropicProvider(model: .sonnet5, configuration: config)
         let opusProvider = try AnthropicProvider(model: .opus48, configuration: config)
 
         #expect(provider.capabilities.supportsStreaming == false)
         #expect(LanguageModel.anthropic(.fable5).supportsStreaming == false)
+        #expect(sonnetProvider.capabilities.supportsStreaming == false)
         #expect(opusProvider.capabilities.supportsStreaming == false)
         #expect(LanguageModel.anthropic(.opus47).supportsStreaming == true)
         #expect(LanguageModel.anthropic(.opus48).supportsStreaming == false)
+        #expect(LanguageModel.anthropic(.sonnet5).supportsStreaming == false)
         #expect(LanguageModel.anthropic(.sonnet46).supportsStreaming == true)
         #expect(LanguageModel.anthropic(.sonnet45).supportsStreaming == true)
         #expect(LanguageModel.anthropic(.haiku45).supportsStreaming == true)
         await #expect(throws: TachikomaError.self) {
             _ = try await provider.streamText(request: ProviderRequest(messages: [.user("hi")]))
+        }
+        await #expect(throws: TachikomaError.self) {
+            _ = try await sonnetProvider.streamText(request: ProviderRequest(messages: [.user("hi")]))
         }
         await #expect(throws: TachikomaError.self) {
             _ = try await opusProvider.streamText(request: ProviderRequest(messages: [.user("hi")]))
@@ -801,6 +988,14 @@ struct AnthropicInterleavedDefaultsTests {
         #expect(LanguageModel.Anthropic.isFable(modelId: "anthropic/claude-fable-5") == true)
         #expect(LanguageModel.Anthropic.isFable(modelId: "vendor/claude-fable-50") == false)
         #expect(LanguageModel.Anthropic.isFable(modelId: "my-claude-fable-5-distill") == false)
+    }
+
+    @Test
+    func `Sonnet 5 detection avoids substring false positives`() {
+        #expect(LanguageModel.Anthropic.isSonnet5(modelId: "claude-sonnet-5") == true)
+        #expect(LanguageModel.Anthropic.isSonnet5(modelId: "anthropic/claude-sonnet-5") == true)
+        #expect(LanguageModel.Anthropic.isSonnet5(modelId: "vendor/claude-sonnet-50") == false)
+        #expect(LanguageModel.Anthropic.isSonnet5(modelId: "my-claude-sonnet-5-distill") == false)
     }
 
     @Test

--- a/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
+++ b/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
@@ -24,6 +24,9 @@ struct OpenAIResponsesProviderTests {
 
         let gpt5Models: [LanguageModel.OpenAI] = [
             .chatLatest,
+            .gpt56Sol,
+            .gpt56Terra,
+            .gpt56Luna,
             .gpt55,
             .gpt54,
             .gpt54Mini,
@@ -84,6 +87,9 @@ struct OpenAIResponsesProviderTests {
 
         let responsesModels: [LanguageModel.OpenAI] = [
             .chatLatest,
+            .gpt56Sol,
+            .gpt56Terra,
+            .gpt56Luna,
             .gpt55,
             .gpt54,
             .gpt54Mini,
@@ -398,6 +404,70 @@ struct OpenAIResponsesProviderTests {
             let provider = try OpenAIResponsesProvider(model: .gpt5Mini, configuration: config, session: session)
             let response = try await provider.generateText(request: self.sampleRequest)
             #expect(response.text.contains("GPT-5") || response.text.contains("pong"))
+        }
+    }
+
+    @Test
+    func `GPT-5_6 Responses payload preserves requested reasoning effort`() async throws {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setAPIKey("live-openai", for: .openai)
+
+        try await self.withMockedSession { request in
+            let body = try #require(Self.bodyData(from: request))
+            let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let reasoning = try #require(json["reasoning"] as? [String: Any])
+
+            #expect(json["model"] as? String == "gpt-5.6-sol")
+            #expect(reasoning["effort"] as? String == "max")
+
+            return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "pong"))
+        } operation: { session in
+            let provider = try OpenAIResponsesProvider(model: .gpt56Sol, configuration: config, session: session)
+            let request = ProviderRequest(
+                messages: [.user("ping")],
+                settings: .init(
+                    maxTokens: 32,
+                    providerOptions: .init(openai: .init(reasoningEffort: .max)),
+                ),
+            )
+            _ = try await provider.generateText(request: request)
+        }
+    }
+
+    @Test
+    func `GPT-5_6 Responses payload preserves xhigh reasoning effort`() async throws {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setAPIKey("live-openai", for: .openai)
+
+        try await self.withMockedSession { request in
+            let body = try #require(Self.bodyData(from: request))
+            let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let reasoning = try #require(json["reasoning"] as? [String: Any])
+
+            #expect(reasoning["effort"] as? String == "xhigh")
+
+            return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "pong"))
+        } operation: { session in
+            let provider = try OpenAIResponsesProvider(model: .gpt56Sol, configuration: config, session: session)
+            let request = ProviderRequest(
+                messages: [.user("ping")],
+                settings: .init(providerOptions: .init(openai: .init(reasoningEffort: .xhigh))),
+            )
+            _ = try await provider.generateText(request: request)
+        }
+    }
+
+    @Test
+    func `GPT-5_6 Responses payload rejects minimal reasoning effort`() async throws {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setAPIKey("live-openai", for: .openai)
+
+        let provider = try OpenAIResponsesProvider(model: .gpt56Sol, configuration: config)
+        await #expect(throws: TachikomaError.self) {
+            _ = try await provider.generateText(request: ProviderRequest(
+                messages: [.user("ping")],
+                settings: .init(providerOptions: .init(openai: .init(reasoningEffort: .minimal))),
+            ))
         }
     }
 

--- a/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
+++ b/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
@@ -122,11 +122,40 @@ struct UsageTrackingTests {
         #expect(gpt5MiniCost.output == 4.00)
         #expect(gpt5MiniCost.total == 5.00)
 
+        let gpt56Costs = [
+            (LanguageModel.openai(.gpt56Sol), 5.00, 30.00),
+            (.openai(.gpt56Terra), 2.50, 15.00),
+            (.openai(.gpt56Luna), 1.00, 6.00),
+        ]
+        for (model, expectedInput, expectedOutput) in gpt56Costs {
+            let cost = calculator.calculateCost(for: model, usage: usage)
+            #expect(cost.input == expectedInput)
+            #expect(cost.output == expectedOutput)
+        }
+
+        let customGPT56Cost = calculator.calculateCost(
+            for: .openai(.custom("gpt-5.6-sol")),
+            usage: usage,
+        )
+        #expect(customGPT56Cost.input == 5.00)
+        #expect(customGPT56Cost.output == 30.00)
+
         // Test Anthropic pricing
         let claudeFableCost = calculator.calculateCost(for: .anthropic(.fable5), usage: usage)
         #expect(claudeFableCost.input == 10.00)
         #expect(claudeFableCost.output == 50.00)
         #expect(claudeFableCost.total == 60.00)
+
+        let claudeSonnet5Cost = calculator.calculateCost(for: .anthropic(.sonnet5), usage: usage)
+        #expect(claudeSonnet5Cost.input == 2.00)
+        #expect(claudeSonnet5Cost.output == 10.00)
+
+        let customClaudeSonnet5Cost = calculator.calculateCost(
+            for: .anthropic(.custom("claude-sonnet-5")),
+            usage: usage,
+        )
+        #expect(customClaudeSonnet5Cost.input == 2.00)
+        #expect(customClaudeSonnet5Cost.output == 10.00)
 
         let customClaudeFableCost = calculator.calculateCost(for: .anthropic(.custom("claude-fable-5")), usage: usage)
         #expect(customClaudeFableCost.input == 10.00)

--- a/docs/models.md
+++ b/docs/models.md
@@ -9,6 +9,7 @@ Tachikoma ships with a built-in model catalog (`CaseIterable` enums) plus suppor
 
 ## OpenAI (`LanguageModel.OpenAI`)
 
+- `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (preview; bare `gpt-5.6` selects Sol)
 - `gpt-5.5`
 - `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`
 - `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`
@@ -18,6 +19,7 @@ Notes:
 
 ## Anthropic (`LanguageModel.Anthropic`)
 
+- `claude-sonnet-5` (1M context, 128K max output)
 - `claude-fable-5` (1M context, 128K max output, non-streaming, explicit opt-in)
 - `claude-opus-4-8` (1M context, 128K max output, non-streaming until refusal rollback is streaming-safe)
 - `claude-opus-4-7`


### PR DESCRIPTION
## Summary

- add first-class Claude Sonnet 5 and GPT-5.6 Sol, Terra, and Luna model metadata, parsing, routing, and pricing
- implement Sonnet 5 adaptive-thinking request rules, signed-thinking replay, assistant-prefill rejection, and refusal-safe non-streaming behavior
- preserve GPT-5.6 reasoning effort, including Sol's `max` effort, through Responses API payloads

## Tests

- `swift test --no-parallel` (789 tests)
- `swiftformat --lint Sources/Tachikoma Tests/TachikomaTests`
- `swiftlint lint --strict`
- autoreview: clean after accepted fixes
