### PR TITLE
fix(models): expire Sonnet 5 launch pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Removed stale direct model support for retired or non-canonical IDs including GPT-5.1/5.2/pseudo-thinking models, deprecated Claude Sonnet/Opus 4 snapshots, Grok 2/3/4-fast rows, old Groq Llama/Mixtral/Gemma aliases, stale Mistral aliases, and invalid LM Studio `current`.
 
 ### Fixed
+- Sonnet 5 usage estimates now switch from introductory to standard pricing after August 31, 2026.
 - GPT-5.6 models now retain their 372K context and 128K output limits through OpenAI-compatible, OpenRouter, and Together endpoints.
 - OpenAI `gpt-5-chat-latest` now preserves its distinct model identity, appears in model listings, and applies GPT-5 parameter filtering instead of being rewritten to `chat-latest`.
 - SwiftPM consumers now resolve Commander from the package URL instead of accidentally inheriting a sibling local checkout.

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -511,7 +511,8 @@ public struct UsageReport: Sendable {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct ModelCostCalculator: Sendable {
     private static let sonnet5StandardPricingStart = Date(
-        timeIntervalSince1970: 1_788_220_800) // 2026-09-01 00:00:00 UTC
+        timeIntervalSince1970: 1_788_220_800,
+    ) // 2026-09-01 00:00:00 UTC
 
     private let now: @Sendable () -> Date
 

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -510,6 +510,19 @@ public struct UsageReport: Sendable {
 /// Calculates costs for different AI models
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct ModelCostCalculator: Sendable {
+    private static let sonnet5StandardPricingStart = Date(
+        timeIntervalSince1970: 1_788_220_800) // 2026-09-01 00:00:00 UTC
+
+    private let now: @Sendable () -> Date
+
+    public init() {
+        self.now = { Date() }
+    }
+
+    init(now: @escaping @Sendable () -> Date) {
+        self.now = now
+    }
+
     /// Calculate cost for a model usage
     public func calculateCost(for model: LanguageModel, usage: Usage) -> Usage.Cost {
         // Calculate cost for a model usage
@@ -553,7 +566,7 @@ public struct ModelCostCalculator: Sendable {
         case let .anthropic(anthropicModel):
             switch anthropicModel {
             case .fable5: (10.00, 50.00)
-            case .sonnet5: (2.00, 10.00) // Introductory pricing through August 31, 2026
+            case .sonnet5: self.sonnet5Pricing()
             case .opus48: (5.00, 25.00)
             case .opus47: (5.00, 25.00)
             case .opus45: (5.00, 25.00)
@@ -565,7 +578,7 @@ public struct ModelCostCalculator: Sendable {
                 if LanguageModel.Anthropic.isFable(modelId: id) {
                     (10.00, 50.00)
                 } else if LanguageModel.Anthropic.isSonnet5(modelId: id) {
-                    (2.00, 10.00)
+                    self.sonnet5Pricing()
                 } else {
                     (3.00, 15.00)
                 }
@@ -601,5 +614,9 @@ public struct ModelCostCalculator: Sendable {
         case .openaiCompatible, .anthropicCompatible, .azureOpenAI: (2.00, 6.00)
         case .custom: (2.00, 6.00)
         }
+    }
+
+    private func sonnet5Pricing() -> (input: Double, output: Double) {
+        self.now() < Self.sonnet5StandardPricingStart ? (2.00, 10.00) : (3.00, 15.00)
     }
 }

--- a/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
+++ b/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
@@ -113,7 +113,8 @@ struct UsageTrackingTests {
 
     @Test
     func `Cost Calculation for Different Models`() {
-        let calculator = ModelCostCalculator()
+        let introductoryDate = Date(timeIntervalSince1970: 1_788_220_799)
+        let calculator = ModelCostCalculator { introductoryDate }
         let usage = Usage(inputTokens: 1_000_000, outputTokens: 1_000_000) // 1M tokens each for easy calculation
 
         // Test OpenAI pricing
@@ -202,6 +203,22 @@ struct UsageTrackingTests {
         #expect(ollamaCost.input == 0.0)
         #expect(ollamaCost.output == 0.0)
         #expect(ollamaCost.total == 0.0)
+    }
+
+    @Test
+    func `Sonnet 5 standard pricing starts September 2026`() {
+        let standardPricingDate = Date(timeIntervalSince1970: 1_788_220_800)
+        let calculator = ModelCostCalculator { standardPricingDate }
+        let usage = Usage(inputTokens: 1_000_000, outputTokens: 1_000_000)
+
+        for model in [
+            LanguageModel.anthropic(.sonnet5),
+            .anthropic(.custom("claude-sonnet-5")),
+        ] {
+            let cost = calculator.calculateCost(for: model, usage: usage)
+            #expect(cost.input == 3.00)
+            #expect(cost.output == 15.00)
+        }
     }
 
     // MARK: - Total Usage Tests


### PR DESCRIPTION
## Summary

- keep Sonnet 5 introductory usage estimates through August 31, 2026
- switch canonical and custom Sonnet 5 IDs to standard pricing on September 1
- inject the pricing clock for deterministic boundary coverage

## Tests

- `swift test --no-parallel` (791 tests)
- focused `UsageTrackingTests`
- `swiftformat Sources Tests --lint`
- `swiftlint lint --strict`
- autoreview: clean
