### PR TITLE
fix(models): strip ollama prefix in ModelSelector; fix order-dependent auth tests

### DIFF
--- a/Sources/Tachikoma/Models/ModelSelection.swift
+++ b/Sources/Tachikoma/Models/ModelSelection.swift
@@ -86,7 +86,8 @@ public struct ModelSelector {
             if provider == "ollama" {
                 // Ollama is an open registry: pass unknown names through as custom
                 // model ids instead of gating on the known-model list.
-                return .ollama(parseOllamaModel(qualified.model.lowercased()) ?? .custom(qualified.model.lowercased()))
+                return .ollama(self
+                    .parseOllamaModel(qualified.model.lowercased()) ?? .custom(qualified.model.lowercased()))
             }
             if !["ollama", "lmstudio", "lm-studio"].contains(provider) {
                 return .openRouter(modelId: normalized)
@@ -441,17 +442,23 @@ public struct ModelSelector {
         switch normalizedProvider {
         case "openai":
             return Model.OpenAI.allCases.compactMap {
-                if case .custom = $0 { return nil }
+                if case .custom = $0 {
+                    return nil
+                }
                 return $0.modelId
             }
         case "anthropic", "claude":
             return Model.Anthropic.allCases.compactMap {
-                if case .custom = $0 { return nil }
+                if case .custom = $0 {
+                    return nil
+                }
                 return $0.modelId
             }
         case "grok", "xai":
             return Model.Grok.allCases.compactMap {
-                if case .custom = $0 { return nil }
+                if case .custom = $0 {
+                    return nil
+                }
                 return $0.modelId
             }
         case "google", "gemini":
@@ -462,12 +469,16 @@ public struct ModelSelector {
             return Model.Kimi.allCases.map(\.modelId)
         case "ollama":
             return Model.Ollama.allCases.compactMap {
-                if case .custom = $0 { return nil }
+                if case .custom = $0 {
+                    return nil
+                }
                 return $0.modelId
             }
         case "lmstudio", "lm-studio":
             return Model.LMStudio.allCases.compactMap {
-                if case .custom = $0 { return nil }
+                if case .custom = $0 {
+                    return nil
+                }
                 return $0.modelId
             }
         default:
@@ -501,9 +512,15 @@ public struct ModelCapabilityInfo {
     /// Format capabilities for CLI display
     public var description: String {
         var capabilities: [String] = []
-        if self.supportsVision { capabilities.append("vision") }
-        if self.supportsTools { capabilities.append("tools") }
-        if self.supportsStreaming { capabilities.append("streaming") }
+        if self.supportsVision {
+            capabilities.append("vision")
+        }
+        if self.supportsTools {
+            capabilities.append("tools")
+        }
+        if self.supportsStreaming {
+            capabilities.append("streaming")
+        }
 
         let capabilityString = capabilities.isEmpty ? "basic" : capabilities.joined(separator: ", ")
         return "\(self.provider)/\(self.modelId) (\(capabilityString))"

--- a/Sources/Tachikoma/Models/ModelSelection.swift
+++ b/Sources/Tachikoma/Models/ModelSelection.swift
@@ -83,6 +83,11 @@ public struct ModelSelector {
             if provider == "openrouter" {
                 return .openRouter(modelId: qualified.model)
             }
+            if provider == "ollama" {
+                // Ollama is an open registry: pass unknown names through as custom
+                // model ids instead of gating on the known-model list.
+                return .ollama(parseOllamaModel(qualified.model.lowercased()) ?? .custom(qualified.model.lowercased()))
+            }
             if !["ollama", "lmstudio", "lm-studio"].contains(provider) {
                 return .openRouter(modelId: normalized)
             }

--- a/Tests/TachikomaTests/Core/MinimalModernAPITests.swift
+++ b/Tests/TachikomaTests/Core/MinimalModernAPITests.swift
@@ -789,34 +789,32 @@ private struct AgentRefusalTests {
 
     private func withRegisteredCustomProvider(
         _ configJSON: String,
-        operation: () async throws -> Void,
+        operation: @Sendable () async throws -> Void,
     ) async throws {
-        let originalProfile = TachikomaConfiguration.profileDirectoryName
-        let tempProfile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let emptyProfile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try await TestEnvironmentMutex.shared.withLock {
+            let originalProfile = TachikomaConfiguration.profileDirectoryName
+            let tempProfile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let emptyProfile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 
-        try FileManager.default.createDirectory(at: tempProfile, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: emptyProfile, withIntermediateDirectories: true)
-        try configJSON.write(to: tempProfile.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
-        try #"{"customProviders":{}}"#.write(
-            to: emptyProfile.appendingPathComponent("config.json"),
-            atomically: true,
-            encoding: .utf8,
-        )
+            try FileManager.default.createDirectory(at: tempProfile, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: emptyProfile, withIntermediateDirectories: true)
+            try configJSON.write(to: tempProfile.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+            try #"{"customProviders":{}}"#.write(
+                to: emptyProfile.appendingPathComponent("config.json"),
+                atomically: true,
+                encoding: .utf8,
+            )
 
-        TachikomaConfiguration.profileDirectoryName = tempProfile.path
-        CustomProviderRegistry.shared.loadFromProfile()
+            TachikomaConfiguration.profileDirectoryName = tempProfile.path
+            CustomProviderRegistry.shared.loadFromProfile()
 
-        do {
+            defer {
+                TachikomaConfiguration.profileDirectoryName = emptyProfile.path
+                CustomProviderRegistry.shared.loadFromProfile()
+                TachikomaConfiguration.profileDirectoryName = originalProfile
+            }
+
             try await operation()
-            TachikomaConfiguration.profileDirectoryName = emptyProfile.path
-            CustomProviderRegistry.shared.loadFromProfile()
-            TachikomaConfiguration.profileDirectoryName = originalProfile
-        } catch {
-            TachikomaConfiguration.profileDirectoryName = emptyProfile.path
-            CustomProviderRegistry.shared.loadFromProfile()
-            TachikomaConfiguration.profileDirectoryName = originalProfile
-            throw error
         }
     }
 }

--- a/Tests/TachikomaTests/Core/MinimalModernAPITests.swift
+++ b/Tests/TachikomaTests/Core/MinimalModernAPITests.swift
@@ -798,7 +798,11 @@ private struct AgentRefusalTests {
 
             try FileManager.default.createDirectory(at: tempProfile, withIntermediateDirectories: true)
             try FileManager.default.createDirectory(at: emptyProfile, withIntermediateDirectories: true)
-            try configJSON.write(to: tempProfile.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+            try configJSON.write(
+                to: tempProfile.appendingPathComponent("config.json"),
+                atomically: true,
+                encoding: .utf8,
+            )
             try #"{"customProviders":{}}"#.write(
                 to: emptyProfile.appendingPathComponent("config.json"),
                 atomically: true,

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -216,7 +216,8 @@ struct ModelParsingTests {
         // prefix still attached, producing .custom("ollama/qwen2.5vl:latest") —
         // a model id that does not exist on the Ollama server.
         #expect(try ModelSelector.parseModel("ollama/qwen2.5vl:latest") == .ollama(.custom("qwen2.5vl:latest")))
-        #expect(try ModelSelector.parseModel("ollama/some-future-model:tag") == .ollama(.custom("some-future-model:tag")))
+        #expect(try ModelSelector
+            .parseModel("ollama/some-future-model:tag") == .ollama(.custom("some-future-model:tag")))
         // Known shortcut names keep resolving to their typed cases.
         #expect(try ModelSelector.parseModel("ollama/llama3.3") == .ollama(.llama33))
     }

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -211,6 +211,17 @@ struct ModelParsingTests {
     }
 
     @Test
+    func `ModelSelector strips the ollama prefix from provider-qualified custom models`() throws {
+        // Regression: parseModel fell through to the bare-name fallback with the
+        // prefix still attached, producing .custom("ollama/qwen2.5vl:latest") —
+        // a model id that does not exist on the Ollama server.
+        #expect(try ModelSelector.parseModel("ollama/qwen2.5vl:latest") == .ollama(.custom("qwen2.5vl:latest")))
+        #expect(try ModelSelector.parseModel("ollama/some-future-model:tag") == .ollama(.custom("some-future-model:tag")))
+        // Known shortcut names keep resolving to their typed cases.
+        #expect(try ModelSelector.parseModel("ollama/llama3.3") == .ollama(.llama33))
+    }
+
+    @Test
     func `parse local provider shortcuts`() {
         #expect(LanguageModel.parse(from: "ollama") == .ollama(.llama33))
         #expect(LanguageModel.parse(from: "lmstudio") == .lmstudio(.gptOSS120B))


### PR DESCRIPTION
## Summary

Slimmed after #30/#31 landed GPT-5.6 on main first — this PR now contains only the two changes main still lacks:

1. **`ModelSelector.parseModel` keeps the `ollama/` prefix in custom model ids.** Provider-qualified unknown names fell through to the bare-name fallback with the prefix attached, producing `.custom("ollama/qwen2.5vl:latest")` — an id that does not exist on the Ollama server. (`LanguageModel.parse` already strips it; the throwing selector now matches.) Found live: Peekaboo's shipped default provider entry `ollama/qwen2.5vl:latest` was unusable through this path.

2. **Custom-provider test helper serialized under `TestEnvironmentMutex`.** It mutated `TachikomaConfiguration.profileDirectoryName` and `CustomProviderRegistry.shared` unlocked, which made `AuthManagerTests` order-dependent — adding any test could (deterministically, given the right scheduling) fail "openrouter resolves env and credential keys as bearer auth". State is restored in `defer` and the callback is `@Sendable`.

## Tests

- New: `ModelSelector strips the ollama prefix from provider-qualified custom models` (regression for 1, incl. known-shortcut preservation).
- Full suite: 792 tests / 103 suites, green, run twice (order-dependency fix verified by repetition).
