### PR TITLE
fix(models): preserve GPT-5.6 compatible limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Removed stale direct model support for retired or non-canonical IDs including GPT-5.1/5.2/pseudo-thinking models, deprecated Claude Sonnet/Opus 4 snapshots, Grok 2/3/4-fast rows, old Groq Llama/Mixtral/Gemma aliases, stale Mistral aliases, and invalid LM Studio `current`.
 
 ### Fixed
+- GPT-5.6 models now retain their 372K context and 128K output limits through OpenAI-compatible, OpenRouter, and Together endpoints.
 - OpenAI `gpt-5-chat-latest` now preserves its distinct model identity, appears in model listings, and applies GPT-5 parameter filtering instead of being rewritten to `chat-latest`.
 - SwiftPM consumers now resolve Commander from the package URL instead of accidentally inheriting a sibling local checkout.
 - Ollama model parsing now preserves explicit custom vision model IDs such as `qwen2.5vl:3b` instead of falling back to `llama3.3` (#16).

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -157,6 +157,31 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             }
         }
 
+        /// Resolves a GPT-5.6 model ID, including provider-qualified IDs used by compatible APIs.
+        public static func gpt56Model(for modelId: String) -> OpenAI? {
+            let trimmed = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+
+            let parsedModel = ProviderParser.parse(trimmed)?.model
+            for candidate in [parsedModel, trimmed].compactMap(\.self) {
+                let compact = candidate.lowercased()
+                    .replacingOccurrences(of: "-", with: "")
+                    .replacingOccurrences(of: ".", with: "")
+                    .replacingOccurrences(of: "_", with: "")
+                switch compact {
+                case "gpt56", "gpt56sol":
+                    return .gpt56Sol
+                case "gpt56terra":
+                    return .gpt56Terra
+                case "gpt56luna":
+                    return .gpt56Luna
+                default:
+                    continue
+                }
+            }
+            return nil
+        }
+
         public var isUnsupportedLegacyFamily: Bool {
             let normalized = self.modelId.lowercased()
             let compact = normalized.replacingOccurrences(of: "-", with: "")
@@ -1184,11 +1209,19 @@ extension LanguageModel {
         case .azureOpenAI:
             128_000 // conservative default matching OpenAI tier
         case let .openRouter(modelId), let .together(modelId):
-            Anthropic.hasMillionTokenContext(modelId: modelId) ? 1_000_000 : 128_000
+            if Anthropic.hasMillionTokenContext(modelId: modelId) {
+                1_000_000
+            } else {
+                OpenAI.gpt56Model(for: modelId)?.contextLength ?? 128_000
+            }
         case .replicate:
             128_000 // Common default
         case let .openaiCompatible(modelId, _):
-            Anthropic.hasMillionTokenContext(modelId: modelId) ? 1_000_000 : 128_000
+            if Anthropic.hasMillionTokenContext(modelId: modelId) {
+                1_000_000
+            } else {
+                OpenAI.gpt56Model(for: modelId)?.contextLength ?? 128_000
+            }
         case let .anthropicCompatible(modelId, _):
             Anthropic.hasMillionTokenContext(modelId: modelId) ? 1_000_000 : 128_000
         case let .custom(provider):

--- a/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
+++ b/Sources/Tachikoma/Providers/Compatible/OpenAICompatibleProvider.swift
@@ -41,12 +41,13 @@ public final class OpenAICompatibleProvider: ModelProvider {
         }
 
         let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
+        let gpt56Model = LanguageModel.OpenAI.gpt56Model(for: modelId)
         self.capabilities = ModelCapabilities(
             supportsVision: false,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),
-            contextLength: hasLargeClaudeLimits ? 1_000_000 : 128_000,
-            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 4096,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : (gpt56Model?.contextLength ?? 128_000),
+            maxOutputTokens: hasLargeClaudeLimits || gpt56Model != nil ? 128_000 : 4096,
         )
     }
 

