### PR TITLE
fix(openai): replay encrypted reasoning items on Codex OAuth tool-call turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Updated Swift package requirements and refreshed transitive pins, including swift-crypto 4.5.1, swift-nio 2.101.3, and swift-system 1.7.5.
 
 ### Fixed
+- Replayed encrypted OpenAI reasoning items across Codex OAuth tool-call turns so stateless follow-up requests retain the required reasoning context.
 - Corrected `tachikoma config init` guidance so it no longer claims to write a file or suggests commands from another application.
 
 ## [0.2.2] - 2026-07-15

--- a/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
+++ b/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
@@ -76,7 +76,7 @@ enum AnthropicMessageConversion {
                                 data: imageContent.data,
                             ),
                         ))
-                    case .toolCall, .toolResult:
+                    case .reasoning, .toolCall, .toolResult:
                         return nil // Skip tool calls and results in user messages
                     }
                 }

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -702,7 +702,7 @@ struct OpenAICompatibleHelper {
                                 type: "image_url",
                                 imageUrl: OpenAIChatMessageContent.ImageUrl(url: base64URL),
                             ))
-                        case .toolCall, .toolResult:
+                        case .reasoning, .toolCall, .toolResult:
                             return nil // Skip tool calls and results in user messages
                         }
                     }

