### PR TITLE
fix(openai): preserve optional response tool parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- OpenAI Responses tools now preserve omission-based optional parameters instead of having automatic strict-schema normalization force fabricated argument values.
+
 ## [0.3.0] - 2026-08-02
 
 ### Added

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -1075,7 +1075,10 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             description: tool.description,
             parameters: parameters,
             inputSchema: nil,
-            strict: nil,
+            // AgentToolParameters represents optional fields by omitting them from `required`.
+            // Responses otherwise attempts to normalize omitted strictness into strict mode,
+            // where every property becomes required and optionals must explicitly allow null.
+            strict: false,
             function: function,
         )
     }

--- a/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
+++ b/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
@@ -917,15 +917,61 @@ struct OpenAIResponsesProviderTests {
             let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
             let tools = try #require(json?["tools"] as? [[String: Any]])
             let encodedTool = try #require(tools.first)
+            #expect(encodedTool["strict"] as? Bool == false)
             let parameters = try #require(encodedTool["parameters"] as? [String: Any])
             let required = try #require(parameters["required"] as? [String])
-            #expect(required.contains("action"))
+            #expect(required == ["action"])
             let props = try #require(parameters["properties"] as? [String: Any])
             let actionProp = try #require(props["action"] as? [String: Any])
             #expect(actionProp["type"] as? String == "string")
             let appsProp = try #require(props["apps"] as? [String: Any])
             let items = try #require(appsProp["items"] as? [String: Any])
             #expect(items["type"] as? String == "string")
+
+            return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "pong"))
+        } operation: { session in
+            let provider = try OpenAIResponsesProvider(model: .gpt5, configuration: config, session: session)
+            _ = try await provider.generateText(request: providerRequest)
+        }
+    }
+
+    @Test
+    func `Responses provider keeps optional tool properties omittable`() async throws {
+        let config = self.openAIConfig()
+        let optionalProperties: [String: AgentToolParameterProperty] = [
+            "app_target": .init(name: "app_target", type: .string, description: "Application target"),
+            "window_id": .init(name: "window_id", type: .integer, description: "Exact window ID"),
+            "snapshot": .init(name: "snapshot", type: .string, description: "Existing snapshot ID"),
+            "web_focus": .init(name: "web_focus", type: .boolean, description: "Allow web focus"),
+            "max_depth": .init(name: "max_depth", type: .number, description: "Traversal depth"),
+            "max_elements": .init(name: "max_elements", type: .number, description: "Element limit"),
+            "max_children": .init(name: "max_children", type: .number, description: "Child limit"),
+        ]
+        let tool = AgentTool(
+            name: "inspect_ui",
+            description: "Inspect accessibility state",
+            parameters: AgentToolParameters(properties: optionalProperties, required: []),
+        ) { _ in
+            AnyAgentToolValue(string: "ok")
+        }
+        let providerRequest = ProviderRequest(
+            messages: [.user("Inspect the frontmost app")],
+            tools: [tool],
+            settings: .init(maxTokens: 32),
+        )
+
+        try await self.withMockedSession { request in
+            let body = try #require(Self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let encodedTool = try #require(tools.first)
+            #expect(encodedTool["strict"] as? Bool == false)
+
+            let parameters = try #require(encodedTool["parameters"] as? [String: Any])
+            #expect(try #require(parameters["required"] as? [String]).isEmpty)
+            let properties = try #require(parameters["properties"] as? [String: Any])
+            #expect(Set(properties.keys) == Set(optionalProperties.keys))
+            #expect((properties["snapshot"] as? [String: Any])?["type"] as? String == "string")
 
             return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "pong"))
         } operation: { session in


### PR DESCRIPTION
## Summary

- encode Responses API function tools with explicit non-strict schemas
- preserve omission-based optional parameters instead of requiring fabricated values
- cover mixed required/optional and fully optional tool schemas

## Why

Tachikoma models optional tool arguments by excluding them from `required`. Leaving Responses tool strictness unspecified allowed schema normalization to make every property required, which broke tools whose optional selectors must remain omittable. OpenAI's strict-mode contract requires all properties to be required, so these omission-based schemas must explicitly opt out of strict mode.

Reference: [OpenAI function calling — strict mode](https://developers.openai.com/api/docs/guides/function-calling#strict-mode)

## Validation

- SwiftFormat strict
- SwiftLint strict
- 848 tests across 104 suites
- final autoreview clean

