### PR TITLE
chore(deps): refresh Swift packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated Swift package requirements and refreshed transitive pins, including swift-crypto 4.5.1, swift-nio 2.101.3, and swift-system 1.7.5.
+
 ## [0.2.2] - 2026-07-15
 
 ### Fixed

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1a563e2a4ae5a17c94f2392e30e44a724f712117ef6e236702f8ec8438854e06",
+  "originHash" : "b651ba776bd26221f0ce2158d7bfaf5dad08e41241bf6fd08c2ab85014dbc361",
   "pins" : [
     {
       "identity" : "commander",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
-        "version" : "2.101.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -130,10 +130,10 @@
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
+      "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let localCommanderPath = packageDirectory
 let isDependencyCheckout = packageDirectory.deletingLastPathComponent().lastPathComponent == "checkouts"
 let commanderDependency: Package.Dependency = !isDependencyCheckout && FileManager.default.fileExists(atPath: localCommanderPath.path)
     ? .package(path: "../Commander")
-    : .package(url: "https://github.com/steipete/Commander.git", from: "0.2.2")
+    : .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4")
 
 let package = Package(
     name: "Tachikoma",
@@ -61,11 +61,11 @@ let package = Package(
     ],
     dependencies: [
         commanderDependency,
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
-        .package(url: "https://github.com/apple/swift-configuration", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
+        .package(url: "https://github.com/apple/swift-configuration", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.2.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.1"),
     ],
     targets: [
         // Core Tachikoma module (no MCP dependencies)


### PR DESCRIPTION
## Summary

- raise direct Swift package requirements to their current stable releases
- refresh the lockfile to swift-crypto 4.5.1, swift-nio 2.101.3, and swift-system 1.7.5
- document the maintenance update in the Unreleased changelog

All other direct and transitive pins were checked against their current stable GitHub releases and were already current. The swift-crypto 5.0 release remains a prerelease, so this intentionally stays on the latest stable 4.x line.

## Proof

- `swift test --no-parallel`: 831 tests in 104 suites passed
- `swift build -c release`: passed
- `.build/release/ai-cli --version`: ran the production binary and reported AI CLI v1.0.0
- `.build/release/tachikoma config init`: ran the production binary successfully without writing secrets
- autoreview: clean, no actionable findings
