### PR TITLE
fix(ollama): harden streaming and reasoning replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Removed stale direct model support for retired or non-canonical IDs including GPT-5.1/5.2/pseudo-thinking models, deprecated Claude Sonnet/Opus 4 snapshots, Grok 2/3/4-fast rows, old Groq Llama/Mixtral/Gemma aliases, stale Mistral aliases, and invalid LM Studio `current`.
 
 ### Fixed
+- Ollama now applies configured bearer auth, requests and exposes thinking, safely preserves same-endpoint history without persisting authentication material, maps terminal reasons without executing truncated tool calls, and streams strict NDJSON incrementally across supported platforms.
 - Ollama tool conversations now replay assistant calls and named results, preserve recursive arguments and array schemas, report tool-call finishes, and surface HTTP-200 stream errors instead of silently succeeding.
 - Sonnet 5 usage estimates now switch from introductory to standard pricing after August 31, 2026.
 - GPT-5.6 models now retain their 372K context and 128K output limits through OpenAI-compatible, OpenRouter, and Together endpoints.

--- a/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
+++ b/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
@@ -7,13 +7,14 @@ struct AnthropicReasoningReplayTarget {
     let allowsLegacyUnknown: Bool
 
     func matches(_ customData: [String: String]) -> Bool {
+        guard let endpointIdentity = self.endpointIdentity else { return false }
         guard customData["tachikoma.reasoning.provider"] == self.provider else {
             return false
         }
         guard customData["tachikoma.reasoning.model"] == self.modelId else {
             return false
         }
-        return customData["tachikoma.reasoning.base_url"] == self.endpointIdentity
+        return customData["tachikoma.reasoning.base_url"] == endpointIdentity
     }
 }
 