--- a/Sources/Tachikoma/Core/Types.swift
+++ b/Sources/Tachikoma/Core/Types.swift
@@ -218,6 +218,7 @@ public struct ModelMessage: Sendable, Codable, Equatable {
     public enum ContentPart: Sendable, Codable, Equatable {
         case text(String)
         case image(ImageContent)
+        case reasoning(ReasoningContent)
         case toolCall(AgentToolCall)
         case toolResult(AgentToolResult)
 
@@ -228,6 +229,29 @@ public struct ModelMessage: Sendable, Codable, Equatable {
             public init(data: String, mimeType: String = "image/png") {
                 self.data = data
                 self.mimeType = mimeType
+            }
+        }
+
+        /// Opaque reasoning state that a provider requires on subsequent turns.
+        public struct ReasoningContent: Sendable, Codable, Equatable {
+            public let id: String
+            public let encryptedContent: String
+            public let summary: [Summary]?
+
+            public struct Summary: Sendable, Codable, Equatable {
+                public let type: String
+                public let text: String
+
+                public init(type: String, text: String) {
+                    self.type = type
+                    self.text = text
+                }
+            }
+
+            public init(id: String, encryptedContent: String, summary: [Summary]? = nil) {
+                self.id = id
+                self.encryptedContent = encryptedContent
+                self.summary = summary
             }
         }
     }
@@ -504,6 +528,7 @@ public struct TextStreamDelta: Sendable {
     public let channel: ResponseChannel?
     public let reasoningSignature: String?
     public let reasoningType: String?
+    public let reasoningContent: ModelMessage.ContentPart.ReasoningContent?
     public let toolCall: AgentToolCall?
     public let toolResult: AgentToolResult?
     public let usage: Usage?
@@ -523,6 +548,7 @@ public struct TextStreamDelta: Sendable {
         channel: ResponseChannel? = nil,
         reasoningSignature: String? = nil,
         reasoningType: String? = nil,
+        reasoningContent: ModelMessage.ContentPart.ReasoningContent? = nil,
         toolCall: AgentToolCall? = nil,
         toolResult: AgentToolResult? = nil,
         usage: Usage? = nil,
@@ -533,6 +559,7 @@ public struct TextStreamDelta: Sendable {
         self.channel = channel
         self.reasoningSignature = reasoningSignature
         self.reasoningType = reasoningType
+        self.reasoningContent = reasoningContent
         self.toolCall = toolCall
         self.toolResult = toolResult
         self.usage = usage
@@ -542,6 +569,10 @@ public struct TextStreamDelta: Sendable {
     /// Convenience constructors
     public static func text(_ content: String, channel: ResponseChannel? = nil) -> TextStreamDelta {
         TextStreamDelta(type: .textDelta, content: content, channel: channel)
+    }
+
+    public static func reasoning(_ content: ModelMessage.ContentPart.ReasoningContent) -> TextStreamDelta {
+        TextStreamDelta(type: .reasoning, reasoningContent: content)
     }
 
     public static func reasoning(_ content: String, signature: String? = nil, type: String? = nil) -> TextStreamDelta {

--- a/Sources/Tachikoma/Core/UIIntegration.swift
+++ b/Sources/Tachikoma/Core/UIIntegration.swift
@@ -164,6 +164,8 @@ extension [ModelMessage] {
                             ))
                         }
                     }
+                case .reasoning:
+                    continue
                 case let .toolCall(call):
                     toolCalls.append(call)
                 case let .toolResult(result):

--- a/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
+++ b/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
@@ -184,6 +184,8 @@ public final class GoogleProvider: ModelProvider {
                         functionResponse: nil,
                         thoughtSignature: nil,
                     ))
+                case .reasoning:
+                    continue
                 case let .toolCall(toolCall):
                     let call = try GoogleGenerateRequest.Content.FunctionCall(
                         id: toolCall.id,

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -33,13 +33,14 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
 
     private static let debugLogURL = URL(fileURLWithPath: "/tmp/tachikoma-gpt5.log")
 
-    var isResponseCacheSafe: Bool { false }
+    var isResponseCacheSafe: Bool {
+        false
+    }
 
     // Provider options (immutable for Sendable conformance)
     private let reasoningEffort: ReasoningEffort = .medium
     private let verbosity: TextVerbosity = .high // Set to high for preambles
     private let previousResponseId: String? = nil // For conversation persistence
-    private let reasoningItemIds: [String] = [] // For stateful reasoning
 
     public init(
         model: LanguageModel.OpenAI,
@@ -283,7 +284,9 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                         var errorBody = ""
                         for try await line in bytes.lines {
                             errorBody += line
-                            if errorBody.count > 1000 { break } // Limit error message size
+                            if errorBody.count > 1000 {
+                                break
+                            } // Limit error message size
                         }
                         if
                             let data = errorBody.data(using: .utf8),
@@ -328,19 +331,31 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         var usage: Usage?
         var finishReason: FinishReason?
         var toolCalls: [AgentToolCall] = []
+        var assistantContent: [ModelMessage.ContentPart] = []
 
         for try await delta in stream {
             switch delta.type {
             case .textDelta:
-                text.append(delta.content ?? "")
+                let deltaText = delta.content ?? ""
+                text.append(deltaText)
+                if case let .text(existing)? = assistantContent.last {
+                    assistantContent[assistantContent.count - 1] = .text(existing + deltaText)
+                } else if !deltaText.isEmpty {
+                    assistantContent.append(.text(deltaText))
+                }
             case .toolCall:
                 if let toolCall = delta.toolCall {
                     toolCalls.append(toolCall)
+                    assistantContent.append(.toolCall(toolCall))
                 }
             case .done:
                 usage = delta.usage ?? usage
                 finishReason = delta.finishReason ?? finishReason
-            case .toolResult, .reasoning:
+            case .reasoning:
+                if let reasoning = delta.reasoningContent {
+                    assistantContent.append(.reasoning(reasoning))
+                }
+            case .toolResult:
                 break
             }
         }
@@ -350,6 +365,9 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             usage: usage,
             finishReason: finishReason,
             toolCalls: toolCalls.isEmpty ? nil : toolCalls,
+            assistantMessages: assistantContent.isEmpty
+                ? []
+                : [ModelMessage(role: .assistant, content: assistantContent)],
         )
     }
 
@@ -376,7 +394,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
 
     private struct ResponsesStreamState {
         struct PartialToolCall {
-            var id: String
+            var callId: String
             var name: String?
             var arguments: String
         }
@@ -385,6 +403,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         var pendingToolCalls: [String: PartialToolCall] = [:]
         var didYieldToolCall = false
         var didReceiveRefusal = false
+        var yieldedReasoningItemIDs: Set<String> = []
     }
 
     private static func processResponsesStreamLine(
@@ -434,20 +453,34 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             case "response.output_item.added":
                 if
                     let item = event["item"] as? [String: Any],
-                    let itemType = item["type"] as? String,
-                    itemType == "function_call"
+                    let itemType = item["type"] as? String
                 {
-                    let identifier = (item["id"] as? String) ??
-                        (item["call_id"] as? String) ?? UUID().uuidString
-                    var partial = state.pendingToolCalls[identifier] ?? ResponsesStreamState.PartialToolCall(
-                        id: identifier,
-                        name: nil,
-                        arguments: "",
-                    )
-                    if let name = item["name"] as? String {
-                        partial.name = name
+                    if itemType == "reasoning", let reasoning = Self.reasoningContent(from: item) {
+                        continuation.yield(.reasoning(reasoning))
+                        state.yieldedReasoningItemIDs.insert(reasoning.id)
+                    } else if itemType == "function_call" {
+                        let itemID = (item["id"] as? String) ?? UUID().uuidString
+                        var partial = state.pendingToolCalls[itemID] ?? ResponsesStreamState.PartialToolCall(
+                            callId: (item["call_id"] as? String) ?? itemID,
+                            name: nil,
+                            arguments: "",
+                        )
+                        if let name = item["name"] as? String {
+                            partial.name = name
+                        }
+                        state.pendingToolCalls[itemID] = partial
                     }
-                    state.pendingToolCalls[identifier] = partial
+                }
+
+            case "response.output_item.done":
+                if
+                    let item = event["item"] as? [String: Any],
+                    item["type"] as? String == "reasoning",
+                    let reasoning = Self.reasoningContent(from: item),
+                    !state.yieldedReasoningItemIDs.contains(reasoning.id)
+                {
+                    continuation.yield(.reasoning(reasoning))
+                    state.yieldedReasoningItemIDs.insert(reasoning.id)
                 }
 
             case "response.function_call_arguments.delta":
@@ -456,7 +489,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                     let delta = event["delta"] as? String
                 {
                     var partial = state.pendingToolCalls[itemId] ?? ResponsesStreamState.PartialToolCall(
-                        id: itemId,
+                        callId: itemId,
                         name: nil,
                         arguments: "",
                     )
@@ -470,7 +503,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                     let arguments = event["arguments"] as? String
                 {
                     var partial = state.pendingToolCalls[itemId] ?? ResponsesStreamState.PartialToolCall(
-                        id: itemId,
+                        callId: itemId,
                         name: nil,
                         arguments: "",
                     )
@@ -479,7 +512,11 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
 
                     if
                         let name = partial.name,
-                        let toolCall = Self.makeToolCall(id: itemId, name: name, argumentsJSON: arguments)
+                        let toolCall = Self.makeToolCall(
+                            id: partial.callId,
+                            name: name,
+                            argumentsJSON: arguments,
+                        )
                     {
                         continuation.yield(.tool(toolCall))
                         state.didYieldToolCall = true
@@ -567,8 +604,8 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             let response = event["response"] as? [String: Any],
             let usage = response["usage"] as? [String: Any],
             let inputTokens = (usage["input_tokens"] as? NSNumber)?.intValue,
-            let outputTokens = (usage["output_tokens"] as? NSNumber)?.intValue
-        else {
+            let outputTokens = (usage["output_tokens"] as? NSNumber)?.intValue else
+        {
             return nil
         }
         return Usage(inputTokens: inputTokens, outputTokens: outputTokens)
@@ -585,6 +622,30 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             return "OpenAI Responses API stream \(eventType): \(message)"
         }
         return "OpenAI Responses API stream \(eventType)"
+    }
+
+    private static func reasoningContent(from item: [String: Any]) -> ModelMessage.ContentPart.ReasoningContent? {
+        guard
+            let id = item["id"] as? String,
+            let encryptedContent = item["encrypted_content"] as? String else
+        {
+            return nil
+        }
+        let summary: [ModelMessage.ContentPart.ReasoningContent.Summary]? =
+            (item["summary"] as? [[String: Any]])?.compactMap { entry in
+                guard
+                    let type = entry["type"] as? String,
+                    let text = entry["text"] as? String else
+                {
+                    return nil
+                }
+                return ModelMessage.ContentPart.ReasoningContent.Summary(type: type, text: text)
+            }
+        return ModelMessage.ContentPart.ReasoningContent(
+            id: id,
+            encryptedContent: encryptedContent,
+            summary: summary,
+        )
     }
 
     private static func authHeader(for auth: TKAuthValue) -> (String, String, String) {
@@ -607,7 +668,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
     {
         // Convert messages to Responses API format
         let inputMessages = codex ? request.messages.filter { $0.role != .system } : request.messages
-        let messages = try self.sanitizeInputs(self.convertMessages(inputMessages))
+        let messages = try self.sanitizeInputs(self.convertMessages(inputMessages, codex: codex))
 
         // Convert tools if present
         let tools = try request.tools?.compactMap { tool in
@@ -705,7 +766,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         return instructions.isEmpty ? "You are a helpful assistant." : instructions
     }
 
-    private func convertMessages(_ messages: [ModelMessage]) throws -> [ResponsesInputItem] {
+    private func convertMessages(_ messages: [ModelMessage], codex: Bool) throws -> [ResponsesInputItem] {
         var inputs: [ResponsesInputItem] = []
 
         for message in messages {
@@ -715,14 +776,44 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                     inputs.append(.message(entry))
                 }
             case .assistant:
-                if let entry = makeMessageEntry(role: message.role.rawValue, message: message) {
-                    inputs.append(.message(entry))
-                }
-
-                for part in message.content {
-                    guard case let .toolCall(call) = part else { continue }
-                    if let functionCall = makeFunctionCall(call) {
-                        inputs.append(.functionCall(functionCall))
+                if codex {
+                    var bufferedContent: [ModelMessage.ContentPart] = []
+                    for part in message.content {
+                        switch part {
+                        case let .reasoning(reasoning):
+                            if let entry = makeMessageEntry(role: message.role.rawValue, content: bufferedContent) {
+                                inputs.append(.message(entry))
+                            }
+                            bufferedContent.removeAll(keepingCapacity: true)
+                            inputs.append(.reasoning(.init(
+                                id: reasoning.id,
+                                encryptedContent: reasoning.encryptedContent,
+                                summary: reasoning.summary,
+                            )))
+                        case let .toolCall(call):
+                            if let entry = makeMessageEntry(role: message.role.rawValue, content: bufferedContent) {
+                                inputs.append(.message(entry))
+                            }
+                            bufferedContent.removeAll(keepingCapacity: true)
+                            if let functionCall = makeFunctionCall(call) {
+                                inputs.append(.functionCall(functionCall))
+                            }
+                        default:
+                            bufferedContent.append(part)
+                        }
+                    }
+                    if let entry = makeMessageEntry(role: message.role.rawValue, content: bufferedContent) {
+                        inputs.append(.message(entry))
+                    }
+                } else {
+                    if let entry = makeMessageEntry(role: message.role.rawValue, message: message) {
+                        inputs.append(.message(entry))
+                    }
+                    for part in message.content {
+                        guard case let .toolCall(call) = part else { continue }
+                        if let functionCall = makeFunctionCall(call) {
+                            inputs.append(.functionCall(functionCall))
+                        }
                     }
                 }
             case .tool:
@@ -798,6 +889,11 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         )
     }
 
+    private func makeMessageEntry(role: String, content: [ModelMessage.ContentPart]) -> ResponsesMessage? {
+        guard !content.isEmpty else { return nil }
+        return self.makeMessageEntry(role: role, message: ModelMessage(role: .assistant, content: content))
+    }
+
     private func normalizedRole(_ role: String) -> String {
         switch role {
         case "assistant", "system", "developer", "user":
@@ -828,7 +924,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                     if !rendered.isEmpty {
                         parts.append(ResponsesContentPart(type: "input_text", text: rendered, imageUrl: nil))
                     }
-                case .toolCall:
+                case .reasoning, .toolCall:
                     continue
                 }
             }
@@ -989,21 +1085,38 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         var text: String
         var toolCalls: [AgentToolCall]?
         var finishReason: FinishReason?
+        var assistantMessages: [ModelMessage] = []
 
         if let outputs = response.output {
             // GPT-5 format with output array
             var collectedText = ""
             var collectedToolCalls: [AgentToolCall] = []
+            var collectedAssistantContent: [ModelMessage.ContentPart] = []
             var didCollectRefusal = false
 
             for output in outputs {
-                if output.type == "message" {
+                if
+                    output.type == "reasoning",
+                    let encryptedContent = output.encryptedContent
+                {
+                    collectedAssistantContent.append(.reasoning(.init(
+                        id: output.id,
+                        encryptedContent: encryptedContent,
+                        summary: output.summary,
+                    )))
+                } else if output.type == "message" {
                     if let content = output.content {
                         for chunk in content {
                             switch chunk.type {
                             case "output_text":
                                 if let textSegment = chunk.text {
                                     collectedText.append(textSegment)
+                                    if case let .text(existing)? = collectedAssistantContent.last {
+                                        collectedAssistantContent[collectedAssistantContent.count - 1] =
+                                            .text(existing + textSegment)
+                                    } else {
+                                        collectedAssistantContent.append(.text(textSegment))
+                                    }
                                 }
                             case "refusal":
                                 if chunk.refusal != nil || chunk.text != nil {
@@ -1015,6 +1128,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                                     let converted = Self.convertToolCall(toolCall)
                                 {
                                     collectedToolCalls.append(converted)
+                                    collectedAssistantContent.append(.toolCall(converted))
                                 }
                             default:
                                 continue
@@ -1026,6 +1140,16 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                     let converted = Self.convertToolCall(toolCall)
                 {
                     collectedToolCalls.append(converted)
+                    collectedAssistantContent.append(.toolCall(converted))
+                } else if
+                    output.type == "function_call",
+                    let callID = output.callId,
+                    let name = output.name,
+                    let arguments = output.arguments,
+                    let converted = Self.makeToolCall(id: callID, name: name, argumentsJSON: arguments)
+                {
+                    collectedToolCalls.append(converted)
+                    collectedAssistantContent.append(.toolCall(converted))
                 }
             }
 
@@ -1037,6 +1161,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
                 text = ""
                 toolCalls = nil
                 finishReason = .contentFilter
+                collectedAssistantContent.removeAll()
             } else {
                 toolCalls = collectedToolCalls.isEmpty ? nil : collectedToolCalls
             }
@@ -1046,6 +1171,9 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             if finishReason == nil {
                 finishReason = incompleteFinishReason ?? .stop
             }
+            assistantMessages = collectedAssistantContent.isEmpty
+                ? []
+                : [ModelMessage(role: .assistant, content: collectedAssistantContent)]
         } else if let choices = response.choices, let choice = choices.first {
             // Alternate format with choices array.
             text = choice.message.content ?? ""
@@ -1095,6 +1223,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             usage: usage,
             finishReason: finishReason,
             toolCalls: toolCalls,
+            assistantMessages: assistantMessages,
         )
     }
 

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesTypes.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesTypes.swift
@@ -275,8 +275,23 @@ struct ResponsesContentPart: Codable {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 enum ResponsesInputItem: Encodable {
     case message(ResponsesMessage)
+    case reasoning(Reasoning)
     case functionCall(FunctionCall)
     case functionCallOutput(FunctionCallOutput)
+
+    struct Reasoning: Encodable {
+        let type: String = "reasoning"
+        let id: String
+        let encryptedContent: String
+        let summary: [ModelMessage.ContentPart.ReasoningContent.Summary]?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case id
+            case encryptedContent = "encrypted_content"
+            case summary
+        }
+    }
 
     struct FunctionCall: Encodable {
         let type: String = "function_call"
@@ -317,6 +332,8 @@ enum ResponsesInputItem: Encodable {
         switch self {
         case let .message(message):
             try container.encode(message)
+        case let .reasoning(reasoning):
+            try container.encode(reasoning)
         case let .functionCall(functionCall):
             try container.encode(functionCall)
         case let .functionCallOutput(output):
@@ -507,7 +524,37 @@ struct OpenAIResponsesResponse: Codable {
         let content: [OutputContent]?
         let role: String?
         let toolCall: ResponsesToolCall?
-        // Summary can be array, which we'll decode but not use for now
+        let encryptedContent: String?
+        let summary: [ModelMessage.ContentPart.ReasoningContent.Summary]?
+        let callId: String?
+        let name: String?
+        let arguments: String?
+
+        init(
+            id: String,
+            type: String,
+            status: String? = nil,
+            content: [OutputContent]? = nil,
+            role: String? = nil,
+            toolCall: ResponsesToolCall? = nil,
+            encryptedContent: String? = nil,
+            summary: [ModelMessage.ContentPart.ReasoningContent.Summary]? = nil,
+            callId: String? = nil,
+            name: String? = nil,
+            arguments: String? = nil,
+        ) {
+            self.id = id
+            self.type = type
+            self.status = status
+            self.content = content
+            self.role = role
+            self.toolCall = toolCall
+            self.encryptedContent = encryptedContent
+            self.summary = summary
+            self.callId = callId
+            self.name = name
+            self.arguments = arguments
+        }
 
         enum CodingKeys: String, CodingKey {
             case id
@@ -516,6 +563,11 @@ struct OpenAIResponsesResponse: Codable {
             case content
             case role
             case toolCall = "tool_call"
+            case encryptedContent = "encrypted_content"
+            case summary
+            case callId = "call_id"
+            case name
+            case arguments
         }
 
         struct OutputContent: Codable {

--- a/Sources/Tachikoma/Utilities/ResponseCache.swift
+++ b/Sources/Tachikoma/Utilities/ResponseCache.swift
@@ -62,6 +62,13 @@ struct CacheKey: Hashable {
                 case let .image(image):
                     hasher.combine(image.mimeType)
                     hasher.combine(image.data.prefix(100)) // Use first 100 chars of base64 data
+                case let .reasoning(reasoning):
+                    hasher.combine(reasoning.id)
+                    hasher.combine(reasoning.encryptedContent)
+                    for summary in reasoning.summary ?? [] {
+                        hasher.combine(summary.type)
+                        hasher.combine(summary.text)
+                    }
                 case let .toolCall(call):
                     hasher.combine(call.id)
                     hasher.combine(call.name)
@@ -540,6 +547,9 @@ final class CacheEntry: @unchecked Sendable {
                     contentTotal + text.utf8.count
                 case let .image(image):
                     contentTotal + image.mimeType.utf8.count + image.data.utf8.count
+                case let .reasoning(reasoning):
+                    contentTotal + reasoning.id.utf8.count + reasoning.encryptedContent.utf8.count +
+                        (reasoning.summary?.reduce(0) { $0 + $1.type.utf8.count + $1.text.utf8.count } ?? 0)
                 case let .toolCall(call):
                     contentTotal + call.id.utf8.count + call.name.utf8.count + 100
                 case let .toolResult(result):

--- a/Sources/TachikomaAgent/Agent.swift
+++ b/Sources/TachikomaAgent/Agent.swift
@@ -360,6 +360,8 @@ public final class AgentSessionManager: @unchecked Sendable {
             return text
         case .image:
             return "[Image]"
+        case .reasoning:
+            return nil
         case let .toolCall(toolCall):
             return "Tool: \(toolCall.name)"
         case let .toolResult(toolResult):

--- a/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
+++ b/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
@@ -224,6 +224,53 @@ struct OpenAIResponsesProviderTests {
     }
 
     @Test
+    func `Responses output preserves encrypted reasoning before function call`() throws {
+        let response = OpenAIResponsesResponse(
+            id: "resp_1",
+            object: "response",
+            createdAt: 0,
+            created: nil,
+            status: "completed",
+            model: "gpt-5",
+            output: [
+                .init(
+                    id: "rs_123",
+                    type: "reasoning",
+                    encryptedContent: "sealed-reasoning",
+                    summary: [.init(type: "summary_text", text: "Checking")],
+                ),
+                .init(
+                    id: "fc_item_123",
+                    type: "function_call",
+                    callId: "call_123",
+                    name: "lookup",
+                    arguments: #"{"query":"weather"}"#,
+                ),
+            ],
+            choices: nil,
+            usage: nil,
+            metadata: nil,
+            incompleteDetails: nil,
+        )
+
+        let providerResponse = try OpenAIResponsesProvider.convertToProviderResponse(response)
+        let assistantMessage = try #require(providerResponse.assistantMessages.first)
+        #expect(assistantMessage.content.count == 2)
+        guard case let .reasoning(reasoning) = assistantMessage.content[0] else {
+            Issue.record("Expected reasoning before the function call")
+            return
+        }
+        #expect(reasoning.id == "rs_123")
+        #expect(reasoning.encryptedContent == "sealed-reasoning")
+        guard case let .toolCall(call) = assistantMessage.content[1] else {
+            Issue.record("Expected function call after reasoning")
+            return
+        }
+        #expect(call.id == "call_123")
+        #expect(providerResponse.finishReason == .toolCalls)
+    }
+
+    @Test
     func `GPT-5 incomplete content filter response maps finish reason`() throws {
         let output = OpenAIResponsesResponse.ResponsesOutput(
             id: "out_1",
@@ -597,6 +644,153 @@ struct OpenAIResponsesProviderTests {
                 #expect(response.finishReason == .stop)
                 #expect(response.usage == Usage(inputTokens: 12, outputTokens: 4))
             }
+        }
+    }
+
+    @Test
+    func `Codex OAuth replays encrypted reasoning before tool calls`() async throws {
+        try await self.withIsolatedAuthState {
+            let accessToken = Self.openAIJWT(
+                accountID: "account-123",
+                expiration: Date().addingTimeInterval(3600),
+            )
+            try TKAuthManager.shared.setCredentials([
+                "OPENAI_ACCESS_TOKEN": accessToken,
+                "OPENAI_REFRESH_TOKEN": "oauth-refresh-token",
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+            let config = TachikomaConfiguration(loadFromEnvironment: false)
+            let firstRequest = ProviderRequest(
+                messages: [.user("Look up the weather")],
+                settings: .init(maxTokens: 32),
+            )
+
+            let firstResponse = try await self.withMockedSession { request in
+                #expect(request.url?.host == "chatgpt.com")
+                let payload = Self.responsesStreamPayload(chunks: [
+                    Self.streamEventJSON([
+                        "type": "response.output_item.added",
+                        "item": ["id": "rs_123", "type": "reasoning", "summary": []],
+                    ]),
+                    Self.streamEventJSON([
+                        "type": "response.output_item.done",
+                        "item": [
+                            "id": "rs_123",
+                            "type": "reasoning",
+                            "encrypted_content": "sealed-reasoning",
+                            "summary": [["type": "summary_text", "text": "Checking the weather"]],
+                        ],
+                    ]),
+                    Self.streamEventJSON([
+                        "type": "response.output_item.added",
+                        "item": [
+                            "id": "fc_item_123",
+                            "type": "function_call",
+                            "call_id": "call_123",
+                            "name": "get_weather",
+                        ],
+                    ]),
+                    Self.streamEventJSON([
+                        "type": "response.function_call_arguments.done",
+                        "item_id": "fc_item_123",
+                        "arguments": #"{"location":"San Francisco"}"#,
+                    ]),
+                    Self.streamEventJSON(["type": "response.completed"]),
+                ])
+                return NetworkMocking.streamResponse(for: request, data: payload)
+            } operation: { session in
+                let provider = try OpenAIResponsesProvider(model: .gpt56Sol, configuration: config, session: session)
+                return try await provider.generateText(request: firstRequest)
+            }
+
+            let assistantMessage = try #require(firstResponse.assistantMessages.first)
+            #expect(firstResponse.toolCalls?.first?.id == "call_123")
+            guard case let .reasoning(reasoning) = assistantMessage.content.first else {
+                Issue.record("Expected the encrypted reasoning item first")
+                return
+            }
+            #expect(reasoning.id == "rs_123")
+            #expect(reasoning.encryptedContent == "sealed-reasoning")
+            #expect(reasoning.summary == [.init(type: "summary_text", text: "Checking the weather")])
+            guard case let .toolCall(toolCall) = assistantMessage.content.last else {
+                Issue.record("Expected the function call after reasoning")
+                return
+            }
+
+            let toolResult = AgentToolResult.success(
+                toolCallId: toolCall.id,
+                result: AnyAgentToolValue(string: "68 F"),
+            )
+            let secondRequest = ProviderRequest(
+                messages: [
+                    .user("Look up the weather"),
+                    assistantMessage,
+                    ModelMessage(role: .tool, content: [.toolResult(toolResult)]),
+                ],
+                settings: .init(maxTokens: 32),
+            )
+
+            try await self.withMockedSession { request in
+                let body = try #require(Self.bodyData(from: request))
+                let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+                let input = try #require(json["input"] as? [[String: Any]])
+                let reasoningIndex = try #require(input.firstIndex { $0["type"] as? String == "reasoning" })
+                let callIndex = try #require(input.firstIndex { $0["type"] as? String == "function_call" })
+                let outputIndex = try #require(input.firstIndex { $0["type"] as? String == "function_call_output" })
+                #expect(reasoningIndex < callIndex)
+                #expect(callIndex < outputIndex)
+                #expect(input[reasoningIndex]["id"] as? String == "rs_123")
+                #expect(input[reasoningIndex]["encrypted_content"] as? String == "sealed-reasoning")
+                let summary = try #require(input[reasoningIndex]["summary"] as? [[String: String]])
+                #expect(summary == [["type": "summary_text", "text": "Checking the weather"]])
+                #expect(input[callIndex]["call_id"] as? String == "call_123")
+                #expect(input[outputIndex]["call_id"] as? String == "call_123")
+
+                let payload = Self.responsesStreamPayload(chunks: [
+                    Self.streamEventJSON(["type": "response.output_text.delta", "delta": "It is 68 F."]),
+                    Self.streamEventJSON(["type": "response.completed"]),
+                ])
+                return NetworkMocking.streamResponse(for: request, data: payload)
+            } operation: { session in
+                let provider = try OpenAIResponsesProvider(model: .gpt56Sol, configuration: config, session: session)
+                let response = try await provider.generateText(request: secondRequest)
+                #expect(response.text == "It is 68 F.")
+            }
+        }
+    }
+
+    @Test
+    func `API key route omits provider-native reasoning input`() async throws {
+        let config = self.openAIConfig()
+        let reasoning = ModelMessage.ContentPart.ReasoningContent(
+            id: "rs_private",
+            encryptedContent: "sealed-private",
+        )
+        let toolCall = AgentToolCall(id: "call_123", name: "lookup", arguments: [:])
+        let toolResult = AgentToolResult.success(
+            toolCallId: toolCall.id,
+            result: AnyAgentToolValue(string: "done"),
+        )
+        let providerRequest = ProviderRequest(
+            messages: [
+                .user("go"),
+                ModelMessage(role: .assistant, content: [.reasoning(reasoning), .toolCall(toolCall)]),
+                ModelMessage(role: .tool, content: [.toolResult(toolResult)]),
+            ],
+            settings: .init(maxTokens: 32),
+        )
+
+        try await self.withMockedSession { request in
+            let body = try #require(Self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let input = try #require(json["input"] as? [[String: Any]])
+            #expect(input.map { $0["type"] as? String } == [nil, "function_call", "function_call_output"])
+            #expect(input.allSatisfy { $0["encrypted_content"] == nil })
+            #expect(json["include"] == nil)
+            return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "Done"))
+        } operation: { session in
+            let provider = try OpenAIResponsesProvider(model: .gpt5, configuration: config, session: session)
+            _ = try await provider.generateText(request: providerRequest)
         }
     }
 


### PR DESCRIPTION
## Summary

- capture encrypted Responses reasoning output items, including their IDs and summaries, on ordered assistant messages
- replay those items before the function calls they precede on ChatGPT OAuth requests
- keep public OpenAI API-key request encoding unchanged

## Why

The Codex route uses `store: false`, so every follow-up request must carry the opaque reasoning item that preceded a function call. Codex CLI follows this wire contract by replaying encrypted reasoning items on every turn. Tachikoma requested `reasoning.encrypted_content` but discarded the returned item, causing stateless reasoning backends to reject the next tool-loop request.

The stream now distinguishes the output-item ID used by argument delta events from the `call_id` used by function-call outputs, preserving both the item order and the tool-call identity expected by the Responses API.

## Test proof

- `swift test --filter OpenAIResponsesProviderTests` — 34 tests passed
- `swift test` — 847 tests across 104 suites passed
- `swiftlint lint --strict --quiet <changed Swift files>` — clean
