### PR TITLE
fix(models): preserve GPT-5.6 variant capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 ### Fixed
 - Sonnet 5 usage estimates now switch from introductory to standard pricing after August 31, 2026.
 - GPT-5.6 models now retain their 372K context and 128K output limits through OpenAI-compatible, OpenRouter, and Together endpoints.
+- GPT-5.6 OpenRouter routes with terminal variants such as `:online`, `:nitro`, `:floor`, and `:exacto` now retain those limits without rewriting the routed model ID.
 - OpenAI `gpt-5-chat-latest` now preserves its distinct model identity, appears in model listings, and applies GPT-5 parameter filtering instead of being rewritten to `chat-latest`.
 - SwiftPM consumers now resolve Commander from the package URL instead of accidentally inheriting a sibling local checkout.
 - Ollama model parsing now preserves explicit custom vision model IDs such as `qwen2.5vl:3b` instead of falling back to `llama3.3` (#16).

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -162,24 +162,32 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             let trimmed = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
 
-            let parsedModel = ProviderParser.parse(trimmed)?.model
-            for candidate in [parsedModel, trimmed].compactMap(\.self) {
-                let compact = candidate.lowercased()
-                    .replacingOccurrences(of: "-", with: "")
-                    .replacingOccurrences(of: ".", with: "")
-                    .replacingOccurrences(of: "_", with: "")
-                switch compact {
-                case "gpt56", "gpt56sol":
-                    return .gpt56Sol
-                case "gpt56terra":
-                    return .gpt56Terra
-                case "gpt56luna":
-                    return .gpt56Luna
-                default:
-                    continue
-                }
+            let modelComponent = trimmed.split(separator: "/", omittingEmptySubsequences: false).last ?? ""
+            guard !modelComponent.isEmpty else { return nil }
+
+            // OpenRouter routing variants are terminal metadata; ignore them only for capability inference.
+            let baseModel = if
+                let suffixSeparator = modelComponent.firstIndex(of: ":"),
+                modelComponent.index(after: suffixSeparator) < modelComponent.endIndex
+            {
+                modelComponent[..<suffixSeparator]
+            } else {
+                modelComponent[...]
             }
-            return nil
+            let compact = baseModel.lowercased()
+                .replacingOccurrences(of: "-", with: "")
+                .replacingOccurrences(of: ".", with: "")
+                .replacingOccurrences(of: "_", with: "")
+            switch compact {
+            case "gpt56", "gpt56sol":
+                return .gpt56Sol
+            case "gpt56terra":
+                return .gpt56Terra
+            case "gpt56luna":
+                return .gpt56Luna
+            default:
+                return nil
+            }
         }
 
         public var isUnsupportedLegacyFamily: Bool {

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -28,6 +28,31 @@ struct ModelParsingTests {
     }
 
     @Test
+    func `infer GPT-5.6 models through OpenRouter routing suffixes`() throws {
+        let models: [(id: String, expected: LanguageModel.OpenAI)] = [
+            ("gpt-5.6-sol", .gpt56Sol),
+            ("gpt-5.6-terra", .gpt56Terra),
+            ("gpt-5.6-luna", .gpt56Luna),
+        ]
+        let variants = ["online", "nitro", "floor", "exacto"]
+
+        for model in models {
+            for variant in variants {
+                let routedModelId = "openai/\(model.id):\(variant)"
+                #expect(LanguageModel.OpenAI.gpt56Model(for: routedModelId) == model.expected)
+                #expect(LanguageModel.OpenAI.gpt56Model(for: "openrouter/\(routedModelId)") == model.expected)
+                #expect(
+                    try ModelSelector.parseModel("openrouter/\(routedModelId)") ==
+                        .openRouter(modelId: routedModelId),
+                )
+            }
+        }
+
+        #expect(LanguageModel.OpenAI.gpt56Model(for: "openai/gpt-5.60:online") == nil)
+        #expect(LanguageModel.OpenAI.gpt56Model(for: "openai/not-gpt-5.6-sol:nitro") == nil)
+    }
+
+    @Test
     func `parse chat latest OpenAI alias`() throws {
         #expect(LanguageModel.parse(from: "chat-latest") == .openai(.chatLatest))
         #expect(LanguageModel.parse(from: "gpt-5-chat-latest") == .openai(.gpt5ChatLatest))

--- a/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
+++ b/Tests/TachikomaTests/Core/OpenAICompatibleHelperTests.swift
@@ -41,6 +41,26 @@ struct OpenAICompatibleHelperTests {
     }
 
     @Test
+    func `OpenRouter GPT-5.6 variants retain limits and routed model ids`() throws {
+        let models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+        let variants = ["online", "nitro", "floor", "exacto"]
+        let configuration = TachikomaConfiguration(apiKeys: ["openrouter": "sk-test"])
+
+        for model in models {
+            for variant in variants {
+                let routedModelId = "openai/\(model):\(variant)"
+                let provider = try OpenRouterProvider(modelId: routedModelId, configuration: configuration)
+
+                #expect(provider.modelId == routedModelId)
+                #expect(provider.capabilities.contextLength == 372_000)
+                #expect(provider.capabilities.maxOutputTokens == 128_000)
+                #expect(LanguageModel.openRouter(modelId: routedModelId).modelId == routedModelId)
+                #expect(LanguageModel.openRouter(modelId: routedModelId).contextLength == 372_000)
+            }
+        }
+    }
+
+    @Test
     func `generateText encodes stop sequences, headers, and tool definitions`() async throws {
         let tool = AgentTool(
             name: "lookup",


### PR DESCRIPTION
## Summary

- recognize GPT-5.6 Sol, Terra, and Luna behind terminal OpenRouter routing variants
- retain 372K context and 128K output capabilities without rewriting routed model IDs
- cover all three GPT-5.6 variants across `:online`, `:nitro`, `:floor`, and `:exacto`

## Testing

- `swift test --filter 'ModelParsingTests|OpenAICompatibleHelperTests'` (51 tests)
- `TACHIKOMA_DISABLE_API_TESTS=true TACHIKOMA_TEST_MODE=mock swift test --no-parallel` (797 tests)
- `mint run nicklockwood/SwiftFormat@0.61.1 swiftformat --lint .`
- `swiftlint lint --reporter xcode --strict --quiet`
- autoreview: clean, no accepted/actionable findings