--- a/Sources/Tachikoma/Providers/OpenRouter/OpenRouterProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenRouter/OpenRouterProvider.swift
@@ -34,12 +34,13 @@ public final class OpenRouterProvider: ModelProvider {
         }
 
         let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
+        let gpt56Model = LanguageModel.OpenAI.gpt56Model(for: modelId)
         self.capabilities = ModelCapabilities(
             supportsVision: true,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),
-            contextLength: hasLargeClaudeLimits ? 1_000_000 : 128_000,
-            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 4096,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : (gpt56Model?.contextLength ?? 128_000),
+            maxOutputTokens: hasLargeClaudeLimits || gpt56Model != nil ? 128_000 : 4096,
         )
 
         self.defaultHeaders = [

--- a/Sources/Tachikoma/Providers/Together/TogetherProvider.swift
+++ b/Sources/Tachikoma/Providers/Together/TogetherProvider.swift
@@ -28,12 +28,13 @@ public final class TogetherProvider: ModelProvider {
         }
 
         let hasLargeClaudeLimits = LanguageModel.Anthropic.hasMillionTokenContext(modelId: modelId)
+        let gpt56Model = LanguageModel.OpenAI.gpt56Model(for: modelId)
         self.capabilities = ModelCapabilities(
             supportsVision: true,
             supportsTools: true,
             supportsStreaming: !LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: modelId),
-            contextLength: hasLargeClaudeLimits ? 1_000_000 : 128_000,
-            maxOutputTokens: hasLargeClaudeLimits ? 128_000 : 4096,
+            contextLength: hasLargeClaudeLimits ? 1_000_000 : (gpt56Model?.contextLength ?? 128_000),
+            maxOutputTokens: hasLargeClaudeLimits || gpt56Model != nil ? 128_000 : 4096,
         )
     }
 

--- a/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
+++ b/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
@@ -13,6 +13,34 @@ struct OpenAICompatibleHelperTests {}
 @Suite(.serialized)
 struct OpenAICompatibleHelperTests {
     @Test
+    func `Compatible providers infer GPT-5.6 limits`() throws {
+        let compatible = try OpenAICompatibleProvider(
+            modelId: "gpt-5.6-sol",
+            baseURL: "https://mock.compatible",
+            configuration: TachikomaConfiguration(apiKeys: ["openai_compatible": "sk-test"]),
+        )
+        let openRouter = try OpenRouterProvider(
+            modelId: "openai/gpt-5.6-terra",
+            configuration: TachikomaConfiguration(apiKeys: ["openrouter": "sk-test"]),
+        )
+        let together = try TogetherProvider(
+            modelId: "gpt-5.6-luna",
+            configuration: TachikomaConfiguration(apiKeys: ["together": "sk-test"]),
+        )
+
+        for provider in [compatible, openRouter, together] as [any ModelProvider] {
+            #expect(provider.capabilities.contextLength == 372_000)
+            #expect(provider.capabilities.maxOutputTokens == 128_000)
+        }
+        #expect(LanguageModel.openaiCompatible(
+            modelId: "openai/gpt-5.6-sol",
+            baseURL: "https://mock.compatible",
+        ).contextLength == 372_000)
+        #expect(LanguageModel.openRouter(modelId: "openai/gpt-5.6-terra").contextLength == 372_000)
+        #expect(LanguageModel.together(modelId: "gpt-5.6-luna").contextLength == 372_000)
+    }
+
+    @Test
     func `generateText encodes stop sequences, headers, and tool definitions`() async throws {
         let tool = AgentTool(
             name: "lookup",


### PR DESCRIPTION
## Summary

- infer first-class GPT-5.6 context and output limits for OpenAI-compatible endpoints
- apply the same limits to OpenRouter and Together model routes
- expose the inferred context through `LanguageModel` wrappers and cover provider-qualified IDs

## Tests

- `swift test` (790 tests)
- focused compatible-provider capability test
- `swiftformat Sources Tests --lint`
- `swiftlint lint --strict`
- autoreview: clean