@@ -56,7 +57,9 @@ enum AnthropicMessageConversion {
             case .system:
                 // Anthropic uses a separate system field
                 systemMessage = message.content.compactMap { part in
-                    if case let .text(text) = part { return text }
+                    if case let .text(text) = part {
+                        return text
+                    }
                     return nil
                 }.joined()
             case .user:
@@ -81,7 +84,9 @@ enum AnthropicMessageConversion {
             case .assistant:
                 if message.channel == .thinking {
                     let text = message.content.compactMap { part -> String? in
-                        if case let .text(text) = part { return text }
+                        if case let .text(text) = part {
+                            return text
+                        }
                         return nil
                     }.joined()
                     let signature = message.metadata?.customData?[thinkingSignatureKey]

--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -1108,26 +1108,151 @@ enum ReasoningEndpointIdentity {
             !trimmed.isEmpty,
             var components = URLComponents(string: trimmed),
             let scheme = components.scheme?.lowercased(),
-            let host = components.host?.lowercased() else
+            let host = components.host?.lowercased(),
+            components.user == nil,
+            components.password == nil,
+            components.percentEncodedQuery == nil else
         {
             return nil
         }
 
         components.scheme = scheme
         components.host = host
-        components.user = nil
-        components.password = nil
         components.fragment = nil
         while components.path.count > 1, components.path.hasSuffix("/") {
             components.path.removeLast()
         }
 
         guard let value = components.string else { return nil }
+        return self.digest(value)
+    }
+
+    static func bindingAuthentication(
+        to endpointIdentity: String?,
+        apiKey: String?,
+        headers: [AnyHashable: Any]?,
+    )
+        -> String?
+    {
+        guard let endpointIdentity else { return nil }
+
+        // A deterministic digest of authentication material would become an
+        // offline verifier when persisted in transcript metadata. Without a
+        // process-local keyed identity, fail closed for authenticated sessions.
+        guard apiKey?.isEmpty != false, headers?.isEmpty != false else { return nil }
+        return endpointIdentity
+    }
+
+    private static func digest(_ value: String) -> String? {
         guard let data = value.data(using: .utf8) else { return nil }
         let digest = ReasoningEndpointHasher.hash(data: data)
             .map { String(format: "%02x", $0) }
             .joined()
         return "sha256:\(digest)"
+    }
+}
+
+private final class OllamaNDJSONStreamDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let continuation: AsyncThrowingStream<String, Error>.Continuation
+    private var buffer = Data()
+    private var errorBody = Data()
+    private var responseStatusCode: Int?
+    private var responseError: Error?
+    private var isFinished = false
+
+    init(continuation: AsyncThrowingStream<String, Error>.Continuation) {
+        self.continuation = continuation
+    }
+
+    func urlSession(
+        _: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void,
+    ) {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            self.responseError = TachikomaError.networkError(
+                NSError(domain: "Invalid response", code: 0),
+            )
+            dataTask.cancel()
+            completionHandler(.cancel)
+            return
+        }
+
+        self.responseStatusCode = httpResponse.statusCode
+        completionHandler(.allow)
+    }
+
+    func urlSession(_: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        guard !self.isFinished else { return }
+        guard self.responseStatusCode == 200 else {
+            self.errorBody.append(data)
+            return
+        }
+
+        self.buffer.append(data)
+        while let newlineIndex = self.buffer.firstIndex(of: 0x0A) {
+            let lineData = self.buffer[..<newlineIndex]
+            self.buffer.removeSubrange(self.buffer.startIndex...newlineIndex)
+            guard let line = String(data: lineData, encoding: .utf8) else {
+                self.finish(
+                    throwing: TachikomaError.apiError("Ollama Error: stream response was not valid UTF-8"),
+                )
+                dataTask.cancel()
+                return
+            }
+            self.continuation.yield(line)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task _: URLSessionTask, didCompleteWithError error: Error?) {
+        defer { session.finishTasksAndInvalidate() }
+        guard !self.isFinished else { return }
+
+        if let responseError {
+            self.finish(throwing: responseError)
+            return
+        }
+        if let responseStatusCode, responseStatusCode != 200 {
+            let errorText = String(data: self.errorBody, encoding: .utf8) ?? "Unknown error"
+            self.finish(
+                throwing: TachikomaError.apiError(
+                    "Ollama Error (HTTP \(responseStatusCode)): \(errorText)",
+                ),
+            )
+            return
+        }
+        if let error {
+            self.finish(throwing: error)
+            return
+        }
+        guard self.responseStatusCode == 200 else {
+            self.finish(
+                throwing: TachikomaError.networkError(NSError(domain: "Invalid response", code: 0)),
+            )
+            return
+        }
+
+        if !self.buffer.isEmpty {
+            guard let line = String(data: self.buffer, encoding: .utf8) else {
+                self.finish(
+                    throwing: TachikomaError.apiError("Ollama Error: stream response was not valid UTF-8"),
+                )
+                return
+            }
+            self.continuation.yield(line)
+        }
+        self.finish()
+    }
+
+    private func finish(throwing error: Error? = nil) {
+        guard !self.isFinished else { return }
+        self.isFinished = true
+        if let error {
+            self.continuation.finish(throwing: error)
+        } else {
+            self.continuation.finish()
+        }
     }
 }
 
@@ -1140,22 +1265,32 @@ public final class OllamaProvider: ModelProvider {
     public let capabilities: ModelCapabilities
 
     private let model: LanguageModel.Ollama
+    private let urlSession: URLSession
 
-    public init(model: LanguageModel.Ollama, configuration: TachikomaConfiguration) throws {
+    var reasoningReplayIdentity: String? {
+        guard let baseURL else { return nil }
+        return Self.reasoningReplayIdentity(
+            baseURL: baseURL,
+            apiKey: self.apiKey,
+            urlSession: self.urlSession,
+        )
+    }
+
+    public init(
+        model: LanguageModel.Ollama,
+        configuration: TachikomaConfiguration,
+        urlSession: URLSession = .shared,
+    ) throws {
         self.model = model
         self.modelId = model.modelId
+        self.urlSession = urlSession
 
-        // Get base URL from configuration or environment or use default
-        if let configURL = configuration.getBaseURL(for: .ollama) {
-            self.baseURL = configURL
-        } else if let customURL = ProcessInfo.processInfo.environment["PEEKABOO_OLLAMA_BASE_URL"] {
-            self.baseURL = customURL
-        } else {
-            self.baseURL = "http://localhost:11434"
-        }
+        let baseURL = Self.resolvedBaseURL(configuration: configuration)
+        let apiKey = configuration.getAPIKey(for: .ollama)
+        self.baseURL = baseURL
 
         // Ollama doesn't typically require an API key for local usage, but allow configuration
-        self.apiKey = configuration.getAPIKey(for: .ollama)
+        self.apiKey = apiKey
 
         self.capabilities = ModelCapabilities(
             supportsVision: model.supportsVision,
@@ -1173,10 +1308,11 @@ public final class OllamaProvider: ModelProvider {
             throw TachikomaError.invalidConfiguration("Ollama base URL not configured")
         }
 
-        let url = URL(string: "\(baseURL)/api/chat")!
+        let url = try Self.ollamaChatURL(baseURL: baseURL)
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        self.applyAuthentication(to: &urlRequest)
         urlRequest.timeoutInterval = 300 // 5 minutes for local processing
 
         let messages = try self.convertMessagesToOllama(request.messages)
@@ -1195,13 +1331,14 @@ public final class OllamaProvider: ModelProvider {
             messages: messages,
             tools: request.tools?.map { try self.convertToolToOllama($0) },
             stream: false,
+            think: Self.ollamaThink(for: request.settings.reasoningEffort, model: self.model),
             options: options,
         )
 
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(ollamaRequest)
 
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        let (data, response) = try await self.urlSession.data(for: urlRequest)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw TachikomaError.networkError(NSError(domain: "Invalid response", code: 0))
@@ -1220,6 +1357,9 @@ public final class OllamaProvider: ModelProvider {
 
         let decoder = JSONDecoder()
         let ollamaResponse = try decoder.decode(OllamaChatResponse.self, from: data)
+        guard ollamaResponse.done else {
+            throw TachikomaError.apiError("Ollama Error: response ended before terminal done status")
+        }
 
         let text = ollamaResponse.message.content
 
@@ -1272,12 +1412,13 @@ public final class OllamaProvider: ModelProvider {
             }
         }
 
-        let finishReason: FinishReason = if toolCalls?.isEmpty == false {
-            .toolCalls
-        } else if ollamaResponse.done {
-            .stop
-        } else {
-            .other
+        let finishReason = Self.mapFinishReason(
+            done: ollamaResponse.done,
+            doneReason: ollamaResponse.doneReason,
+            hasToolCalls: toolCalls?.isEmpty == false,
+        )
+        let reasoning = ollamaResponse.message.thinking.flatMap { thinking in
+            thinking.isEmpty ? nil : ProviderReasoningBlock(text: thinking, type: "ollama_thinking")
         }
 
         return ProviderResponse(
@@ -1285,6 +1426,7 @@ public final class OllamaProvider: ModelProvider {
             usage: usage,
             finishReason: finishReason,
             toolCalls: toolCalls,
+            reasoning: reasoning.map { [$0] } ?? [],
         )
     }
 
@@ -1293,10 +1435,11 @@ public final class OllamaProvider: ModelProvider {
             throw TachikomaError.invalidConfiguration("Ollama base URL not configured")
         }
 
-        let url = URL(string: "\(baseURL)/api/chat")!
+        let url = try Self.ollamaChatURL(baseURL: baseURL)
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        self.applyAuthentication(to: &urlRequest)
         urlRequest.timeoutInterval = 300 // 5 minutes for local processing
 
         let messages = try self.convertMessagesToOllama(request.messages)
@@ -1315,65 +1458,362 @@ public final class OllamaProvider: ModelProvider {
             messages: messages,
             tools: request.tools?.map { try self.convertToolToOllama($0) },
             stream: true,
+            think: Self.ollamaThink(for: request.settings.reasoningEffort, model: self.model),
             options: options,
         )
 
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(ollamaRequest)
 
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw TachikomaError.networkError(NSError(domain: "Invalid response", code: 0))
-        }
-
-        guard httpResponse.statusCode == 200 else {
-            let errorText = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw TachikomaError.apiError("Ollama Error (HTTP \(httpResponse.statusCode)): \(errorText)")
-        }
-
-        return AsyncThrowingStream { continuation in
-            Task {
-                // Split the data by lines for streaming JSON processing
-                let responseString = String(data: data, encoding: .utf8) ?? ""
-                let lines = responseString.components(separatedBy: .newlines)
-
-                for line in lines {
-                    guard let data = line.data(using: .utf8) else { continue }
-
-                    if let errorResponse = try? JSONDecoder().decode(OllamaErrorResponse.self, from: data) {
-                        continuation.finish(
-                            throwing: TachikomaError.apiError("Ollama Error: \(errorResponse.error)"),
-                        )
-                        return
-                    }
-
-                    do {
-                        let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
-
-                        if let content = chunk.message.content, !content.isEmpty {
-                            continuation.yield(TextStreamDelta.text(content))
-                        }
-
-                        for ollamaCall in chunk.message.toolCalls ?? [] {
-                            continuation.yield(TextStreamDelta.tool(Self.convertOllamaToolCall(ollamaCall)))
-                        }
-
-                        if chunk.done {
-                            continuation.yield(TextStreamDelta.done())
-                            break
-                        }
-                    } catch {
-                        // Skip malformed chunks
-                        continue
-                    }
-                }
-                continuation.finish()
-            }
-        }
+        return Self.ollamaStream(lines: self.ollamaResponseLines(for: urlRequest))
     }
 
     // MARK: - Helper Methods
+
+    private struct OllamaStreamState {
+        var sawToolCall = false
+        var sawDone = false
+    }
+
+    static func resolvedBaseURL(configuration: TachikomaConfiguration) -> String {
+        if let configuredURL = configuration.configuredBaseURL(for: .ollama) {
+            return configuredURL
+        }
+        if
+            let legacyURL = ProcessInfo.processInfo.environment["PEEKABOO_OLLAMA_BASE_URL"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !legacyURL.isEmpty
+        {
+            return legacyURL
+        }
+        return Provider.ollama.defaultBaseURL ?? "http://localhost:11434"
+    }
+
+    private static func ollamaChatURL(baseURL: String) throws -> URL {
+        guard
+            var components = URLComponents(string: baseURL),
+            let scheme = components.scheme?.lowercased(),
+            ["http", "https"].contains(scheme),
+            components.host?.isEmpty == false else
+        {
+            throw TachikomaError.invalidConfiguration("Ollama base URL is invalid")
+        }
+
+        components.scheme = scheme
+        var basePath = components.percentEncodedPath
+        while basePath.hasSuffix("/") {
+            basePath.removeLast()
+        }
+        if basePath.hasSuffix("/api/chat") {
+            components.percentEncodedPath = basePath
+        } else if basePath.hasSuffix("/api") {
+            components.percentEncodedPath = "\(basePath)/chat"
+        } else {
+            components.percentEncodedPath = "\(basePath)/api/chat"
+        }
+        components.fragment = nil
+
+        guard let url = components.url else {
+            throw TachikomaError.invalidConfiguration("Ollama base URL is invalid")
+        }
+        return url
+    }
+
+    private static func reasoningReplayIdentity(
+        baseURL: String,
+        apiKey: String?,
+        urlSession: URLSession,
+    )
+        -> String?
+    {
+        // Delegate challenge handling can select credentials dynamically. Without
+        // an inspectable auth boundary, fail closed and omit replay metadata.
+        guard urlSession.delegate == nil else { return nil }
+
+        let configuration = urlSession.configuration
+        if
+            let requestURL = try? self.ollamaChatURL(baseURL: baseURL),
+            configuration.httpCookieStorage?.cookies(for: requestURL)?.isEmpty == false
+        {
+            return nil
+        }
+        guard !self.hasStoredCredentials(for: baseURL, configuration: configuration) else {
+            return nil
+        }
+
+        return ReasoningEndpointIdentity.bindingAuthentication(
+            to: ReasoningEndpointIdentity.canonical(baseURL),
+            apiKey: apiKey,
+            headers: configuration.httpAdditionalHeaders,
+        )
+    }
+
+    private static func hasStoredCredentials(
+        for baseURL: String,
+        configuration: URLSessionConfiguration,
+    )
+        -> Bool
+    {
+        guard
+            let components = URLComponents(string: baseURL),
+            let host = components.host,
+            let scheme = components.scheme else
+        {
+            return true
+        }
+        let port = components.port ?? (scheme.lowercased() == "https" ? 443 : 80)
+        return configuration.urlCredentialStorage?.allCredentials.keys.contains { protectionSpace in
+            protectionSpace.host.caseInsensitiveCompare(host) == .orderedSame &&
+                protectionSpace.protocol?.caseInsensitiveCompare(scheme) == .orderedSame &&
+                protectionSpace.port == port
+        } == true
+    }
+
+    private func applyAuthentication(to request: inout URLRequest) {
+        guard let apiKey, !apiKey.isEmpty else { return }
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    }
+
+    private static func ollamaThink(
+        for effort: ReasoningEffort?,
+        model: LanguageModel.Ollama,
+    )
+        -> OllamaChatRequest.OllamaThink?
+    {
+        guard let effort else { return nil }
+
+        let modelId = model.modelId.lowercased()
+        let usesThinkingLevels = switch model {
+        case .gptOSS120B, .gptOSS20B:
+            true
+        case .custom:
+            modelId.contains("gpt-oss")
+        default:
+            false
+        }
+        if usesThinkingLevels {
+            let level = switch effort {
+            case .low: "low"
+            case .medium: "medium"
+            case .high, .xhigh, .max: "high"
+            }
+            return .level(level)
+        }
+
+        let supportsBooleanThinking = switch model {
+        case .deepseekR18b, .deepseekR1671b:
+            true
+        case .custom:
+            // The Ollama registry is open-ended. Keep custom models fail-closed
+            // except for documented thinking families, because unsupported
+            // templates return HTTP 400 when `think` is present.
+            modelId.contains("deepseek-r1") ||
+                modelId.contains("deepseek-v3.1") ||
+                modelId.contains("deepseek-v3-1") ||
+                modelId.contains("deepseek-v3_1") ||
+                modelId.contains("qwen3") ||
+                modelId.contains("qwq")
+        default:
+            false
+        }
+        guard supportsBooleanThinking else {
+            return nil
+        }
+        return .enabled(true)
+    }
+
+    private func ollamaResponseLines(for request: URLRequest) -> AsyncThrowingStream<String, Error> {
+        #if canImport(FoundationNetworking)
+        // Corelibs Foundation has no AsyncBytes API. Keep custom-delegate sessions
+        // intact even though their safe fallback must buffer the response.
+        if self.urlSession.delegate != nil {
+            return self.bufferedOllamaResponseLines(for: request)
+        }
+
+        let configuration = self.urlSession.configuration
+        return AsyncThrowingStream { continuation in
+            let delegate = OllamaNDJSONStreamDelegate(continuation: continuation)
+            let delegateQueue = OperationQueue()
+            delegateQueue.maxConcurrentOperationCount = 1
+            let session = URLSession(
+                configuration: configuration,
+                delegate: delegate,
+                delegateQueue: delegateQueue,
+            )
+            let task = session.dataTask(with: request)
+            continuation.onTermination = { _ in
+                task.cancel()
+                session.invalidateAndCancel()
+            }
+            task.resume()
+        }
+        #else
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let taskDelegate = self.urlSession.delegate as? URLSessionTaskDelegate
+                    let (bytes, response) = try await self.urlSession.bytes(
+                        for: request,
+                        delegate: taskDelegate,
+                    )
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        throw TachikomaError.networkError(NSError(domain: "Invalid response", code: 0))
+                    }
+                    guard httpResponse.statusCode == 200 else {
+                        var errorData = Data()
+                        for try await byte in bytes {
+                            errorData.append(byte)
+                        }
+                        let errorText = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+                        throw TachikomaError.apiError(
+                            "Ollama Error (HTTP \(httpResponse.statusCode)): \(errorText)",
+                        )
+                    }
+
+                    var buffer = Data()
+                    for try await byte in bytes {
+                        if byte == 0x0A {
+                            try continuation.yield(Self.decodeOllamaStreamLine(buffer))
+                            buffer.removeAll(keepingCapacity: true)
+                        } else {
+                            buffer.append(byte)
+                        }
+                    }
+                    if !buffer.isEmpty {
+                        try continuation.yield(Self.decodeOllamaStreamLine(buffer))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+        #endif
+    }
+
+    #if canImport(FoundationNetworking)
+    private func bufferedOllamaResponseLines(for request: URLRequest) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let (data, response) = try await self.urlSession.data(for: request)
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        throw TachikomaError.networkError(NSError(domain: "Invalid response", code: 0))
+                    }
+                    guard httpResponse.statusCode == 200 else {
+                        let errorText = String(data: data, encoding: .utf8) ?? "Unknown error"
+                        throw TachikomaError.apiError(
+                            "Ollama Error (HTTP \(httpResponse.statusCode)): \(errorText)",
+                        )
+                    }
+                    let text = try Self.decodeOllamaStreamLine(data)
+                    for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+                        continuation.yield(String(line))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+    #endif
+
+    private static func decodeOllamaStreamLine(_ data: Data) throws -> String {
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw TachikomaError.apiError("Ollama Error: stream response was not valid UTF-8")
+        }
+        return line
+    }
+
+    private static func ollamaStream<Lines: AsyncSequence & Sendable>(lines: Lines)
+        -> AsyncThrowingStream<TextStreamDelta, Error>
+        where Lines.Element == String
+    {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var state = OllamaStreamState()
+                    for try await line in lines {
+                        try Self.processOllamaStreamLine(line, state: &state, continuation: continuation)
+                        if state.sawDone {
+                            continuation.finish()
+                            return
+                        }
+                    }
+
+                    throw TachikomaError.apiError("Ollama Error: stream ended before terminal done response")
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private static func processOllamaStreamLine(
+        _ line: String,
+        state: inout OllamaStreamState,
+        continuation: AsyncThrowingStream<TextStreamDelta, Error>.Continuation,
+    ) throws {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard let data = trimmed.data(using: .utf8) else {
+            throw TachikomaError.apiError("Ollama Error: stream contained a non-UTF-8 chunk")
+        }
+
+        let decoder = JSONDecoder()
+        if let errorResponse = try? decoder.decode(OllamaErrorResponse.self, from: data) {
+            throw TachikomaError.apiError("Ollama Error: \(errorResponse.error)")
+        }
+
+        let chunk: OllamaStreamChunk
+        do {
+            chunk = try decoder.decode(OllamaStreamChunk.self, from: data)
+        } catch {
+            throw TachikomaError.apiError(
+                "Ollama Error: malformed NDJSON stream chunk (\(error.localizedDescription))",
+            )
+        }
+
+        if let thinking = chunk.message.thinking, !thinking.isEmpty {
+            continuation.yield(.reasoning(thinking, type: "ollama_thinking"))
+        }
+        if let content = chunk.message.content, !content.isEmpty {
+            continuation.yield(.text(content))
+        }
+
+        for ollamaCall in chunk.message.toolCalls ?? [] {
+            state.sawToolCall = true
+            continuation.yield(.tool(Self.convertOllamaToolCall(ollamaCall)))
+        }
+
+        if chunk.done {
+            state.sawDone = true
+            continuation.yield(.done(finishReason: Self.mapFinishReason(
+                done: true,
+                doneReason: chunk.doneReason,
+                hasToolCalls: state.sawToolCall,
+            )))
+        }
+    }
+
+    static func mapFinishReason(done: Bool, doneReason: String?, hasToolCalls: Bool) -> FinishReason {
+        guard done else {
+            return .other
+        }
+
+        switch doneReason?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case nil, "", "stop":
+            return hasToolCalls ? .toolCalls : .stop
+        case "length":
+            return .length
+        default:
+            return .other
+        }
+    }
 
     /// Shared by the streaming and non-streaming paths so both surface Ollama's
     /// native tool calls identically.
@@ -1388,6 +1828,7 @@ public final class OllamaProvider: ModelProvider {
     private func convertMessagesToOllama(_ messages: [ModelMessage]) throws -> [OllamaChatMessage] {
         var toolNamesByCallID: [String: String] = [:]
         var converted: [OllamaChatMessage] = []
+        var pendingThinking = ""
 
         for message in messages {
             let text = message.content.compactMap { part in
@@ -1401,6 +1842,21 @@ public final class OllamaProvider: ModelProvider {
                     return image.data
                 }
                 return nil
+            }
+
+            if message.role == .assistant, message.channel == .thinking {
+                guard self.canReplayThinking(message) else { continue }
+                pendingThinking.append(text)
+                continue
+            }
+
+            if message.role != .assistant, !pendingThinking.isEmpty {
+                converted.append(OllamaChatMessage(
+                    role: ModelMessage.Role.assistant.rawValue,
+                    content: "",
+                    thinking: pendingThinking,
+                ))
+                pendingThinking = ""
             }
 
             let toolCalls = message.content.compactMap { part -> AgentToolCall? in
@@ -1447,15 +1903,42 @@ public final class OllamaProvider: ModelProvider {
                     ),
                 )
             }
+            let thinking = message.role == .assistant && !pendingThinking.isEmpty ? pendingThinking : nil
             converted.append(OllamaChatMessage(
                 role: message.role.rawValue,
                 content: text,
+                thinking: thinking,
                 images: images.isEmpty ? nil : images,
                 toolCalls: ollamaCalls.isEmpty ? nil : ollamaCalls,
+            ))
+            if thinking != nil {
+                pendingThinking = ""
+            }
+        }
+
+        if !pendingThinking.isEmpty {
+            converted.append(OllamaChatMessage(
+                role: ModelMessage.Role.assistant.rawValue,
+                content: "",
+                thinking: pendingThinking,
             ))
         }
 
         return converted
+    }
+
+    private func canReplayThinking(_ message: ModelMessage) -> Bool {
+        guard
+            let endpointIdentity = self.reasoningReplayIdentity,
+            let customData = message.metadata?.customData,
+            customData["ollama.thinking"] != nil,
+            customData["tachikoma.reasoning.provider"] == "ollama",
+            customData["tachikoma.reasoning.model"] == self.modelId,
+            customData["tachikoma.reasoning.base_url"] == endpointIdentity else
+        {
+            return false
+        }
+        return true
     }
 
     private static func ollamaToolResultContent(_ result: AnyAgentToolValue) throws -> String {
@@ -1513,5 +1996,13 @@ public final class OllamaProvider: ModelProvider {
                 parameters: parameters,
             ),
         )
+    }
+}
+
+extension OllamaProvider: ResponseCacheSafetyProviding {
+    var isResponseCacheSafe: Bool {
+        // URLSession authentication state can change after provider creation.
+        // Never place Ollama responses in a shared cache without a stable auth boundary.
+        false
     }
 }

--- a/Sources/Tachikoma/Core/Configuration.swift
+++ b/Sources/Tachikoma/Core/Configuration.swift
@@ -251,6 +251,13 @@ public final class TachikomaConfiguration: @unchecked Sendable {
         }
     }
 
