### PR TITLE
fix(ollama): surface native tool calls from the streaming chat API

### DIFF
--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -162,7 +162,9 @@ public final class AnthropicProvider: ModelProvider {
             }
             return nil
         case .adaptive:
-            if Self.isFable(model: model) { return nil }
+            if Self.isFable(model: model) {
+                return nil
+            }
             guard self.usesAdaptiveThinking(model: model) else { return nil }
             return AnthropicThinking(type: "adaptive", budgetTokens: nil)
         case let .enabled(budgetTokens):
@@ -198,7 +200,9 @@ public final class AnthropicProvider: ModelProvider {
             }
             return AnthropicOutputConfig(effort: effort.rawValue)
         }
-        if case .disabled = mode { return nil }
+        if case .disabled = mode {
+            return nil
+        }
 
         let effort = self.usesAdaptiveThinking(model: model) ? self.adaptiveEffort(from: mode) : nil
         return effort.map { AnthropicOutputConfig(effort: $0) }
@@ -220,17 +224,31 @@ public final class AnthropicProvider: ModelProvider {
     }
 
     private func usesAdaptiveThinking(model: LanguageModel.Anthropic) -> Bool {
-        if Self.isFable(model: model) { return true }
-        if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) { return true }
-        if case .opus48 = model { return true }
-        if case .opus47 = model { return true }
-        if case .sonnet46 = model { return true }
+        if Self.isFable(model: model) {
+            return true
+        }
+        if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
+            return true
+        }
+        if case .opus48 = model {
+            return true
+        }
+        if case .opus47 = model {
+            return true
+        }
+        if case .sonnet46 = model {
+            return true
+        }
         return false
     }
 
     private func supportsEffort(model: LanguageModel.Anthropic) -> Bool {
-        if Self.isFable(model: model) { return true }
-        if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) { return true }
+        if Self.isFable(model: model) {
+            return true
+        }
+        if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
+            return true
+        }
         switch model {
         case .opus48, .opus47, .opus45, .sonnet46:
             return true
@@ -242,8 +260,12 @@ public final class AnthropicProvider: ModelProvider {
     private func adaptiveEffort(from mode: AnthropicOptions.ThinkingMode?) -> String? {
         guard case let .enabled(budgetTokens) = mode else { return nil }
 
-        if budgetTokens <= 4096 { return ReasoningEffort.low.rawValue }
-        if budgetTokens <= 12000 { return ReasoningEffort.medium.rawValue }
+        if budgetTokens <= 4096 {
+            return ReasoningEffort.low.rawValue
+        }
+        if budgetTokens <= 12000 {
+            return ReasoningEffort.medium.rawValue
+        }
         return ReasoningEffort.high.rawValue
     }
 
@@ -307,7 +329,11 @@ public final class AnthropicProvider: ModelProvider {
         var thinking: AnthropicThinking?
         let systemMessage: String?
         let messages: [AnthropicMessage]
-        let thinkingDisabled = if case .disabled = thinkingMode { true } else { false }
+        let thinkingDisabled = if case .disabled = thinkingMode {
+            true
+        } else {
+            false
+        }
         let requiresSignedThinkingReplay = self.requiresSignedThinkingReplay(model: self.model)
         let preserveSignedThinking = !thinkingDisabled && (requestedThinking != nil || requiresSignedThinkingReplay)
         let reasoningTarget = AnthropicReasoningReplayTarget(
@@ -1156,13 +1182,17 @@ public final class OllamaProvider: ModelProvider {
         // Convert messages to Ollama format
         let messages = request.messages.map { message in
             let images = message.content.compactMap { part in
-                if case let .image(image) = part { return image.data }
+                if case let .image(image) = part {
+                    return image.data
+                }
                 return nil
             }
             return OllamaChatMessage(
                 role: message.role.rawValue,
                 content: message.content.compactMap { part in
-                    if case let .text(text) = part { return text }
+                    if case let .text(text) = part {
+                        return text
+                    }
                     return nil
                 }.joined(),
                 images: images.isEmpty ? nil : images,
@@ -1214,7 +1244,9 @@ public final class OllamaProvider: ModelProvider {
         // Ollama doesn't provide detailed token usage, estimate based on content
         let usage = Usage(
             inputTokens: request.messages.map { $0.content.compactMap { part in
-                if case let .text(text) = part { return text }
+                if case let .text(text) = part {
+                    return text
+                }
                 return nil
             }.joined().count / 4 }.reduce(0, +),
             outputTokens: text.count / 4,
@@ -1225,25 +1257,7 @@ public final class OllamaProvider: ModelProvider {
         // Handle tool calls - Ollama might return them in different formats
         var toolCalls: [AgentToolCall]?
         if let messageCalls = ollamaResponse.message.toolCalls {
-            toolCalls = messageCalls.compactMap { ollamaCall in
-                // Convert arguments dictionary to AnyAgentToolValue format
-                var arguments: [String: AnyAgentToolValue] = [:]
-                for (key, value) in ollamaCall.function.arguments {
-                    do {
-                        arguments[key] = try AnyAgentToolValue.fromJSON(value)
-                    } catch {
-                        // Log warning and skip arguments that can't be converted
-                        print("[WARNING] Failed to convert tool argument '\(key)': \(error)")
-                        continue
-                    }
-                }
-
-                return AgentToolCall(
-                    id: "ollama_\(UUID().uuidString)",
-                    name: ollamaCall.function.name,
-                    arguments: arguments,
-                )
-            }
+            toolCalls = messageCalls.map { Self.convertOllamaToolCall($0) }
         }
 
         // Some Ollama models output tool calls as JSON in the content
@@ -1300,13 +1314,17 @@ public final class OllamaProvider: ModelProvider {
         // Convert messages to Ollama format
         let messages = request.messages.map { message in
             let images = message.content.compactMap { part in
-                if case let .image(image) = part { return image.data }
+                if case let .image(image) = part {
+                    return image.data
+                }
                 return nil
             }
             return OllamaChatMessage(
                 role: message.role.rawValue,
                 content: message.content.compactMap { part in
-                    if case let .text(text) = part { return text }
+                    if case let .text(text) = part {
+                        return text
+                    }
                     return nil
                 }.joined(),
                 images: images.isEmpty ? nil : images,
@@ -1360,6 +1378,10 @@ public final class OllamaProvider: ModelProvider {
                             continuation.yield(TextStreamDelta.text(content))
                         }
 
+                        for ollamaCall in chunk.message.toolCalls ?? [] {
+                            continuation.yield(TextStreamDelta.tool(Self.convertOllamaToolCall(ollamaCall)))
+                        }
+
                         if chunk.done {
                             continuation.yield(TextStreamDelta.done())
                             break
@@ -1375,6 +1397,27 @@ public final class OllamaProvider: ModelProvider {
     }
 
     // MARK: - Helper Methods
+
+    /// Shared by the streaming and non-streaming paths so both surface Ollama's
+    /// native tool calls identically.
+    static func convertOllamaToolCall(_ ollamaCall: OllamaToolCall) -> AgentToolCall {
+        var arguments: [String: AnyAgentToolValue] = [:]
+        for (key, value) in ollamaCall.function.arguments {
+            do {
+                arguments[key] = try AnyAgentToolValue.fromJSON(value)
+            } catch {
+                // Log warning and skip arguments that can't be converted
+                print("[WARNING] Failed to convert tool argument '\(key)': \(error)")
+                continue
+            }
+        }
+
+        return AgentToolCall(
+            id: "ollama_\(UUID().uuidString)",
+            name: ollamaCall.function.name,
+            arguments: arguments,
+        )
+    }
 
     private func convertToolToOllama(_ tool: AgentTool) throws -> OllamaTool {
         // Convert AgentToolParameters to [String: Any]

--- a/Sources/Tachikoma/Providers/Ollama/OllamaTypes.swift
+++ b/Sources/Tachikoma/Providers/Ollama/OllamaTypes.swift
@@ -247,6 +247,16 @@ struct OllamaStreamChunk: Codable {
     struct Delta: Codable {
         let role: String?
         let content: String?
+        /// Ollama emits native tool calls on the streaming `/api/chat` response
+        /// (`{"message":{"content":"","tool_calls":[…]},"done":false}`). Without
+        /// this the caller sees zero tool calls and models fall back to printing
+        /// tool-call JSON as plain text.
+        let toolCalls: [OllamaToolCall]?
+
+        enum CodingKeys: String, CodingKey {
+            case role, content
+            case toolCalls = "tool_calls"
+        }
     }
 }
 

--- a/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
+++ b/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
@@ -24,7 +24,8 @@ struct OllamaStreamingToolCallTests {
         let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
 
         #expect(chunk.done == false)
-        #expect(chunk.message.content == "")
+        // Ollama pairs an empty content string with the tool calls.
+        #expect(chunk.message.content?.isEmpty == true)
         let calls = try #require(chunk.message.toolCalls)
         #expect(calls.count == 1)
         #expect(calls[0].function.name == "get_weather")

--- a/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
+++ b/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import Tachikoma
+
+struct OllamaStreamingToolCallTests {
+    /// Captured verbatim from a live `POST /api/chat` with `"stream": true` and a
+    /// tools array (ollama 0.x, llama3.1:8b). Before this was decoded, the stream
+    /// parser only read `content`/`done`, so tool calls were silently dropped and
+    /// the agent reported success having executed nothing.
+    private static let toolCallChunk = """
+    {"model":"llama3.1:8b","created_at":"2026-07-10T09:40:30.514383Z","message":{"role":"assistant",\
+    "content":"","tool_calls":[{"id":"call_icagibop","function":{"index":0,"name":"get_weather",\
+    "arguments":{"city":"Paris"}}}]},"done":false}
+    """
+
+    private static let doneChunk = """
+    {"model":"llama3.1:8b","created_at":"2026-07-10T09:40:30.52607Z",\
+    "message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}
+    """
+
+    @Test
+    func `stream chunk decodes native tool calls`() throws {
+        let data = try #require(Self.toolCallChunk.data(using: .utf8))
+        let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
+
+        #expect(chunk.done == false)
+        #expect(chunk.message.content == "")
+        let calls = try #require(chunk.message.toolCalls)
+        #expect(calls.count == 1)
+        #expect(calls[0].function.name == "get_weather")
+        #expect(calls[0].function.arguments["city"] as? String == "Paris")
+    }
+
+    @Test
+    func `stream chunk without tool calls still decodes`() throws {
+        let data = try #require(Self.doneChunk.data(using: .utf8))
+        let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
+
+        #expect(chunk.done == true)
+        #expect(chunk.message.toolCalls == nil)
+    }
+
+    @Test
+    func `decoded tool call converts to an AgentToolCall`() throws {
+        let data = try #require(Self.toolCallChunk.data(using: .utf8))
+        let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
+        let ollamaCall = try #require(chunk.message.toolCalls?.first)
+
+        let agentCall = OllamaProvider.convertOllamaToolCall(ollamaCall)
+
+        #expect(agentCall.name == "get_weather")
+        #expect(agentCall.arguments["city"]?.stringValue == "Paris")
+        #expect(agentCall.id.hasPrefix("ollama_"))
+    }
+}


### PR DESCRIPTION
## Summary

The streaming `/api/chat` parser only read `message.content` and `done`, so the `tool_calls` Ollama returns were silently dropped. Callers saw **zero tool calls**; models then fell back to emitting tool-call JSON as plain text, so an agent loop executed nothing and still reported success.

Verified against a live ollama server (llama3.1:8b) — it does stream native tool calls:

    {"model":"llama3.1:8b","message":{"role":"assistant","content":"",
     "tool_calls":[{"id":"call_icagibop","function":{"index":0,"name":"get_weather",
     "arguments":{"city":"Paris"}}}]},"done":false}

`OllamaStreamChunk.Delta` had no `tool_calls` field at all. This adds it, yields the calls as tool deltas, and shares the existing conversion with the non-streaming path (which already handled them correctly).

## Impact

Downstream (Peekaboo): `peekaboo agent --model ollama/<tool-capable-model>` went from `toolCallCount: 0`, empty content, and nothing executed — to tools actually dispatching against the real UI (verified live: `see`, `click`, `launch_app` invoked; 8 `see` calls executed in a second run) with assistant text populated.

## Tests

New `OllamaStreamingToolCallTests` decodes the captured live chunk verbatim: tool calls decode with name/arguments; a chunk without them still decodes; the decoded call converts to an `AgentToolCall`. Full suite: 795 tests / 104 suites green.
