### PR TITLE
fix(ollama): expose safe reasoning replay identity

### DIFF
--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -1267,7 +1267,7 @@ public final class OllamaProvider: ModelProvider {
     private let model: LanguageModel.Ollama
     private let urlSession: URLSession
 
-    var reasoningReplayIdentity: String? {
+    public var reasoningReplayIdentity: String? {
         guard let baseURL else { return nil }
         return Self.reasoningReplayIdentity(
             baseURL: baseURL,


### PR DESCRIPTION
## Summary

- expose Ollama's existing auth-safe reasoning replay identity to downstream agent runtimes
- preserve the current fail-closed checks for API keys, headers, cookies, and session delegates

## Proof

- `swift test --no-parallel --filter OllamaStreamingToolCallTests`
- autoreview: clean (`codex`, `gpt-5.5`, `xhigh`)

Needed by Peekaboo so its agent history sanitizer can reuse Tachikoma's canonical authentication-boundary check instead of reconstructing a weaker endpoint identity.
