### PR TITLE
fix(ollama): preserve multi-step tool conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Removed stale direct model support for retired or non-canonical IDs including GPT-5.1/5.2/pseudo-thinking models, deprecated Claude Sonnet/Opus 4 snapshots, Grok 2/3/4-fast rows, old Groq Llama/Mixtral/Gemma aliases, stale Mistral aliases, and invalid LM Studio `current`.
 
 ### Fixed
+- Ollama tool conversations now replay assistant calls and named results, preserve recursive arguments and array schemas, report tool-call finishes, and surface HTTP-200 stream errors instead of silently succeeding.
 - Sonnet 5 usage estimates now switch from introductory to standard pricing after August 31, 2026.
 - GPT-5.6 models now retain their 372K context and 128K output limits through OpenAI-compatible, OpenRouter, and Together endpoints.
 - GPT-5.6 OpenRouter routes with terminal variants such as `:online`, `:nitro`, `:floor`, and `:exacto` now retain those limits without rewriting the routed model ID.

--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -1179,25 +1179,7 @@ public final class OllamaProvider: ModelProvider {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.timeoutInterval = 300 // 5 minutes for local processing
 
-        // Convert messages to Ollama format
-        let messages = request.messages.map { message in
-            let images = message.content.compactMap { part in
-                if case let .image(image) = part {
-                    return image.data
-                }
-                return nil
-            }
-            return OllamaChatMessage(
-                role: message.role.rawValue,
-                content: message.content.compactMap { part in
-                    if case let .text(text) = part {
-                        return text
-                    }
-                    return nil
-                }.joined(),
-                images: images.isEmpty ? nil : images,
-            )
-        }
+        let messages = try self.convertMessagesToOllama(request.messages)
 
         var options: OllamaChatRequest.OllamaOptions?
         if request.settings.temperature != nil || request.settings.maxTokens != nil {
@@ -1252,8 +1234,6 @@ public final class OllamaProvider: ModelProvider {
             outputTokens: text.count / 4,
         )
 
-        let finishReason: FinishReason = ollamaResponse.done ? .stop : .other
-
         // Handle tool calls - Ollama might return them in different formats
         var toolCalls: [AgentToolCall]?
         if let messageCalls = ollamaResponse.message.toolCalls {
@@ -1292,6 +1272,14 @@ public final class OllamaProvider: ModelProvider {
             }
         }
 
+        let finishReason: FinishReason = if toolCalls?.isEmpty == false {
+            .toolCalls
+        } else if ollamaResponse.done {
+            .stop
+        } else {
+            .other
+        }
+
         return ProviderResponse(
             text: text,
             usage: usage,
@@ -1311,25 +1299,7 @@ public final class OllamaProvider: ModelProvider {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.timeoutInterval = 300 // 5 minutes for local processing
 
-        // Convert messages to Ollama format
-        let messages = request.messages.map { message in
-            let images = message.content.compactMap { part in
-                if case let .image(image) = part {
-                    return image.data
-                }
-                return nil
-            }
-            return OllamaChatMessage(
-                role: message.role.rawValue,
-                content: message.content.compactMap { part in
-                    if case let .text(text) = part {
-                        return text
-                    }
-                    return nil
-                }.joined(),
-                images: images.isEmpty ? nil : images,
-            )
-        }
+        let messages = try self.convertMessagesToOllama(request.messages)
 
         var options: OllamaChatRequest.OllamaOptions?
         if request.settings.temperature != nil || request.settings.maxTokens != nil {
@@ -1371,6 +1341,13 @@ public final class OllamaProvider: ModelProvider {
                 for line in lines {
                     guard let data = line.data(using: .utf8) else { continue }
 
+                    if let errorResponse = try? JSONDecoder().decode(OllamaErrorResponse.self, from: data) {
+                        continuation.finish(
+                            throwing: TachikomaError.apiError("Ollama Error: \(errorResponse.error)"),
+                        )
+                        return
+                    }
+
                     do {
                         let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
 
@@ -1401,44 +1378,131 @@ public final class OllamaProvider: ModelProvider {
     /// Shared by the streaming and non-streaming paths so both surface Ollama's
     /// native tool calls identically.
     static func convertOllamaToolCall(_ ollamaCall: OllamaToolCall) -> AgentToolCall {
-        var arguments: [String: AnyAgentToolValue] = [:]
-        for (key, value) in ollamaCall.function.arguments {
-            do {
-                arguments[key] = try AnyAgentToolValue.fromJSON(value)
-            } catch {
-                // Log warning and skip arguments that can't be converted
-                print("[WARNING] Failed to convert tool argument '\(key)': \(error)")
-                continue
-            }
-        }
-
-        return AgentToolCall(
+        AgentToolCall(
             id: "ollama_\(UUID().uuidString)",
             name: ollamaCall.function.name,
-            arguments: arguments,
+            arguments: ollamaCall.function.arguments,
         )
     }
 
+    private func convertMessagesToOllama(_ messages: [ModelMessage]) throws -> [OllamaChatMessage] {
+        var toolNamesByCallID: [String: String] = [:]
+        var converted: [OllamaChatMessage] = []
+
+        for message in messages {
+            let text = message.content.compactMap { part in
+                if case let .text(text) = part {
+                    return text
+                }
+                return nil
+            }.joined()
+            let images = message.content.compactMap { part in
+                if case let .image(image) = part {
+                    return image.data
+                }
+                return nil
+            }
+
+            let toolCalls = message.content.compactMap { part -> AgentToolCall? in
+                if case let .toolCall(call) = part {
+                    return call
+                }
+                return nil
+            }
+            for call in toolCalls {
+                toolNamesByCallID[call.id] = call.name
+            }
+
+            if message.role == .tool {
+                let toolResults = message.content.compactMap { part -> AgentToolResult? in
+                    if case let .toolResult(result) = part {
+                        return result
+                    }
+                    return nil
+                }
+
+                if !toolResults.isEmpty {
+                    for result in toolResults {
+                        guard let toolName = toolNamesByCallID[result.toolCallId] else {
+                            throw TachikomaError.invalidInput(
+                                "Ollama tool result references unknown call ID '\(result.toolCallId)'",
+                            )
+                        }
+                        try converted.append(OllamaChatMessage(
+                            role: message.role.rawValue,
+                            content: Self.ollamaToolResultContent(result.result),
+                            toolName: toolName,
+                        ))
+                    }
+                    continue
+                }
+            }
+
+            let ollamaCalls = toolCalls.enumerated().map { index, call in
+                OllamaToolCall(
+                    function: OllamaToolCall.Function(
+                        index: index,
+                        name: call.name,
+                        arguments: call.arguments,
+                    ),
+                )
+            }
+            converted.append(OllamaChatMessage(
+                role: message.role.rawValue,
+                content: text,
+                images: images.isEmpty ? nil : images,
+                toolCalls: ollamaCalls.isEmpty ? nil : ollamaCalls,
+            ))
+        }
+
+        return converted
+    }
+
+    private static func ollamaToolResultContent(_ result: AnyAgentToolValue) throws -> String {
+        if let string = result.stringValue {
+            return string
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(result)
+        guard let content = String(bytes: data, encoding: .utf8) else {
+            throw TachikomaError.invalidInput("Could not encode Ollama tool result as UTF-8")
+        }
+        return content
+    }
+
     private func convertToolToOllama(_ tool: AgentTool) throws -> OllamaTool {
-        // Convert AgentToolParameters to [String: Any]
-        var properties: [String: Any] = [:]
+        var properties: [String: AnyAgentToolValue] = [:]
         for (key, prop) in tool.parameters.properties {
-            var propDict: [String: Any] = [
-                "type": prop.type.rawValue,
-                "description": prop.description,
+            var propDict: [String: AnyAgentToolValue] = [
+                "type": AnyAgentToolValue(string: prop.type.rawValue),
+                "description": AnyAgentToolValue(string: prop.description),
             ]
 
             if let enumValues = prop.enumValues {
-                propDict["enum"] = enumValues
+                propDict["enum"] = AnyAgentToolValue(array: enumValues.map { AnyAgentToolValue(string: $0) })
             }
 
-            properties[key] = propDict
+            if let items = prop.items {
+                var itemSchema = [
+                    "type": AnyAgentToolValue(string: items.type),
+                ]
+                if let description = items.description {
+                    itemSchema["description"] = AnyAgentToolValue(string: description)
+                }
+                propDict["items"] = AnyAgentToolValue(object: itemSchema)
+            }
+
+            properties[key] = AnyAgentToolValue(object: propDict)
         }
 
-        let parameters: [String: Any] = [
-            "type": tool.parameters.type,
-            "properties": properties,
-            "required": tool.parameters.required,
+        let parameters: [String: AnyAgentToolValue] = [
+            "type": AnyAgentToolValue(string: tool.parameters.type),
+            "properties": AnyAgentToolValue(object: properties),
+            "required": AnyAgentToolValue(
+                array: tool.parameters.required.map { AnyAgentToolValue(string: $0) },
+            ),
         ]
 
         return OllamaTool(

--- a/Sources/Tachikoma/Providers/Ollama/OllamaTypes.swift
+++ b/Sources/Tachikoma/Providers/Ollama/OllamaTypes.swift
@@ -27,107 +27,62 @@ struct OllamaChatMessage: Codable {
     let content: String
     let images: [String]?
     let toolCalls: [OllamaToolCall]?
+    let toolName: String?
 
     enum CodingKeys: String, CodingKey {
         case role, content, images
         case toolCalls = "tool_calls"
+        case toolName = "tool_name"
     }
 
-    init(role: String, content: String, images: [String]? = nil, toolCalls: [OllamaToolCall]? = nil) {
+    init(
+        role: String,
+        content: String,
+        images: [String]? = nil,
+        toolCalls: [OllamaToolCall]? = nil,
+        toolName: String? = nil,
+    ) {
         self.role = role
         self.content = content
         self.images = images
         self.toolCalls = toolCalls
+        self.toolName = toolName
     }
 }
 
 struct OllamaToolCall: Codable {
+    let type: String?
     let function: Function
 
     struct Function: Codable {
+        let index: Int?
         let name: String
-        let arguments: [String: Any]
+        let arguments: [String: AnyAgentToolValue]
 
-        init(name: String, arguments: [String: Any]) {
+        enum CodingKeys: String, CodingKey {
+            case index, name, arguments
+        }
+
+        init(index: Int? = nil, name: String, arguments: [String: AnyAgentToolValue]) {
+            self.index = index
             self.name = name
             self.arguments = arguments
         }
 
-        enum CodingKeys: String, CodingKey {
-            case name, arguments
-        }
-
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.index = try container.decodeIfPresent(Int.self, forKey: .index)
             self.name = try container.decode(String.self, forKey: .name)
-
-            // Try to decode arguments as direct JSON object using a nested container (GPT-OSS format)
-            if let nestedContainer = try? container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: .arguments) {
-                self.arguments = try Self.decodeAnyDictionary(from: nestedContainer)
-            }
-            // Fallback: decode arguments as Data then parse (legacy format)
-            else if
-                let data = try? container.decode(Data.self, forKey: .arguments),
-                let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            {
-                self.arguments = dict
-            } else {
-                self.arguments = [:]
-            }
+            self.arguments = try container.decodeIfPresent(
+                [String: AnyAgentToolValue].self,
+                forKey: .arguments,
+            ) ?? [:]
         }
+    }
 
-        private static func decodeAnyDictionary(from container: KeyedDecodingContainer<AnyCodingKey>) throws
-            -> [String: Any]
-        {
-            var result: [String: Any] = [:]
-            for key in container.allKeys {
-                if let stringValue = try? container.decode(String.self, forKey: key) {
-                    result[key.stringValue] = stringValue
-                } else if let intValue = try? container.decode(Int.self, forKey: key) {
-                    result[key.stringValue] = intValue
-                } else if let doubleValue = try? container.decode(Double.self, forKey: key) {
-                    result[key.stringValue] = doubleValue
-                } else if let boolValue = try? container.decode(Bool.self, forKey: key) {
-                    result[key.stringValue] = boolValue
-                }
-            }
-            return result
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(self.name, forKey: .name)
-
-            // Encode arguments as a JSON object (not base64 Data)
-            var argsContainer = container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: .arguments)
-            try Self.encodeAnyDictionary(self.arguments, to: &argsContainer)
-        }
-
-        private static func encodeAnyDictionary(
-            _ dict: [String: Any],
-            to container: inout KeyedEncodingContainer<AnyCodingKey>,
-        ) throws {
-            for (key, value) in dict {
-                guard let codingKey = AnyCodingKey(stringValue: key) else { continue }
-                switch value {
-                case let stringValue as String:
-                    try container.encode(stringValue, forKey: codingKey)
-                case let intValue as Int:
-                    try container.encode(intValue, forKey: codingKey)
-                case let doubleValue as Double:
-                    try container.encode(doubleValue, forKey: codingKey)
-                case let boolValue as Bool:
-                    try container.encode(boolValue, forKey: codingKey)
-                case let arrayValue as [Any]:
-                    try container.encode(arrayValue.map { String(describing: $0) }, forKey: codingKey)
-                case let dictValue as [String: Any]:
-                    var nestedContainer = container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: codingKey)
-                    try Self.encodeAnyDictionary(dictValue, to: &nestedContainer)
-                default:
-                    try container.encode(String(describing: value), forKey: codingKey)
-                }
-            }
-        }
+    init(type: String? = "function", function: Function) {
+        self.type = type
+        self.function = function
     }
 }
 
@@ -138,71 +93,7 @@ struct OllamaTool: Codable {
     struct Function: Codable {
         let name: String
         let description: String
-        let parameters: [String: Any]
-
-        init(name: String, description: String, parameters: [String: Any]) {
-            self.name = name
-            self.description = description
-            self.parameters = parameters
-        }
-
-        enum CodingKeys: String, CodingKey {
-            case name, description, parameters
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.description = try container.decode(String.self, forKey: .description)
-
-            // Decode parameters as generic dictionary
-            if
-                let data = try? container.decode(Data.self, forKey: .parameters),
-                let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            {
-                self.parameters = dict
-            } else {
-                self.parameters = [:]
-            }
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(self.name, forKey: .name)
-            try container.encode(self.description, forKey: .description)
-
-            // Encode parameters directly as JSON object, not as base64 data
-            var parametersContainer = container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: .parameters)
-            try self.encodeAnyDictionary(self.parameters, to: &parametersContainer)
-        }
-
-        private func encodeAnyDictionary(
-            _ dict: [String: Any],
-            to container: inout KeyedEncodingContainer<AnyCodingKey>,
-        ) throws {
-            for (key, value) in dict {
-                guard let codingKey = AnyCodingKey(stringValue: key) else { continue }
-                switch value {
-                case let stringValue as String:
-                    try container.encode(stringValue, forKey: codingKey)
-                case let intValue as Int:
-                    try container.encode(intValue, forKey: codingKey)
-                case let doubleValue as Double:
-                    try container.encode(doubleValue, forKey: codingKey)
-                case let boolValue as Bool:
-                    try container.encode(boolValue, forKey: codingKey)
-                case let arrayValue as [Any]:
-                    try container.encode(arrayValue.map { String(describing: $0) }, forKey: codingKey)
-                case let dictValue as [String: Any]:
-                    // Encode nested objects properly as nested containers
-                    var nestedContainer = container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: codingKey)
-                    try self.encodeAnyDictionary(dictValue, to: &nestedContainer)
-                default:
-                    // Fallback: convert to string
-                    try container.encode(String(describing: value), forKey: codingKey)
-                }
-            }
-        }
+        let parameters: [String: AnyAgentToolValue]
     }
 }
 

--- a/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
+++ b/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
@@ -18,6 +18,17 @@ struct OllamaStreamingToolCallTests {
     "message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}
     """
 
+    private static let recursiveToolCallChunk = """
+    {"model":"llama3.1:8b","message":{"role":"assistant","content":"","tool_calls":[{"function":{
+    "index":0,"name":"run_plan","arguments":{"enabled":true,"metadata":{"attempt":2,"note":null},
+    "steps":["inspect",3,false,null,{"kind":"finish"}]}}}]},"done":false}
+    """
+
+    private static let zeroArgumentToolCallChunk = """
+    {"model":"llama3.1:8b","message":{"role":"assistant","content":"","tool_calls":[{"function":{
+    "index":0,"name":"get_status"}}]},"done":false}
+    """
+
     @Test
     func `stream chunk decodes native tool calls`() throws {
         let data = try #require(Self.toolCallChunk.data(using: .utf8))
@@ -29,7 +40,7 @@ struct OllamaStreamingToolCallTests {
         let calls = try #require(chunk.message.toolCalls)
         #expect(calls.count == 1)
         #expect(calls[0].function.name == "get_weather")
-        #expect(calls[0].function.arguments["city"] as? String == "Paris")
+        #expect(calls[0].function.arguments["city"]?.stringValue == "Paris")
     }
 
     @Test
@@ -52,5 +63,38 @@ struct OllamaStreamingToolCallTests {
         #expect(agentCall.name == "get_weather")
         #expect(agentCall.arguments["city"]?.stringValue == "Paris")
         #expect(agentCall.id.hasPrefix("ollama_"))
+    }
+
+    @Test
+    func `stream chunk preserves recursive tool arguments`() throws {
+        let data = try #require(Self.recursiveToolCallChunk.data(using: .utf8))
+        let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
+        let call = try #require(chunk.message.toolCalls?.first)
+
+        #expect(call.function.index == 0)
+        #expect(call.function.arguments["enabled"]?.boolValue == true)
+        #expect(call.function.arguments["metadata"]?.objectValue?["attempt"]?.intValue == 2)
+        #expect(call.function.arguments["metadata"]?.objectValue?["note"]?.isNull == true)
+
+        let steps = try #require(call.function.arguments["steps"]?.arrayValue)
+        #expect(steps[0].stringValue == "inspect")
+        #expect(steps[1].intValue == 3)
+        #expect(steps[2].boolValue == false)
+        #expect(steps[3].isNull)
+        #expect(steps[4].objectValue?["kind"]?.stringValue == "finish")
+
+        let converted = OllamaProvider.convertOllamaToolCall(call)
+        #expect(converted.arguments == call.function.arguments)
+    }
+
+    @Test
+    func `stream chunk defaults omitted tool arguments to empty`() throws {
+        let data = try #require(Self.zeroArgumentToolCallChunk.data(using: .utf8))
+        let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
+        let call = try #require(chunk.message.toolCalls?.first)
+
+        #expect(call.function.name == "get_status")
+        #expect(call.function.arguments.isEmpty)
+        #expect(OllamaProvider.convertOllamaToolCall(call).arguments.isEmpty)
     }
 }

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -298,6 +298,159 @@ struct ProviderEndToEndTests {
         }
     }
 
+    @Test
+    func `Ollama provider replays tool history and recursive schemas`() async throws {
+        let toolCall = AgentToolCall(
+            id: "call_plan",
+            name: "run_plan",
+            arguments: [
+                "metadata": AnyAgentToolValue(object: [
+                    "attempt": AnyAgentToolValue(int: 2),
+                    "note": AnyAgentToolValue(null: ()),
+                ]),
+                "steps": AnyAgentToolValue(array: [
+                    AnyAgentToolValue(string: "inspect"),
+                    AnyAgentToolValue(int: 3),
+                    AnyAgentToolValue(bool: false),
+                ]),
+            ],
+        )
+        let result = AgentToolResult.success(
+            toolCallId: toolCall.id,
+            result: AnyAgentToolValue(object: [
+                "completed": AnyAgentToolValue(bool: true),
+                "outputs": AnyAgentToolValue(array: [
+                    AnyAgentToolValue(string: "alpha"),
+                    AnyAgentToolValue(int: 4),
+                ]),
+            ]),
+        )
+        let tool = AgentTool(
+            name: "run_plan",
+            description: "Run a plan",
+            parameters: AgentToolParameters(
+                properties: [
+                    "steps": AgentToolParameterProperty(
+                        name: "steps",
+                        type: .array,
+                        description: "Plan steps",
+                        items: AgentToolParameterItems(type: "object", description: "One step"),
+                    ),
+                ],
+                required: ["steps"],
+            ),
+        ) { _ in
+            AnyAgentToolValue(string: "unused")
+        }
+        let providerRequest = ProviderRequest(
+            messages: [
+                .user("Run it"),
+                ModelMessage(role: .assistant, content: [.text("Working."), .toolCall(toolCall)]),
+                ModelMessage(role: .tool, content: [.toolResult(result)]),
+            ],
+            tools: [tool],
+            settings: .init(maxTokens: 32),
+        )
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let messages = try #require(json["messages"] as? [[String: Any]])
+
+            #expect(messages.count == 3)
+            let assistantCalls = try #require(messages[1]["tool_calls"] as? [[String: Any]])
+            #expect(assistantCalls.first?["type"] as? String == "function")
+            let function = try #require(assistantCalls.first?["function"] as? [String: Any])
+            #expect(function["index"] as? Int == 0)
+            #expect(function["name"] as? String == "run_plan")
+            let arguments = try #require(function["arguments"] as? [String: Any])
+            let metadata = try #require(arguments["metadata"] as? [String: Any])
+            #expect(metadata["attempt"] as? Int == 2)
+            #expect(metadata["note"] is NSNull)
+            let steps = try #require(arguments["steps"] as? [Any])
+            #expect(steps[0] as? String == "inspect")
+            #expect(steps[1] as? Int == 3)
+            #expect(steps[2] as? Bool == false)
+
+            #expect(messages[2]["role"] as? String == "tool")
+            #expect(messages[2]["tool_name"] as? String == "run_plan")
+            let resultText = try #require(messages[2]["content"] as? String)
+            let resultData = try #require(resultText.data(using: .utf8))
+            let resultJSON = try #require(JSONSerialization.jsonObject(with: resultData) as? [String: Any])
+            #expect(resultJSON["completed"] as? Bool == true)
+            #expect(resultJSON["outputs"] as? [AnyHashable] == ["alpha", 4])
+
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let toolFunction = try #require(tools.first?["function"] as? [String: Any])
+            let parameters = try #require(toolFunction["parameters"] as? [String: Any])
+            let properties = try #require(parameters["properties"] as? [String: Any])
+            let stepsSchema = try #require(properties["steps"] as? [String: Any])
+            let items = try #require(stepsSchema["items"] as? [String: Any])
+            #expect(items["type"] as? String == "object")
+            #expect(items["description"] as? String == "One step")
+
+            return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "Finished"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let response = try await provider.generateText(request: providerRequest)
+            #expect(response.text == "Finished")
+        }
+    }
+
+    @Test
+    func `Ollama provider marks native tool responses as tool calls`() async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"","tool_calls":[{"function":{
+        "index":0,"name":"lookup","arguments":{"filters":{"active":true},"limit":2}}}]},"done":true}
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.jsonResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let response = try await provider.generateText(request: Self.basicRequest)
+            #expect(response.finishReason == .toolCalls)
+            #expect(response.toolCalls?.first?.name == "lookup")
+            #expect(response.toolCalls?.first?.arguments["filters"]?.objectValue?["active"]?.boolValue == true)
+            #expect(response.toolCalls?.first?.arguments["limit"]?.intValue == 2)
+        }
+    }
+
+    @Test
+    func `Ollama stream surfaces HTTP 200 NDJSON errors`() async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"prefix"},"done":false}
+        {"error":"mock streamed failure"}
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.streamResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let stream = try await provider.streamText(request: Self.basicRequest)
+
+            var collected = ""
+            do {
+                for try await delta in stream where delta.type == .textDelta {
+                    collected.append(delta.content ?? "")
+                }
+                Issue.record("Expected Ollama's HTTP 200 stream error")
+            } catch {
+                #expect(error.localizedDescription.contains("mock streamed failure"))
+            }
+            #expect(collected == "prefix")
+        }
+    }
+
     // MARK: - LMStudio
 
     @Test


### PR DESCRIPTION
## Summary

- replay assistant tool calls and named tool results in native Ollama conversations
- preserve recursive tool arguments, zero-argument calls, and array item schemas
- report native tool-call finishes and surface HTTP-200 NDJSON errors

## Why

Ollama requires each follow-up request to include the prior assistant `tool_calls` message followed by a `role: "tool"` message with `tool_name` and the result content. Tachikoma previously dropped both parts, so a model could request and execute a tool but could not consume its result on the next step. Ollama also documents that mid-stream failures may arrive as HTTP-200 NDJSON error records; those were silently skipped.

## Proof

- live local `llama3.1:8b`: canonical replay consumed `add(7, 8)` and answered 15; the old lossy shape did not consume the result
- `swift test --filter Ollama` — 15 tests passed
- `swift test` — 801 tests passed
- strict SwiftLint and SwiftFormat on all changed Swift files
- autoreview clean after fixing its zero-argument compatibility finding

Official contracts: [tool calling](https://docs.ollama.com/capabilities/tool-calling), [stream errors](https://docs.ollama.com/api/errors).