+    /// Get only an explicitly configured base URL, without applying provider defaults.
+    func configuredBaseURL(for provider: Provider) -> String? {
+        self.lock.withLock {
+            self._baseURLs[provider.identifier]
+        }
+    }
+
     /// Remove a custom base URL for a provider (type-safe)
     public func removeBaseURL(for provider: Provider) {
         // Remove a custom base URL for a provider (type-safe)

--- a/Sources/Tachikoma/Core/Generation.swift
+++ b/Sources/Tachikoma/Core/Generation.swift
@@ -39,7 +39,11 @@ public func generateText(
 
     for stepIndex in 0..<maxSteps {
         let request = ProviderRequest(
-            messages: currentMessages.sanitizedForProvider(model, configuration: resolvedConfiguration),
+            messages: currentMessages.sanitizedForProvider(
+                model,
+                provider: provider,
+                configuration: resolvedConfiguration,
+            ),
             tools: tools,
             settings: settings,
         )
@@ -57,13 +61,37 @@ public func generateText(
         let responseToolCalls = isContentFiltered ? [] : (response.toolCalls ?? [])
         let responseReasoning = isContentFiltered ? [] : response.reasoning
         let responseAssistantMessages = isContentFiltered ? [] : response.assistantMessages
+        // Providers historically may omit a finish reason for valid tool calls.
+        // Explicit non-tool terminal reasons must never trigger or persist side effects.
+        let canExecuteToolCalls = response.finishReason == nil || response.finishReason == .toolCalls
+        let historyAssistantMessages = canExecuteToolCalls
+            ? responseAssistantMessages
+            : responseAssistantMessages.compactMap { message in
+                let safeContent = message.content.filter { part in
+                    if case .toolCall = part {
+                        false
+                    } else {
+                        true
+                    }
+                }
+                guard !safeContent.isEmpty else { return nil }
+                return ModelMessage(
+                    id: message.id,
+                    role: message.role,
+                    content: safeContent,
+                    timestamp: message.timestamp,
+                    channel: message.channel,
+                    metadata: message.metadata,
+                )
+            }
         let responseMessageStartIndex = currentMessages.count
         finalResponseStartIndex = responseMessageStartIndex
         let responseHistoryMessages = model.responseHistoryMessages(
-            nativeMessages: responseAssistantMessages,
+            nativeMessages: historyAssistantMessages,
             text: responseText,
             reasoning: responseReasoning,
-            toolCalls: responseToolCalls,
+            toolCalls: canExecuteToolCalls ? responseToolCalls : [],
+            provider: provider,
             configuration: resolvedConfiguration,
         )
 
@@ -126,8 +154,7 @@ public func generateText(
             }
         }
 
-        // Handle tool calls
-        if !responseToolCalls.isEmpty {
+        if !responseToolCalls.isEmpty, canExecuteToolCalls {
             // Execute tools
             var toolResults: [AgentToolResult] = []
             for toolCall in responseToolCalls {
@@ -191,13 +218,9 @@ public func generateText(
                 usage: response.usage,
                 finishReason: response.finishReason,
             )
-
-            // Continue to next step if not done
-            if response.finishReason != .toolCalls, response.finishReason != .stop {
-                break
-            }
         } else {
-            // No tool calls, we're done
+            // Providers can expose partial calls alongside length or error-like
+            // terminal reasons. Preserve them for diagnostics without executing.
             break
         }
     }
@@ -272,6 +295,51 @@ public func streamText(
     messages: [ModelMessage],
     tools: [AgentTool]? = nil,
     settings: GenerationSettings = .default,
+    maxSteps: Int = 1,
+    timeout: TimeInterval? = nil,
+    configuration: TachikomaConfiguration = .current,
+    sessionId: String? = nil,
+) async throws
+    -> StreamTextResult
+{
+    guard model.supportsStreaming else {
+        throw TachikomaError.invalidConfiguration("\(model.modelId) does not support streaming")
+    }
+    let resolvedConfiguration = TachikomaConfiguration.resolve(configuration)
+    let provider = try resolvedConfiguration.makeProvider(for: model)
+    return try await streamText(
+        model: model,
+        provider: provider,
+        messages: messages,
+        tools: tools,
+        settings: settings,
+        maxSteps: maxSteps,
+        timeout: timeout,
+        configuration: resolvedConfiguration,
+        sessionId: sessionId,
+    )
+}
+
+/// Stream text generation through an already-resolved provider.
+///
+/// Use this overload when the caller must pin one verified provider instance across
+/// multiple turns while retaining the standard message sanitization and usage tracking.
+///
+/// - Parameters:
+///   - model: The language model represented by the supplied provider
+///   - provider: The exact provider instance to use without rebuilding it from configuration
+///   - messages: Array of conversation messages
+///   - tools: Optional tools the model can call
+///   - settings: Generation settings (temperature, maxTokens, etc.)
+///   - maxSteps: Maximum number of tool calling steps (default: 1)
+/// - Returns: StreamTextResult with async sequence and metadata
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public func streamText(
+    model: LanguageModel,
+    provider: any ModelProvider,
+    messages: [ModelMessage],
+    tools: [AgentTool]? = nil,
+    settings: GenerationSettings = .default,
     maxSteps _: Int = 1,
     timeout: TimeInterval? = nil,
     configuration: TachikomaConfiguration = .current,
@@ -287,14 +355,13 @@ public func streamText(
     let debugEnabled = ProcessInfo.processInfo.environment["DEBUG_TACHIKOMA"] != nil ||
         resolvedConfiguration.verbose
     if debugEnabled {
-        print("\n🔵 DEBUG streamText: Creating provider for model: \(model)")
+        print("\n🔵 DEBUG streamText: Using provider for model: \(model)")
         print("🔵 DEBUG streamText: Model details: \(model.description)")
         if case let .openai(openaiModel) = model {
             print("🔵 DEBUG streamText: OpenAI model enum case: \(openaiModel)")
             print("🔵 DEBUG streamText: OpenAI model modelId: \(openaiModel.modelId)")
         }
     }
-    let provider = try resolvedConfiguration.makeProvider(for: model)
     if debugEnabled {
         let providerModelId = (provider as? AnthropicProvider)?.modelId ??
             (provider as? OpenAIProvider)?.modelId ??
@@ -305,7 +372,11 @@ public func streamText(
     }
 
     let request = ProviderRequest(
-        messages: messages.sanitizedForProvider(model, configuration: resolvedConfiguration),
+        messages: messages.sanitizedForProvider(
+            model,
+            provider: provider,
+            configuration: resolvedConfiguration,
+        ),
         tools: tools,
         settings: settings,
     )
@@ -344,7 +415,13 @@ public func streamText(
     let capturedStopCondition = buffersUntilDone ? settings.stopConditions : nil
 
     let trackedStream = AsyncThrowingStream<TextStreamDelta, Error> { continuation in
-        Task {
+        let forwardingTask = Task {
+            defer {
+                if shouldEndSession {
+                    _ = UsageTracker.shared.endSession(capturedSessionId)
+                }
+            }
+
             do {
                 let totalInputTokens = 0
                 var totalOutputTokens = 0
@@ -427,9 +504,6 @@ public func streamText(
                             usage: usage,
                             operation: .textStreaming,
                         )
-                        if shouldEndSession {
-                            _ = UsageTracker.shared.endSession(capturedSessionId)
-                        }
                     }
                 }
 
@@ -439,12 +513,10 @@ public func streamText(
 
                 continuation.finish()
             } catch {
-                if shouldEndSession {
-                    _ = UsageTracker.shared.endSession(capturedSessionId)
-                }
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { _ in forwardingTask.cancel() }
     }
 
     return StreamTextResult(
@@ -481,7 +553,11 @@ public func generateObject<T: Codable & Sendable>(
     let provider = try resolvedConfiguration.makeProvider(for: model)
 
     let request = ProviderRequest(
-        messages: messages.sanitizedForProvider(model, configuration: resolvedConfiguration),
+        messages: messages.sanitizedForProvider(
+            model,
+            provider: provider,
+            configuration: resolvedConfiguration,
+        ),
         tools: nil,
         settings: settings,
         outputFormat: .json,
@@ -546,7 +622,11 @@ public func streamObject<T: Codable & Sendable>(
 
     // Create request with JSON output format
     let request = ProviderRequest(
-        messages: messages.sanitizedForProvider(model, configuration: resolvedConfiguration),
+        messages: messages.sanitizedForProvider(
+            model,
+            provider: provider,
+            configuration: resolvedConfiguration,
+        ),
         tools: nil,
         settings: settings,
         outputFormat: .json,
@@ -814,21 +894,42 @@ extension LanguageModel {
 private struct ReasoningReplayTarget {
     let provider: String
     let modelId: String
-    let baseURL: String?
+    let endpointIdentity: String?
     let allowsLegacyUnknown: Bool
 
+    init(
+        provider: String,
+        modelId: String,
+        baseURL: String?,
+        allowsLegacyUnknown: Bool,
+    ) {
+        self.provider = provider
+        self.modelId = modelId
+        self.endpointIdentity = ReasoningEndpointIdentity.canonical(baseURL)
+        self.allowsLegacyUnknown = allowsLegacyUnknown
+    }
+
+    init(
+        provider: String,
+        modelId: String,
+        endpointIdentity: String?,
+        allowsLegacyUnknown: Bool,
+    ) {
+        self.provider = provider
+        self.modelId = modelId
+        self.endpointIdentity = endpointIdentity
+        self.allowsLegacyUnknown = allowsLegacyUnknown
+    }
+
     func matches(_ customData: [String: String]) -> Bool {
+        guard let endpointIdentity = self.endpointIdentity else { return false }
         guard customData["tachikoma.reasoning.provider"] == self.provider else {
             return false
         }
         guard customData["tachikoma.reasoning.model"] == self.modelId else {
             return false
         }
-        return customData["tachikoma.reasoning.base_url"] == self.endpointIdentity
-    }
-
-    var endpointIdentity: String? {
-        ReasoningEndpointIdentity.canonical(self.baseURL)
+        return customData["tachikoma.reasoning.base_url"] == endpointIdentity
     }
 }
 
@@ -880,10 +981,34 @@ extension [ModelMessage] {
 extension [ModelMessage] {
     fileprivate func sanitizedForProvider(
         _ model: LanguageModel,
+        provider: any ModelProvider,
         configuration: TachikomaConfiguration,
     )
         -> [ModelMessage]
     {
+        if let target = model.ollamaReasoningReplayTarget(provider: provider) {
+            var sanitized: [ModelMessage] = []
+            for message in self {
+                if message.isSyntheticReasoningBoundary {
+                    if sanitized.last?.channel == .thinking {
+                        sanitized.append(message)
+                    }
+                    continue
+                }
+                guard message.channel == .thinking else {
+                    sanitized.append(message)
+                    continue
+                }
+                guard message.hasOllamaThinkingReplayMetadata else {
+                    continue
+                }
+                if target.matches(message.metadata?.customData ?? [:]) {
+                    sanitized.append(message)
+                }
+            }
+            return sanitized
+        }
+
         if let target = model.anthropicThinkingReplayTarget(configuration: configuration) {
             var sanitized: [ModelMessage] = []
             for message in self {
@@ -985,9 +1110,13 @@ extension ModelMessage {
         self.metadata?.customData?["kimi.reasoning_content"] != nil
     }
 
+    fileprivate var hasOllamaThinkingReplayMetadata: Bool {
+        self.metadata?.customData?["ollama.thinking"] != nil
+    }
+
     private var hasProviderReasoningReplayMetadata: Bool {
         self.hasAnthropicThinkingReplayMetadata || self.hasOpenRouterReasoningReplayMetadata ||
-            self.hasKimiReasoningReplayMetadata
+            self.hasKimiReasoningReplayMetadata || self.hasOllamaThinkingReplayMetadata
     }
 
     fileprivate var isSyntheticReasoningBoundary: Bool {
@@ -1047,6 +1176,7 @@ extension LanguageModel {
         text: String,
         reasoning: [ProviderReasoningBlock],
         toolCalls: [AgentToolCall],
+        provider: any ModelProvider,
         configuration: TachikomaConfiguration,
     )
         -> [ModelMessage]
@@ -1060,6 +1190,7 @@ extension LanguageModel {
                 channel: .thinking,
                 metadata: .init(customData: self.anthropicThinkingMetadata(
                     for: reasoningBlock,
+                    provider: provider,
                     configuration: configuration,
                 )),
             ))
@@ -1188,12 +1319,48 @@ extension LanguageModel {
         }
     }
 
+    fileprivate func ollamaReasoningReplayTarget(provider: any ModelProvider) -> ReasoningReplayTarget? {
+        switch self {
+        case .ollama:
+            guard
+                let ollamaProvider = provider as? OllamaProvider,
+                let endpointIdentity = ollamaProvider.reasoningReplayIdentity else
+            {
+                return nil
+            }
+            return ReasoningReplayTarget(
+                provider: "ollama",
+                modelId: provider.modelId,
+                endpointIdentity: endpointIdentity,
+                allowsLegacyUnknown: false,
+            )
+        default:
+            return nil
+        }
+    }
+
     private func anthropicThinkingMetadata(
         for reasoning: ProviderReasoningBlock,
+        provider: any ModelProvider,
         configuration: TachikomaConfiguration,
     )
         -> [String: String]
     {
+        if
+            reasoning.type == "ollama_thinking",
+            let target = self.ollamaReasoningReplayTarget(provider: provider)
+        {
+            var metadata = [
+                "ollama.thinking": reasoning.text,
+                "tachikoma.reasoning.type": reasoning.type,
+                "tachikoma.reasoning.provider": target.provider,
+                "tachikoma.reasoning.model": target.modelId,
+            ]
+            if let endpointIdentity = target.endpointIdentity {
+                metadata["tachikoma.reasoning.base_url"] = endpointIdentity
+            }
+            return metadata
+        }
         if
             reasoning.type == "kimi_reasoning_content",
             let target = self.kimiReasoningReplayTarget(configuration: configuration)

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -285,7 +285,9 @@ struct OpenAICompatibleHelper {
                         var errorBody = ""
                         for try await line in bytes.lines {
                             errorBody += line
-                            if errorBody.count > 1000 { break }
+                            if errorBody.count > 1000 {
+                                break
+                            }
                         }
                         let errorText = errorBody.isEmpty ? "Unknown error" : errorBody
                         throw TachikomaError
@@ -638,6 +640,7 @@ struct OpenAICompatibleHelper {
         for message in messages {
             if
                 message.channel == .thinking,
+                let endpointIdentity,
                 let customData = message.metadata?.customData,
                 customData["tachikoma.reasoning.provider"] == "openrouter",
                 customData["tachikoma.reasoning.model"] == modelId,
@@ -649,6 +652,7 @@ struct OpenAICompatibleHelper {
             }
             if
                 message.channel == .thinking,
+                let kimiEndpointIdentity,
                 let customData = message.metadata?.customData,
                 customData["tachikoma.reasoning.provider"] == "kimi",
                 customData["tachikoma.reasoning.model"] == kimiModelId,
@@ -660,6 +664,7 @@ struct OpenAICompatibleHelper {
             }
             if
                 message.channel == .thinking,
+                let endpointIdentity,
                 let customData = message.metadata?.customData,
                 customData["tachikoma.reasoning.provider"] == "openrouter",
                 customData["tachikoma.reasoning.model"] == modelId,
@@ -676,7 +681,9 @@ struct OpenAICompatibleHelper {
             switch message.role {
             case .system:
                 converted.append(OpenAIChatMessage(role: "system", content: message.content.compactMap { part in
-                    if case let .text(text) = part { return text }
+                    if case let .text(text) = part {
+                        return text
+                    }
                     return nil
                 }.joined()))
             case .user:
@@ -724,7 +731,9 @@ struct OpenAICompatibleHelper {
 
                 // Extract text content
                 let textContent = message.content.compactMap { part in
-                    if case let .text(text) = part { return text }
+                    if case let .text(text) = part {
+                        return text
+                    }
                     return nil
                 }.joined()
 

--- a/Sources/Tachikoma/Providers/Ollama/OllamaTypes.swift
+++ b/Sources/Tachikoma/Providers/Ollama/OllamaTypes.swift
@@ -7,7 +7,32 @@ struct OllamaChatRequest: Codable {
     let messages: [OllamaChatMessage]
     let tools: [OllamaTool]?
     let stream: Bool?
+    let think: OllamaThink?
     let options: OllamaOptions?
+
+    enum OllamaThink: Codable, Equatable {
+        case enabled(Bool)
+        case level(String)
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let enabled = try? container.decode(Bool.self) {
+                self = .enabled(enabled)
+                return
+            }
+            self = try .level(container.decode(String.self))
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case let .enabled(enabled):
+                try container.encode(enabled)
+            case let .level(level):
+                try container.encode(level)
+            }
+        }
+    }
 
     struct OllamaOptions: Codable {
         let temperature: Double?
@@ -25,12 +50,13 @@ struct OllamaChatRequest: Codable {
 struct OllamaChatMessage: Codable {
     let role: String
     let content: String
+    let thinking: String?
     let images: [String]?
     let toolCalls: [OllamaToolCall]?
     let toolName: String?
 
     enum CodingKeys: String, CodingKey {
-        case role, content, images
+        case role, content, thinking, images
         case toolCalls = "tool_calls"
         case toolName = "tool_name"
     }
@@ -38,12 +64,14 @@ struct OllamaChatMessage: Codable {
     init(
         role: String,
         content: String,
+        thinking: String? = nil,
         images: [String]? = nil,
         toolCalls: [OllamaToolCall]? = nil,
         toolName: String? = nil,
     ) {
         self.role = role
         self.content = content
+        self.thinking = thinking
         self.images = images
         self.toolCalls = toolCalls
         self.toolName = toolName
@@ -101,6 +129,7 @@ struct OllamaChatResponse: Codable {
     let model: String
     let message: Message
     let done: Bool
+    let doneReason: String?
     let totalDuration: Int?
     let loadDuration: Int?
     let promptEvalCount: Int?
@@ -110,6 +139,7 @@ struct OllamaChatResponse: Codable {
 
     enum CodingKeys: String, CodingKey {
         case model, message, done
+        case doneReason = "done_reason"
         case totalDuration = "total_duration"
         case loadDuration = "load_duration"
         case promptEvalCount = "prompt_eval_count"
@@ -121,10 +151,11 @@ struct OllamaChatResponse: Codable {
     struct Message: Codable {
         let role: String
         let content: String
+        let thinking: String?
         let toolCalls: [OllamaToolCall]?
 
         enum CodingKeys: String, CodingKey {
-            case role, content
+            case role, content, thinking
             case toolCalls = "tool_calls"
         }
     }
@@ -134,10 +165,17 @@ struct OllamaStreamChunk: Codable {
     let model: String
     let message: Delta
     let done: Bool
+    let doneReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case model, message, done
+        case doneReason = "done_reason"
+    }
 
     struct Delta: Codable {
         let role: String?
         let content: String?
+        let thinking: String?
         /// Ollama emits native tool calls on the streaming `/api/chat` response
         /// (`{"message":{"content":"","tool_calls":[…]},"done":false}`). Without
         /// this the caller sees zero tool calls and models fall back to printing
@@ -145,7 +183,7 @@ struct OllamaStreamChunk: Codable {
         let toolCalls: [OllamaToolCall]?
 
         enum CodingKeys: String, CodingKey {
-            case role, content
+            case role, content, thinking
             case toolCalls = "tool_calls"
         }
     }

--- a/Sources/Tachikoma/Utilities/ResponseCache.swift
+++ b/Sources/Tachikoma/Utilities/ResponseCache.swift
@@ -3,6 +3,10 @@ import Foundation
 import UIKit
 #endif
 
+protocol ResponseCacheSafetyProviding {
+    var isResponseCacheSafe: Bool { get }
+}
+
 // MARK: - Cache Key
 
 /// Hashable key for cache entries
@@ -11,11 +15,13 @@ public struct CacheProviderIdentity: Hashable, Sendable {
     public let providerKind: String
     public let modelId: String
     public let endpointIdentity: String?
+    public let isCacheable: Bool
 
-    public init(providerKind: String, modelId: String, baseURL: String?) {
+    public init(providerKind: String, modelId: String, baseURL: String?, hasAuthentication: Bool = false) {
         self.providerKind = providerKind
         self.modelId = modelId
         self.endpointIdentity = ReasoningEndpointIdentity.canonical(baseURL)
+        self.isCacheable = !hasAuthentication && (baseURL == nil || self.endpointIdentity != nil)
     }
 }
 
@@ -27,6 +33,11 @@ struct CacheKey: Hashable {
 
     init(from request: ProviderRequest, providerIdentity: CacheProviderIdentity? = nil, model: String? = nil) {
         self.model = providerIdentity?.modelId ?? model
+        if providerIdentity?.isCacheable == false {
+            self.hash = ""
+            self.isCacheable = false
+            return
+        }
         // Create a unique hash from the request
         var hasher = Hasher()
         if let providerIdentity {
@@ -654,6 +665,8 @@ public struct CacheAwareProvider<Base: ModelProvider>: ModelProvider {
             providerKind: String(reflecting: Base.self),
             modelId: provider.modelId,
             baseURL: provider.baseURL,
+            hasAuthentication: provider.apiKey?.isEmpty == false ||
+                (provider as? any ResponseCacheSafetyProviding)?.isResponseCacheSafe == false,
         )
     }
 

--- a/Tests/TachikomaTests/Core/GenerationTests.swift
+++ b/Tests/TachikomaTests/Core/GenerationTests.swift
@@ -134,13 +134,21 @@ struct GenerationTests {
 
     @Test
     func `StreamText rejects refusal-prone aggregator models`() async throws {
+        let factoryInvocation = MessageBox()
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setProviderFactoryOverride { _, _ in
+            factoryInvocation.messages = []
+            return StaticProvider(response: ProviderResponse(text: "unexpected"))
+        }
+
         await #expect(throws: TachikomaError.self) {
             _ = try await streamText(
                 model: .openRouter(modelId: "anthropic/claude-fable-5"),
                 messages: [.user("hi")],
-                configuration: TachikomaConfiguration(loadFromEnvironment: false),
+                configuration: configuration,
             )
         }
+        #expect(factoryInvocation.messages == nil)
 
         await #expect(throws: TachikomaError.self) {
             _ = try await streamText(
@@ -563,6 +571,33 @@ struct GenerationTests {
     }
 
     @Test
+    func `GenerateText executes tool calls when finish reason is omitted`() async throws {
+        let call = AgentToolCall(id: "call-1", name: "lookup", arguments: [:])
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setProviderFactoryOverride { _, _ in
+            StaticProvider(response: ProviderResponse(text: "", toolCalls: [call]))
+        }
+        let tool = AgentTool(
+            name: "lookup",
+            description: "Lookup",
+            parameters: AgentToolParameters(),
+        ) { _ in
+            AnyAgentToolValue(string: "result")
+        }
+
+        let result = try await generateText(
+            model: .custom(provider: StaticProvider(response: ProviderResponse(text: ""))),
+            messages: [.user("go")],
+            tools: [tool],
+            maxSteps: 1,
+            configuration: config,
+        )
+
+        #expect(result.steps.first?.finishReason == nil)
+        #expect(result.steps.first?.toolResults.count == 1)
+    }
+
+    @Test
     func `GenerateText merges fallback fields into partial assistant messages`() async throws {
         let call = AgentToolCall(id: "call-1", name: "inspect_context", arguments: [:])
         let thinking = ModelMessage(
@@ -620,6 +655,38 @@ struct GenerationTests {
                 return false
             }
         })
+    }
+
+    @Test
+    func `GenerateText strips native tool calls from abnormal response history`() async throws {
+        let call = AgentToolCall(id: "partial-call", name: "lookup", arguments: [:])
+        let providerResponse = ProviderResponse(
+            text: "partial",
+            finishReason: .length,
+            toolCalls: [call],
+            assistantMessages: [
+                ModelMessage(role: .assistant, content: [.text("partial"), .toolCall(call)]),
+            ],
+        )
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setProviderFactoryOverride { _, _ in StaticProvider(response: providerResponse) }
+
+        let result = try await generateText(
+            model: .anthropic(.fable5),
+            messages: [.user("go")],
+            maxSteps: 1,
+            configuration: config,
+        )
+
+        #expect(result.steps.first?.toolCalls == [call])
+        #expect(result.messages.flatMap(\.content).contains { part in
+            if case .toolCall = part {
+                true
+            } else {
+                false
+            }
+        } == false)
+        #expect(result.messages.flatMap(\.content).contains(.text("partial")))
     }
 
     @Test
@@ -1129,7 +1196,7 @@ struct GenerationTests {
     }
 
     @Test
-    func `GenerateText preserves direct custom Anthropic thinking for same model`() async throws {
+    func `GenerateText drops direct custom Anthropic thinking without endpoint identity`() async throws {
         let seenMessages = MessageBox()
         let provider = StaticProvider(
             modelId: "claude-fable-5",
@@ -1159,8 +1226,8 @@ struct GenerationTests {
         )
 
         let messages = try #require(seenMessages.messages)
-        #expect(messages.count == 3)
-        #expect(messages[1].channel == .thinking)
+        #expect(messages.count == 2)
+        #expect(messages.allSatisfy { $0.channel != .thinking })
     }
 
     @Test
@@ -1384,6 +1451,63 @@ struct GenerationTests {
         let messages = try #require(seenMessages.messages)
         #expect(messages.count == 2)
         #expect(messages.allSatisfy { $0.channel != .thinking })
+    }
+}
+
+extension GenerationTests {
+    @Test
+    func `StreamText uses the caller supplied provider instance`() async throws {
+        let embeddedProvider = StaticProvider(
+            response: ProviderResponse(text: "unused", finishReason: .stop),
+            streamDeltas: [
+                .text("embedded"),
+                .done(finishReason: .stop),
+            ],
+        )
+        let suppliedProvider = StaticProvider(
+            response: ProviderResponse(text: "unused", finishReason: .stop),
+            streamDeltas: [
+                .text("supplied"),
+                .done(finishReason: .stop),
+            ],
+        )
+
+        let result = try await streamText(
+            model: .custom(provider: embeddedProvider),
+            provider: suppliedProvider,
+            messages: [.user("hi")],
+            configuration: TachikomaConfiguration(loadFromEnvironment: false),
+        )
+
+        var text = ""
+        for try await delta in result.stream where delta.type == .textDelta {
+            text += delta.content ?? ""
+        }
+        #expect(text == "supplied")
+    }
+
+    @Test
+    func `StreamText cancellation reaches the provider stream`() async throws {
+        let probe = StreamCancellationProbe()
+        let provider = CancellationAwareProvider(probe: probe)
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setProviderFactoryOverride { _, _ in provider }
+
+        let result = try await streamText(
+            model: .custom(provider: provider),
+            messages: [.user("hi")],
+            configuration: config,
+        )
+        let consumer = Task {
+            for try await delta in result.stream where delta.type == .textDelta {
+                await probe.markDelivered()
+            }
+        }
+
+        #expect(await probe.waitForDelivery())
+        consumer.cancel()
+        _ = try? await consumer.value
+        #expect(await probe.waitForTermination())
     }
 
     @Test
@@ -1899,11 +2023,7 @@ struct GenerationTests {
         let thinking = try #require(result.messages.first { $0.channel == .thinking })
         #expect(thinking.metadata?.customData?["tachikoma.reasoning.provider"] == "openrouter")
         #expect(thinking.metadata?.customData?["tachikoma.reasoning.model"] == "anthropic/claude-fable-5")
-        let endpointIdentity = try #require(thinking.metadata?.customData?["tachikoma.reasoning.base_url"])
-        #expect(endpointIdentity == ReasoningEndpointIdentity
-            .canonical("https://proxy.example.test/api/v1?token=secret"))
-        #expect(endpointIdentity.contains("secret") == false)
-        #expect(endpointIdentity.contains("token") == false)
+        #expect(thinking.metadata?.customData?["tachikoma.reasoning.base_url"] == nil)
         #expect(thinking.metadata?.customData?["openrouter.reasoning_details"]?.contains("sealed") == true)
     }
 
@@ -1935,8 +2055,7 @@ struct GenerationTests {
         #expect(thinking.metadata?.customData?["kimi.reasoning_content"] == "native Kimi thought")
         #expect(thinking.metadata?.customData?["tachikoma.reasoning.provider"] == "kimi")
         #expect(thinking.metadata?.customData?["tachikoma.reasoning.model"] == "kimi-k2.7-code")
-        #expect(thinking.metadata?.customData?["tachikoma.reasoning.base_url"] == ReasoningEndpointIdentity
-            .canonical("https://kimi-proxy.example.test/v1?tenant=a"))
+        #expect(thinking.metadata?.customData?["tachikoma.reasoning.base_url"] == nil)
     }
 
     // MARK: - Image Input Type Tests
@@ -2077,4 +2196,57 @@ private final class ResponseQueue: @unchecked Sendable {
 
 private final class MessageBox: @unchecked Sendable {
     var messages: [ModelMessage]?
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+private struct CancellationAwareProvider: ModelProvider {
+    let modelId = "cancellation-aware"
+    let baseURL: String? = nil
+    let apiKey: String? = nil
+    let capabilities = ModelCapabilities(supportsStreaming: true)
+    let probe: StreamCancellationProbe
+
+    func generateText(request _: ProviderRequest) async throws -> ProviderResponse {
+        ProviderResponse(text: "unused", finishReason: .stop)
+    }
+
+    func streamText(request _: ProviderRequest) async throws -> AsyncThrowingStream<TextStreamDelta, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.onTermination = { _ in
+                Task { await self.probe.markTerminated() }
+            }
+            continuation.yield(.text("first"))
+        }
+    }
+}
+
+private actor StreamCancellationProbe {
+    private var delivered = false
+    private var terminated = false
+
+    func markDelivered() {
+        self.delivered = true
+    }
+
+    func markTerminated() {
+        self.terminated = true
+    }
+
+    func waitForDelivery() async -> Bool {
+        await self.wait { self.delivered }
+    }
+
+    func waitForTermination() async -> Bool {
+        await self.wait { self.terminated }
+    }
+
+    private func wait(until condition: () -> Bool) async -> Bool {
+        for _ in 0..<100 {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
+    }
 }

--- a/Tests/TachikomaTests/HarmonyFeatures/ResponseCacheTests.swift
+++ b/Tests/TachikomaTests/HarmonyFeatures/ResponseCacheTests.swift
@@ -517,7 +517,7 @@ struct ResponseCacheTests {
     }
 
     @Test
-    func `CachedProvider keys include provider endpoint identity`() async throws {
+    func `CachedProvider bypasses cache for query-bearing endpoints`() async throws {
         let cache = ResponseCache()
         let callCountA = Box(value: 0)
         let callCountB = Box(value: 0)
@@ -544,8 +544,68 @@ struct ResponseCacheTests {
         #expect(try await cachedB.generateText(request: request).text == "tenant-b")
         #expect(try await cachedA.generateText(request: request).text == "tenant-a")
         #expect(try await cachedB.generateText(request: request).text == "tenant-b")
-        #expect(callCountA.value == 1)
-        #expect(callCountB.value == 1)
+        #expect(callCountA.value == 2)
+        #expect(callCountB.value == 2)
+    }
+
+    @Test
+    func `CachedProvider bypasses cache for credential-bearing endpoint URLs`() async throws {
+        let cache = ResponseCache()
+        let callCount = Box(value: 0)
+        var provider = ResponseCacheMockProvider(
+            model: .openaiCompatible(modelId: "shared-model", baseURL: "https://user:secret@gateway.test/v1"),
+            response: ProviderResponse(text: "uncached", usage: nil, finishReason: .stop),
+            mockModelId: "shared-model",
+            mockBaseURL: "https://user:secret@gateway.test/v1",
+        )
+        provider.onGenerateText = { _ in callCount.value += 1 }
+
+        let cachedProvider = await cache.wrapProvider(provider)
+        let request = ProviderRequest(messages: [ModelMessage.user("Test")], tools: nil, settings: .default)
+
+        #expect(try await cachedProvider.generateText(request: request).text == "uncached")
+        #expect(try await cachedProvider.generateText(request: request).text == "uncached")
+        #expect(callCount.value == 2)
+    }
+
+    @Test
+    func `CachedProvider bypasses cache for API-key-authenticated providers`() async throws {
+        let cache = ResponseCache()
+        let callCount = Box(value: 0)
+        var provider = ResponseCacheMockProvider(
+            model: .ollama(.llama33),
+            response: ProviderResponse(text: "tenant response", usage: nil, finishReason: .stop),
+            mockModelId: "llama3.3",
+            mockBaseURL: "https://ollama.example.test",
+            mockAPIKey: UUID().uuidString,
+        )
+        provider.onGenerateText = { _ in callCount.value += 1 }
+
+        let cachedProvider = await cache.wrapProvider(provider)
+        let request = ProviderRequest(messages: [ModelMessage.user("Test")], tools: nil, settings: .default)
+
+        #expect(try await cachedProvider.generateText(request: request).text == "tenant response")
+        #expect(try await cachedProvider.generateText(request: request).text == "tenant response")
+        #expect(callCount.value == 2)
+    }
+
+    @Test
+    func `CachedProvider bypasses providers without a stable authentication boundary`() async throws {
+        let cache = ResponseCache()
+        let callCount = Box(value: 0)
+        var provider = ResponseCacheMockProvider(
+            model: .ollama(.llama33),
+            response: ProviderResponse(text: "uncached", usage: nil, finishReason: .stop),
+            mockResponseCacheSafe: false,
+        )
+        provider.onGenerateText = { _ in callCount.value += 1 }
+
+        let cachedProvider = await cache.wrapProvider(provider)
+        let request = ProviderRequest(messages: [ModelMessage.user("Test")], tools: nil, settings: .default)
+
+        #expect(try await cachedProvider.generateText(request: request).text == "uncached")
+        #expect(try await cachedProvider.generateText(request: request).text == "uncached")
+        #expect(callCount.value == 2)
     }
 
     @Test
@@ -580,11 +640,13 @@ struct ResponseCacheTests {
 
 // MARK: - Mock Provider for Testing
 
-private struct ResponseCacheMockProvider: ModelProvider {
+private struct ResponseCacheMockProvider: ModelProvider, ResponseCacheSafetyProviding {
     let model: LanguageModel
     let response: ProviderResponse
     let mockModelId: String
     let mockBaseURL: String?
+    let mockAPIKey: String?
+    let mockResponseCacheSafe: Bool
     var onGenerateText: (@Sendable (ProviderRequest) -> Void)?
     var onStreamText: (@Sendable (ProviderRequest) -> Void)?
 
@@ -597,11 +659,15 @@ private struct ResponseCacheMockProvider: ModelProvider {
     }
 
     var apiKey: String? {
-        nil
+        self.mockAPIKey
     }
 
     var capabilities: ModelCapabilities {
         ModelCapabilities()
+    }
+
+    var isResponseCacheSafe: Bool {
+        self.mockResponseCacheSafe
     }
 
     init(
@@ -609,6 +675,8 @@ private struct ResponseCacheMockProvider: ModelProvider {
         response: ProviderResponse,
         mockModelId: String = "mock-model",
         mockBaseURL: String? = nil,
+        mockAPIKey: String? = nil,
+        mockResponseCacheSafe: Bool = true,
         onGenerateText: (@Sendable (ProviderRequest) -> Void)? = nil,
         onStreamText: (@Sendable (ProviderRequest) -> Void)? = nil,
     ) {
@@ -616,6 +684,8 @@ private struct ResponseCacheMockProvider: ModelProvider {
         self.response = response
         self.mockModelId = mockModelId
         self.mockBaseURL = mockBaseURL
+        self.mockAPIKey = mockAPIKey
+        self.mockResponseCacheSafe = mockResponseCacheSafe
         self.onGenerateText = onGenerateText
         self.onStreamText = onStreamText
     }

--- a/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
+++ b/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
@@ -26,16 +26,21 @@ struct AnthropicInterleavedDefaultsTests {
     }
 
     @Test
-    func `Endpoint identity includes routing query without exposing raw values`() {
+    func `Endpoint identity rejects query and userinfo credentials`() {
         let tenantA = ReasoningEndpointIdentity.canonical("https://gateway.test/v1?tenant=a")
         let tenantB = ReasoningEndpointIdentity.canonical("https://gateway.test/v1?tenant=b")
 
-        #expect(tenantA != tenantB)
-        #expect(tenantA?.hasPrefix("sha256:") == true)
-        #expect(tenantA?.contains("tenant") == false)
-        #expect(tenantA?.contains("gateway") == false)
-        #expect(ReasoningEndpointIdentity.canonical("https://gateway.test/v1/?tenant=a") == tenantA)
-        #expect(ReasoningEndpointIdentity.canonical("https://user:secret@gateway.test/v1?tenant=a#frag") == tenantA)
+        #expect(tenantA == nil)
+        #expect(tenantB == nil)
+        #expect(ReasoningEndpointIdentity.canonical("https://gateway.test/v1/") != nil)
+        let credentialA = ReasoningEndpointIdentity.canonical(
+            "https://user:secret@gateway.test/v1?tenant=a#frag",
+        )
+        let credentialB = ReasoningEndpointIdentity.canonical(
+            "https://user:rotated@gateway.test/v1?tenant=a#other",
+        )
+        #expect(credentialA == nil)
+        #expect(credentialB == nil)
     }
 
     @Test
@@ -1015,12 +1020,7 @@ struct AnthropicInterleavedDefaultsTests {
         let thinking = try #require(response.assistantMessages.first { $0.channel == .thinking })
         #expect(thinking.metadata?.customData?["tachikoma.reasoning.provider"] == "anthropic-compatible")
         #expect(thinking.metadata?.customData?["tachikoma.reasoning.model"] == "claude-fable-5")
-        let endpointIdentity = thinking.metadata?.customData?["tachikoma.reasoning.base_url"]
-        #expect(endpointIdentity == ReasoningEndpointIdentity.canonical("https://example.test/path?token=secret"))
-        #expect(endpointIdentity?.hasPrefix("sha256:") == true)
-        #expect(endpointIdentity?.contains("path") == false)
-        #expect(endpointIdentity?.contains("secret") == false)
-        #expect(endpointIdentity?.contains("token") == false)
+        #expect(thinking.metadata?.customData?["tachikoma.reasoning.base_url"] == nil)
         #expect(thinking.metadata?.customData?["anthropic.thinking.signature"] == "sig")
     }
 

--- a/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
+++ b/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
@@ -1,6 +1,130 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import Tachikoma
+
+private final class IncrementalOllamaTransportURLProtocol: URLProtocol {
+    private static let terminalGate = DispatchSemaphore(value: 0)
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: self.request.url ?? URL(string: "http://localhost:11434/api/chat")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/x-ndjson"],
+        )!
+        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        self.client?.urlProtocol(self, didLoad: Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"first"},"done":false}
+
+        """.utf8))
+
+        _ = Self.terminalGate.wait(timeout: .now() + 2)
+        self.client?.urlProtocol(self, didLoad: Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":" second"},"done":true,"done_reason":"stop"}
+
+        """.utf8))
+        self.client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func releaseTerminalChunk() {
+        self.terminalGate.signal()
+    }
+}
+
+private final class DelegatedOllamaTransportURLProtocol: URLProtocol {
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let challengeSender = OllamaAuthenticationChallengeSender()
+        let protectionSpace = URLProtectionSpace(
+            host: "localhost",
+            port: 11434,
+            protocol: "http",
+            realm: "ollama-test",
+            authenticationMethod: NSURLAuthenticationMethodHTTPBasic,
+        )
+        let challenge = URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: 0,
+            failureResponse: nil,
+            error: nil,
+            sender: challengeSender,
+        )
+        self.client?.urlProtocol(self, didReceive: challenge)
+
+        let response = HTTPURLResponse(
+            url: self.request.url ?? URL(string: "http://localhost:11434/api/chat")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/x-ndjson"],
+        )!
+        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        self.client?.urlProtocol(self, didLoad: Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"delegated"},\
+        "done":true,"done_reason":"stop"}
+
+        """.utf8))
+        self.client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class OllamaAuthenticationChallengeSender: NSObject, URLAuthenticationChallengeSender {
+    func use(_: URLCredential, for _: URLAuthenticationChallenge) {}
+
+    func continueWithoutCredential(for _: URLAuthenticationChallenge) {}
+
+    func cancel(_: URLAuthenticationChallenge) {}
+}
+
+private final class OllamaSessionDelegateProbe: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var receivedChallenge = false
+
+    func urlSession(
+        _: URLSession,
+        task _: URLSessionTask,
+        didReceive _: URLAuthenticationChallenge,
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void,
+    ) {
+        self.lock.withLock { self.receivedChallenge = true }
+        completionHandler(
+            .useCredential,
+            URLCredential(user: "test-user", password: "pw", persistence: .none),
+        )
+    }
+
+    func waitForChallenge() async -> Bool {
+        for _ in 0..<100 {
+            if self.lock.withLock({ self.receivedChallenge }) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return self.lock.withLock { self.receivedChallenge }
+    }
+}
 
 struct OllamaStreamingToolCallTests {
     /// Captured verbatim from a live `POST /api/chat` with `"stream": true` and a
@@ -49,6 +173,7 @@ struct OllamaStreamingToolCallTests {
         let chunk = try JSONDecoder().decode(OllamaStreamChunk.self, from: data)
 
         #expect(chunk.done == true)
+        #expect(chunk.doneReason == "stop")
         #expect(chunk.message.toolCalls == nil)
     }
 
@@ -96,5 +221,57 @@ struct OllamaStreamingToolCallTests {
         #expect(call.function.name == "get_status")
         #expect(call.function.arguments.isEmpty)
         #expect(OllamaProvider.convertOllamaToolCall(call).arguments.isEmpty)
+    }
+
+    @Test
+    func `delegate transport emits a line before the response completes`() async throws {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [IncrementalOllamaTransportURLProtocol.self]
+        let session = URLSession(configuration: sessionConfiguration)
+        defer { session.invalidateAndCancel() }
+
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setBaseURL("http://localhost:11434", for: .ollama)
+        let provider = try OllamaProvider(model: .llama33, configuration: configuration, urlSession: session)
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let stream = try await provider.streamText(request: ProviderRequest(messages: [.user("Hello")]))
+        var iterator = stream.makeAsyncIterator()
+
+        let first = try #require(try await iterator.next())
+        #expect(first.type == .textDelta)
+        #expect(first.content == "first")
+        #expect(startedAt.duration(to: clock.now) < .seconds(1))
+
+        IncrementalOllamaTransportURLProtocol.releaseTerminalChunk()
+        let second = try #require(try await iterator.next())
+        let done = try #require(try await iterator.next())
+        #expect(second.content == " second")
+        #expect(done.finishReason == .stop)
+        #expect(try await iterator.next() == nil)
+    }
+
+    @Test
+    func `streaming preserves the supplied session delegate`() async throws {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [DelegatedOllamaTransportURLProtocol.self]
+        let delegate = OllamaSessionDelegateProbe()
+        let session = URLSession(configuration: sessionConfiguration, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setBaseURL("http://localhost:11434", for: .ollama)
+        let provider = try OllamaProvider(model: .llama33, configuration: configuration, urlSession: session)
+        #expect(provider.reasoningReplayIdentity == nil)
+
+        let stream = try await provider.streamText(request: ProviderRequest(messages: [.user("Hello")]))
+        var text = ""
+        for try await delta in stream where delta.type == .textDelta {
+            text += delta.content ?? ""
+        }
+
+        #expect(text == "delegated")
+        let preservedDelegate = await delegate.waitForChallenge()
+        #expect(preservedDelegate)
     }
 }

--- a/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
+++ b/Tests/TachikomaTests/Providers/OllamaStreamingToolCallTests.swift
@@ -96,6 +96,10 @@ private final class OllamaAuthenticationChallengeSender: NSObject, URLAuthentica
     func continueWithoutCredential(for _: URLAuthenticationChallenge) {}
 
     func cancel(_: URLAuthenticationChallenge) {}
+
+    func performDefaultHandling(for _: URLAuthenticationChallenge) {}
+
+    func rejectProtectionSpaceAndContinue(with _: URLAuthenticationChallenge) {}
 }
 
 private final class OllamaSessionDelegateProbe: NSObject, URLSessionDataDelegate, @unchecked Sendable {

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -247,14 +247,204 @@ struct ProviderEndToEndTests {
     func `Ollama provider handles local responses`() async throws {
         try await NetworkMocking.withMockedNetwork { request in
             self.expectPath(request, endsWith: "/api/chat")
+            let body = try #require(self.bodyData(from: request))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            #expect(decoded.think == nil)
             return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "Ollama local reply"))
         } operation: {
             let config = Self.makeConfiguration { config in
                 config.setBaseURL("http://localhost:11434", for: .ollama)
             }
             let provider = try OllamaProvider(model: .llama33, configuration: config)
+            #expect(provider.isResponseCacheSafe == false)
             let response = try await provider.generateText(request: Self.basicRequest)
             #expect(response.text == "Ollama local reply")
+            #expect(response.finishReason == .stop)
+        }
+    }
+
+    @Test
+    func `Ollama provider normalizes documented and prefixed API base paths`() async throws {
+        let cases = [
+            ("https://ollama.example.test/api", "/api/chat"),
+            ("https://ollama.example.test/api/", "/api/chat"),
+            ("https://ollama.example.test/api/chat", "/api/chat"),
+            ("https://ollama.example.test/prefix/api", "/prefix/api/chat"),
+            ("https://ollama.example.test/prefix", "/prefix/api/chat"),
+        ]
+
+        for (baseURL, expectedPath) in cases {
+            try await NetworkMocking.withMockedNetwork { request in
+                #expect(request.url?.path == expectedPath)
+                return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "ok"))
+            } operation: {
+                let config = Self.makeConfiguration { config in
+                    config.setBaseURL(baseURL, for: .ollama)
+                }
+                let provider = try OllamaProvider(model: .llama33, configuration: config)
+                _ = try await provider.generateText(request: Self.basicRequest)
+            }
+        }
+    }
+
+    @Test(arguments: [
+        LanguageModel.Ollama.deepseekR18b,
+        LanguageModel.Ollama.custom("qwen3:8b"),
+    ])
+    func `Ollama provider enables thinking for known boolean models`(model: LanguageModel.Ollama) async throws {
+        let request = ProviderRequest(
+            messages: Self.basicRequest.messages,
+            settings: GenerationSettings(reasoningEffort: .low),
+        )
+
+        try await NetworkMocking.withMockedNetwork { urlRequest in
+            let body = try #require(self.bodyData(from: urlRequest))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            #expect(decoded.think == .enabled(true))
+            return NetworkMocking.jsonResponse(for: urlRequest, data: Self.ollamaPayload(text: "Reasoned"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: model, configuration: config)
+            _ = try await provider.generateText(request: request)
+        }
+    }
+
+    @Test
+    func `Ollama provider omits thinking for unsupported built-in models`() async throws {
+        let request = ProviderRequest(
+            messages: Self.basicRequest.messages,
+            settings: GenerationSettings(reasoningEffort: .low),
+        )
+
+        try await NetworkMocking.withMockedNetwork { urlRequest in
+            let body = try #require(self.bodyData(from: urlRequest))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            #expect(decoded.think == nil)
+            return NetworkMocking.jsonResponse(for: urlRequest, data: Self.ollamaPayload(text: "Plain reply"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            _ = try await provider.generateText(request: request)
+        }
+    }
+
+    @Test
+    func `Ollama reasoning identity fails closed for API keys and session headers`() throws {
+        let baseURL = "https://ollama.example.test/v1"
+        let firstConfiguration = Self.makeConfiguration { config in
+            config.setBaseURL(baseURL, for: .ollama)
+            config.setAPIKey("api-key-one", for: .ollama)
+        }
+        let rotatedKeyConfiguration = Self.makeConfiguration { config in
+            config.setBaseURL(baseURL, for: .ollama)
+            config.setAPIKey("api-key-two", for: .ollama)
+        }
+        let firstSessionConfiguration = URLSessionConfiguration.ephemeral
+        firstSessionConfiguration.httpAdditionalHeaders = ["X-Tenant": "tenant-one"]
+        let rotatedHeaderConfiguration = URLSessionConfiguration.ephemeral
+        rotatedHeaderConfiguration.httpAdditionalHeaders = ["X-Tenant": "tenant-two"]
+        let firstSession = URLSession(configuration: firstSessionConfiguration)
+        let rotatedKeySession = URLSession(configuration: firstSessionConfiguration)
+        let rotatedHeaderSession = URLSession(configuration: rotatedHeaderConfiguration)
+        defer {
+            firstSession.invalidateAndCancel()
+            rotatedKeySession.invalidateAndCancel()
+            rotatedHeaderSession.invalidateAndCancel()
+        }
+
+        let first = try OllamaProvider(
+            model: .llama33,
+            configuration: firstConfiguration,
+            urlSession: firstSession,
+        )
+        let rotatedKey = try OllamaProvider(
+            model: .llama33,
+            configuration: rotatedKeyConfiguration,
+            urlSession: rotatedKeySession,
+        )
+        let rotatedHeader = try OllamaProvider(
+            model: .llama33,
+            configuration: firstConfiguration,
+            urlSession: rotatedHeaderSession,
+        )
+
+        #expect(first.reasoningReplayIdentity == nil)
+        #expect(rotatedKey.reasoningReplayIdentity == nil)
+        #expect(rotatedHeader.reasoningReplayIdentity == nil)
+        #expect(first.isResponseCacheSafe == false)
+        #expect(rotatedKey.isResponseCacheSafe == false)
+        #expect(rotatedHeader.isResponseCacheSafe == false)
+    }
+
+    @Test
+    func `Ollama provider sends configured API key as bearer auth`() async throws {
+        try await NetworkMocking.withMockedNetwork { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer ollama-test-key")
+            return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "Authenticated"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("https://ollama.example.test", for: .ollama)
+                config.setAPIKey("ollama-test-key", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let response = try await provider.generateText(request: Self.basicRequest)
+            #expect(response.text == "Authenticated")
+        }
+    }
+
+    @Test
+    func `Ollama stream clamps GPT OSS thinking effort to a supported level`() async throws {
+        let payload = Data("""
+        {"model":"gpt-oss:20b","message":{"role":"assistant","content":"answer"},"done":true,"done_reason":"stop"}
+
+        """.utf8)
+        let request = ProviderRequest(
+            messages: Self.basicRequest.messages,
+            settings: GenerationSettings(reasoningEffort: .xhigh),
+        )
+
+        try await NetworkMocking.withMockedNetwork { urlRequest in
+            let body = try #require(self.bodyData(from: urlRequest))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            #expect(decoded.think == .level("high"))
+            return NetworkMocking.streamResponse(for: urlRequest, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(model: .gptOSS20B, configuration: config)
+            let stream = try await provider.streamText(request: request)
+            for try await _ in stream {}
+        }
+    }
+
+    @Test
+    func `Ollama stream clamps GPT OSS maximum thinking effort to high`() async throws {
+        let payload = Data("""
+        {"model":"gpt-oss:20b","message":{"role":"assistant","content":"answer"},"done":true,"done_reason":"stop"}
+
+        """.utf8)
+        let request = ProviderRequest(
+            messages: Self.basicRequest.messages,
+            settings: GenerationSettings(reasoningEffort: .max),
+        )
+
+        try await NetworkMocking.withMockedNetwork { urlRequest in
+            let body = try #require(self.bodyData(from: urlRequest))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            #expect(decoded.think == .level("high"))
+            return NetworkMocking.streamResponse(for: urlRequest, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(model: .gptOSS20B, configuration: config)
+            let stream = try await provider.streamText(request: request)
+            for try await _ in stream {}
         }
     }
 
@@ -422,6 +612,508 @@ struct ProviderEndToEndTests {
         }
     }
 
+    @Test(arguments: [
+        ("length", FinishReason.length),
+        ("unexpected_reason", FinishReason.other),
+    ])
+    func `Ollama provider preserves abnormal done reasons on tool responses`(
+        doneReason: String,
+        expected: FinishReason,
+    ) async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"","tool_calls":[
+        {"function":{"index":0,"name":"lookup","arguments":{}}}]},"done":true,"done_reason":"\(
+            doneReason
+        )"}
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.jsonResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let response = try await provider.generateText(request: Self.basicRequest)
+            #expect(response.finishReason == expected)
+            #expect(response.toolCalls?.first?.name == "lookup")
+        }
+    }
+
+    @Test(arguments: [
+        ("length", FinishReason.length),
+        ("unexpected_reason", FinishReason.other),
+    ])
+    func `Ollama abnormal tool responses are not executed`(
+        doneReason: String,
+        expected: FinishReason,
+    ) async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"","tool_calls":[
+        {"function":{"index":0,"name":"lookup","arguments":{}}}]},"done":true,"done_reason":"\(
+            doneReason
+        )"}
+        """.utf8)
+        let probe = ToolInvocationProbe()
+        let tool = AgentTool(
+            name: "lookup",
+            description: "Lookup",
+            parameters: AgentToolParameters(),
+        ) { _ in
+            await probe.recordInvocation()
+            return AnyAgentToolValue(string: "should not run")
+        }
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.jsonResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let result = try await generateText(
+                model: .ollama(.llama33),
+                messages: [.user("Look it up")],
+                tools: [tool],
+                maxSteps: 2,
+                configuration: config,
+            )
+
+            let invocationCount = await probe.invocationCount
+            #expect(invocationCount == 0)
+            #expect(result.finishReason == expected)
+            #expect(result.steps.first?.toolCalls.first?.name == "lookup")
+            #expect(result.steps.first?.toolResults.isEmpty == true)
+            #expect(result.messages.flatMap(\.content).contains { part in
+                if case .toolCall = part {
+                    true
+                } else {
+                    false
+                }
+            } == false)
+        }
+    }
+
+    @Test
+    func `Ollama provider requires terminal done status`() async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"partial"},"done":false}
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.jsonResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            do {
+                _ = try await provider.generateText(request: Self.basicRequest)
+                Issue.record("Expected incomplete Ollama response failure")
+            } catch {
+                #expect(error.localizedDescription.contains("before terminal done"))
+            }
+        }
+    }
+
+    @Test(arguments: [
+        ("length", FinishReason.length),
+        ("unexpected_reason", FinishReason.other),
+    ])
+    func `Ollama provider maps done reasons`(doneReason: String, expected: FinishReason) async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"partial"},"done":true,"done_reason":"\(
+            doneReason
+        )"}
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.jsonResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let response = try await provider.generateText(request: Self.basicRequest)
+            #expect(response.finishReason == expected)
+        }
+    }
+
+    @Test(arguments: [
+        ("length", FinishReason.length),
+        ("unexpected_reason", FinishReason.other),
+    ])
+    func `Ollama stream maps done reasons and thinking`(doneReason: String, expected: FinishReason) async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"","thinking":"considering"},"done":false}
+        {"model":"llama3.3","message":{"role":"assistant","content":"partial"},"done":true,"done_reason":"\(
+            doneReason
+        )"}
+
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.streamResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(configuration: config)
+            let stream = try await provider.streamText(request: Self.basicRequest)
+
+            var thinking = ""
+            var finishReason: FinishReason?
+            for try await delta in stream {
+                if delta.type == .reasoning {
+                    thinking.append(delta.content ?? "")
+                    #expect(delta.reasoningType == "ollama_thinking")
+                } else if delta.type == .done {
+                    finishReason = delta.finishReason
+                }
+            }
+
+            #expect(thinking == "considering")
+            #expect(finishReason == expected)
+        }
+    }
+
+    @Test
+    func `Ollama thinking survives response history replay`() async throws {
+        let config = Self.makeConfiguration { config in
+            config.setBaseURL("http://localhost:11434", for: .ollama)
+        }
+        let firstPayload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","thinking":"private plan","content":"answer"},
+        "done":true,"done_reason":"stop"}
+        """.utf8)
+        let first = try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.jsonResponse(for: request, data: firstPayload)
+        } operation: {
+            try await generateText(
+                model: .ollama(.llama33),
+                messages: [.user("Question")],
+                configuration: config,
+            )
+        }
+
+        let thinkingMessage = try #require(first.messages.first { $0.channel == .thinking })
+        #expect(thinkingMessage.content == [.text("private plan")])
+        #expect(thinkingMessage.metadata?.customData?["ollama.thinking"] == "private plan")
+
+        let replayMessages = first.messages + [.user("Follow up")]
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            let replayedAssistant = try #require(decoded.messages.first { $0.role == "assistant" })
+            #expect(replayedAssistant.thinking == "private plan")
+            #expect(replayedAssistant.content == "answer")
+            return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "next"))
+        } operation: {
+            _ = try await generateText(
+                model: .ollama(.llama33),
+                messages: replayMessages,
+                configuration: config,
+            )
+        }
+    }
+
+    @Test
+    func `Ollama direct provider only replays endpoint-bound thinking`() async throws {
+        let config = Self.makeConfiguration { config in
+            config.setBaseURL("http://localhost:11434", for: .ollama)
+        }
+        let provider = try OllamaProvider(model: .llama33, configuration: config)
+        let endpointIdentity = try #require(provider.reasoningReplayIdentity)
+        let boundThinking = ModelMessage(
+            role: .assistant,
+            content: [.text("bound plan")],
+            channel: .thinking,
+            metadata: .init(customData: [
+                "ollama.thinking": "bound plan",
+                "tachikoma.reasoning.provider": "ollama",
+                "tachikoma.reasoning.model": provider.modelId,
+                "tachikoma.reasoning.base_url": endpointIdentity,
+            ]),
+        )
+        let unboundThinking = ModelMessage(
+            role: .assistant,
+            content: [.text("unbound plan")],
+            channel: .thinking,
+        )
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            #expect(decoded.messages.contains { $0.thinking == "bound plan" })
+            #expect(decoded.messages.contains { $0.thinking == "unbound plan" } == false)
+            return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "next"))
+        } operation: {
+            _ = try await provider.generateText(request: ProviderRequest(messages: [
+                .user("Question"),
+                unboundThinking,
+                boundThinking,
+                .assistant("answer"),
+                .user("Follow up"),
+            ]))
+        }
+    }
+
+    @Test
+    func `Ollama reasoning identity stays pinned to the instantiated provider`() async throws {
+        let firstURL = "https://first.example.test/ollama"
+        let changedURL = "https://changed.example.test/ollama"
+        let config = Self.makeConfiguration { config in
+            config.setBaseURL(firstURL, for: .ollama)
+        }
+        let firstPayload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","thinking":"first plan","content":"answer"},
+        "done":true,"done_reason":"stop"}
+        """.utf8)
+        let first = try await NetworkMocking.withMockedNetwork { request in
+            #expect(request.url?.host == "first.example.test")
+            return NetworkMocking.jsonResponse(for: request, data: firstPayload)
+        } operation: {
+            try await generateText(
+                model: .ollama(.llama33),
+                messages: [.user("Question")],
+                configuration: config,
+            )
+        }
+
+        config.setProviderFactoryOverride { model, configuration in
+            guard case let .ollama(ollamaModel) = model else {
+                throw TachikomaError.invalidConfiguration("Expected Ollama model")
+            }
+            let provider = try Self.mockedOllamaProvider(model: ollamaModel, configuration: configuration)
+            configuration.setBaseURL(changedURL, for: .ollama)
+            return provider
+        }
+
+        let nextPayload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","thinking":"next plan","content":"next"},
+        "done":true,"done_reason":"stop"}
+        """.utf8)
+        let replayMessages = first.messages + [.user("Follow up")]
+        let next = try await NetworkMocking.withMockedNetwork { request in
+            #expect(request.url?.host == "first.example.test")
+            let body = try #require(self.bodyData(from: request))
+            let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+            let replayedAssistant = try #require(decoded.messages.first { $0.role == "assistant" })
+            #expect(replayedAssistant.thinking == "first plan")
+            return NetworkMocking.jsonResponse(for: request, data: nextPayload)
+        } operation: {
+            try await generateText(
+                model: .ollama(.llama33),
+                messages: replayMessages,
+                configuration: config,
+            )
+        }
+
+        #expect(config.getBaseURL(for: .ollama) == changedURL)
+        let nextThinking = try #require(next.messages.last { $0.content == [.text("next plan")] })
+        #expect(nextThinking.metadata?.customData?["tachikoma.reasoning.base_url"] == ReasoningEndpointIdentity
+            .canonical(firstURL))
+    }
+
+    @Test
+    func `Ollama credential changes prevent thinking replay without leaking its URL`() async throws {
+        try await TestEnvironmentMutex.shared.withLock {
+            let environmentKey = "PEEKABOO_OLLAMA_BASE_URL"
+            let previousValue = getenv(environmentKey).map { String(cString: $0) }
+            defer {
+                if let previousValue {
+                    setenv(environmentKey, previousValue, 1)
+                } else {
+                    unsetenv(environmentKey)
+                }
+            }
+
+            let firstURL = "https://ollama-user:private-secret@first.example.test/v1?token=hidden#local"
+            let secondURL = "https://ollama-user:rotated-secret@first.example.test/v1?token=hidden#changed"
+            setenv(environmentKey, firstURL, 1)
+
+            let config = Self.makeConfiguration { _ in }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            #expect(provider.baseURL == firstURL)
+
+            let explicitConfig = Self.makeConfiguration { configuration in
+                configuration.setBaseURL("https://explicit.example.test", for: .ollama)
+            }
+            let explicitProvider = try OllamaProvider(model: .llama33, configuration: explicitConfig)
+            #expect(explicitProvider.baseURL == "https://explicit.example.test")
+
+            let firstPayload = Data("""
+            {"model":"llama3.3","message":{"role":"assistant","thinking":"private plan","content":"answer"},
+            "done":true,"done_reason":"stop"}
+            """.utf8)
+            let first = try await NetworkMocking.withMockedNetwork { request in
+                #expect(request.url?.host == "first.example.test")
+                #expect(request.url?.path == "/v1/api/chat")
+                #expect(request.url?.query == "token=hidden")
+                #expect(request.url?.fragment == nil)
+                return NetworkMocking.jsonResponse(for: request, data: firstPayload)
+            } operation: {
+                try await generateText(
+                    model: .ollama(.llama33),
+                    messages: [.user("Question")],
+                    settings: GenerationSettings(reasoningEffort: .medium),
+                    configuration: config,
+                )
+            }
+
+            let thinkingMessage = try #require(first.messages.first { $0.channel == .thinking })
+            #expect(thinkingMessage.metadata?.customData?["tachikoma.reasoning.base_url"] == nil)
+            #expect(thinkingMessage.metadata?.customData?["ollama.thinking"] == nil)
+            #expect(ReasoningEndpointIdentity.canonical(firstURL) == nil)
+            #expect(ReasoningEndpointIdentity.canonical(secondURL) == nil)
+
+            setenv(environmentKey, secondURL, 1)
+            let replayMessages = first.messages + [.user("Follow up")]
+            try await NetworkMocking.withMockedNetwork { request in
+                #expect(request.url?.host == "first.example.test")
+                #expect(request.url?.path == "/v1/api/chat")
+                #expect(request.url?.query == "token=hidden")
+                let body = try #require(self.bodyData(from: request))
+                let decoded = try JSONDecoder().decode(OllamaChatRequest.self, from: body)
+                let replayedAssistant = try #require(decoded.messages.first { $0.role == "assistant" })
+                #expect(replayedAssistant.content == "answer")
+                #expect(replayedAssistant.thinking == nil)
+                return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "next"))
+            } operation: {
+                _ = try await generateText(
+                    model: .ollama(.llama33),
+                    messages: replayMessages,
+                    settings: GenerationSettings(reasoningEffort: .medium),
+                    configuration: config,
+                )
+            }
+        }
+    }
+
+    @Test
+    func `Ollama stream gives tool calls precedence over stop`() async throws {
+        let payload = Data("""
+        {"model":"m","message":{"tool_calls":[{"function":{"name":"lookup"}}]},"done":false}
+        {"model":"llama3.3","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}
+
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.streamResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(configuration: config)
+            let stream = try await provider.streamText(request: Self.basicRequest)
+
+            var toolName: String?
+            var finishReason: FinishReason?
+            for try await delta in stream {
+                if delta.type == .toolCall {
+                    toolName = delta.toolCall?.name
+                } else if delta.type == .done {
+                    finishReason = delta.finishReason
+                }
+            }
+            #expect(toolName == "lookup")
+            #expect(finishReason == .toolCalls)
+        }
+    }
+
+    @Test(arguments: [
+        ("length", FinishReason.length),
+        ("unexpected_reason", FinishReason.other),
+    ])
+    func `Ollama stream preserves abnormal done reasons after tool calls`(
+        doneReason: String,
+        expected: FinishReason,
+    ) async throws {
+        let payload = Data("""
+        {"model":"m","message":{"tool_calls":[{"function":{"name":"lookup"}}]},"done":false}
+        {"model":"llama3.3","message":{"role":"assistant","content":""},"done":true,"done_reason":"\(
+            doneReason
+        )"}
+
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.streamResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(configuration: config)
+            let stream = try await provider.streamText(request: Self.basicRequest)
+
+            var toolName: String?
+            var finishReason: FinishReason?
+            for try await delta in stream {
+                if delta.type == .toolCall {
+                    toolName = delta.toolCall?.name
+                } else if delta.type == .done {
+                    finishReason = delta.finishReason
+                }
+            }
+            #expect(toolName == "lookup")
+            #expect(finishReason == expected)
+        }
+    }
+
+    @Test
+    func `Ollama stream rejects malformed nonblank chunks`() async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"prefix"},"done":false}
+        this is not json
+
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.streamResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(configuration: config)
+            let stream = try await provider.streamText(request: Self.basicRequest)
+
+            var collected = ""
+            do {
+                for try await delta in stream where delta.type == .textDelta {
+                    collected.append(delta.content ?? "")
+                }
+                Issue.record("Expected malformed Ollama stream failure")
+            } catch {
+                #expect(error.localizedDescription.contains("malformed NDJSON"))
+            }
+            #expect(collected == "prefix")
+        }
+    }
+
+    @Test
+    func `Ollama stream requires a terminal done chunk`() async throws {
+        let payload = Data("""
+        {"model":"llama3.3","message":{"role":"assistant","content":"prefix"},"done":false}
+
+        """.utf8)
+
+        try await NetworkMocking.withMockedNetwork { request in
+            NetworkMocking.streamResponse(for: request, data: payload)
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try Self.mockedOllamaProvider(configuration: config)
+            let stream = try await provider.streamText(request: Self.basicRequest)
+
+            do {
+                for try await _ in stream {}
+                Issue.record("Expected truncated Ollama stream failure")
+            } catch {
+                #expect(error.localizedDescription.contains("before terminal done"))
+            }
+        }
+    }
+
     @Test
     func `Ollama stream surfaces HTTP 200 NDJSON errors`() async throws {
         let payload = Data("""
@@ -435,7 +1127,7 @@ struct ProviderEndToEndTests {
             let config = Self.makeConfiguration { config in
                 config.setBaseURL("http://localhost:11434", for: .ollama)
             }
-            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            let provider = try Self.mockedOllamaProvider(configuration: config)
             let stream = try await provider.streamText(request: Self.basicRequest)
 
             var collected = ""
@@ -665,7 +1357,7 @@ struct ProviderEndToEndTests {
             #expect(metadata["tachikoma.reasoning.provider"] == "minimax")
             #expect(metadata["tachikoma.reasoning.model"] == "MiniMax-M2.7")
             #expect(metadata["anthropic.thinking.signature"] == "sig-mm")
-            #expect(metadata["tachikoma.reasoning.base_url"] == ReasoningEndpointIdentity.canonical(baseURL))
+            #expect(metadata["tachikoma.reasoning.base_url"] == nil)
         }
     }
 
@@ -958,6 +1650,19 @@ struct ProviderEndToEndTests {
         return config
     }
 
+    private static func mockedOllamaProvider(
+        model: LanguageModel.Ollama = .llama33,
+        configuration: TachikomaConfiguration,
+    ) throws
+        -> OllamaProvider
+    {
+        try OllamaProvider(
+            model: model,
+            configuration: configuration,
+            urlSession: URLSession(configuration: self.mockedSessionConfiguration()),
+        )
+    }
+
     private func bodyData(from request: URLRequest) -> Data? {
         if let body = request.httpBody {
             return body
@@ -1005,6 +1710,14 @@ struct ProviderEndToEndTests {
         allowAudioTranscriptions: Bool = false,
     ) {
         self.expectPath(request, endsWithAny: [suffix], allowAudioTranscriptions: allowAudioTranscriptions)
+    }
+}
+
+private actor ToolInvocationProbe {
+    private(set) var invocationCount = 0
+
+    func recordInvocation() {
+        self.invocationCount += 1
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- harden Ollama streaming with incremental portable NDJSON parsing, strict terminal/error handling, cancellation cleanup, native tool calls, recursive schemas, bearer auth, and documented cloud base paths
- preserve thinking only across the same safe provider/model/endpoint boundary; fail closed for API keys, headers, cookies, credentials, delegates, userinfo, and query-bearing URLs
- prevent abnormal/truncated tool calls from executing or entering replayable history, including provider-native assistant messages
- add supplied-provider streaming so callers can pin an already-verified provider without losing standard sanitization and usage tracking
- isolate shared response caching by provider endpoint and bypass authenticated, query-bearing, or mutable-auth providers; Ollama always bypasses the shared cache

## Proof

- `swiftformat --lint` on all changed Swift files
- `swiftlint lint --strict --config .swiftlint.yml` on all changed Swift files
- `git diff --check`
- `swift test --no-parallel` — 831 tests passed
- autoreview (`gpt-5.5`, xhigh) — no actionable findings, patch correct

## Notes

- GPT-OSS reasoning effort maps `.max` to Ollama's documented highest supported level, `high`.
- Query-bearing endpoint URLs intentionally fail closed for replay and caching because arbitrary query values may contain credentials.
