### PR TITLE
fix(cli): correct config init guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 ### Changed
 - Updated Swift package requirements and refreshed transitive pins, including swift-crypto 4.5.1, swift-nio 2.101.3, and swift-system 1.7.5.
 
+### Fixed
+- Corrected `tachikoma config init` guidance so it no longer claims to write a file or suggests commands from another application.
+
 ## [0.2.2] - 2026-07-15
 
 ### Fixed

--- a/Sources/Tachikoma/Auth/ConfigMessages.swift
+++ b/Sources/Tachikoma/Auth/ConfigMessages.swift
@@ -4,17 +4,16 @@ import Foundation
 public enum TKConfigMessages {
     /// Lines to show when no configuration exists yet.
     public static let initGuidance: [String] = [
-        "[ok] Configuration file created at: {path}",
+        "[info] Configuration file path: {path}",
         "",
-        "Next steps (no secrets written yet):",
-        "  peekaboo config add openai sk-...    # API key",
-        "  peekaboo config add anthropic sk-ant-...",
-        "  peekaboo config add grok gsk-...      # aliases: xai",
-        "  peekaboo config add gemini ya29-...",
-        "  peekaboo config login openai          # OAuth, no key stored",
-        "  peekaboo config login anthropic",
+        "No file was written. Configure credentials when ready:",
+        "  tachikoma config add openai sk-...    # API key",
+        "  tachikoma config add anthropic sk-ant-...",
+        "  tachikoma config add grok gsk-...      # aliases: xai",
+        "  tachikoma config add gemini ya29-...",
+        "  tachikoma config login openai          # OAuth",
+        "  tachikoma config login anthropic",
         "",
-        "Use 'peekaboo config show --effective' to see detected env/creds,",
-        "and 'peekaboo config edit' to tweak the JSONC file if needed.",
+        "Use 'tachikoma config status' to inspect detected environment and stored credentials.",
     ]
 }

--- a/Tests/TachikomaTests/CLITests/__snapshots__/config_init.txt
+++ b/Tests/TachikomaTests/CLITests/__snapshots__/config_init.txt
@@ -1,12 +1,11 @@
-[ok] Configuration file created at: /tmp/config.json
+[info] Configuration file path: /tmp/config.json
 
-Next steps (no secrets written yet):
-  peekaboo config add openai sk-...    # API key
-  peekaboo config add anthropic sk-ant-...
-  peekaboo config add grok gsk-...      # aliases: xai
-  peekaboo config add gemini ya29-...
-  peekaboo config login openai          # OAuth, no key stored
-  peekaboo config login anthropic
+No file was written. Configure credentials when ready:
+  tachikoma config add openai sk-...    # API key
+  tachikoma config add anthropic sk-ant-...
+  tachikoma config add grok gsk-...      # aliases: xai
+  tachikoma config add gemini ya29-...
+  tachikoma config login openai          # OAuth
+  tachikoma config login anthropic
 
-Use 'peekaboo config show --effective' to see detected env/creds,
-and 'peekaboo config edit' to tweak the JSONC file if needed.
+Use 'tachikoma config status' to inspect detected environment and stored credentials.


### PR DESCRIPTION
## Summary

`tachikoma config init` only prints setup guidance, but its first line claimed a configuration file had been created. The remaining examples were stale Peekaboo commands, including unsupported `show --effective` and `edit` suggestions.

This makes the non-writing behavior explicit and replaces every example with Tachikoma's supported `add`, `login`, and `status` commands. The snapshot and Unreleased changelog are updated with it.

## Proof

- `swift test --filter ConfigGuidanceSnapshotTests`: 1 test passed
- `swift build -c release --product tachikoma`: passed
- real release binary: `.build/release/tachikoma config init` printed the corrected guidance and exited successfully
- source-blind behavior proof: both `tachikoma config init` and the accepted `tachikoma init` shorthand produced the corrected output; `~/.tachikoma/config.json` was absent before and after both runs
- SwiftFormat and strict SwiftLint: clean for the changed Swift source
- autoreview: clean, no actionable findings
