### PR TITLE
fix(openai): omit function output status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ### Fixed
 - OpenAI Responses tools now preserve omission-based optional parameters instead of having automatic strict-schema normalization force fabricated argument values.
+- OpenAI Responses tool errors now keep their diagnostic output without sending an unsupported `failed` status that caused request-level errors.
 
 ## [0.3.0] - 2026-08-02
 

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -970,7 +970,6 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         return ResponsesInputItem.FunctionCallOutput(
             callId: result.toolCallId,
             output: safeOutput,
-            status: result.isError ? "failed" : nil,
         )
     }
 

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesTypes.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesTypes.swift
@@ -311,19 +311,11 @@ enum ResponsesInputItem: Encodable {
         let type: String = "function_call_output"
         let callId: String
         let output: String
-        let status: String?
-
-        init(callId: String, output: String, status: String? = nil) {
-            self.callId = callId
-            self.output = output
-            self.status = status
-        }
 
         enum CodingKeys: String, CodingKey {
             case type
             case callId = "call_id"
             case output
-            case status
         }
     }
 

--- a/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
+++ b/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
@@ -1019,11 +1019,51 @@ struct OpenAIResponsesProviderTests {
             let outputEntry = input.first { ($0["type"] as? String) == "function_call_output" }
             #expect(outputEntry?["call_id"] as? String == "call_123")
             #expect((outputEntry?["output"] as? String)?.contains("temperature") == true)
+            #expect(outputEntry?["status"] == nil)
 
             let messageRoles = input.compactMap { $0["role"] as? String }
             #expect(!messageRoles.contains("tool"))
 
             return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "Done"))
+        } operation: { session in
+            let provider = try OpenAIResponsesProvider(model: .gpt5, configuration: config, session: session)
+            _ = try await provider.generateText(request: providerRequest)
+        }
+    }
+
+    @Test
+    func `Responses tool errors preserve output and omit status`() async throws {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setAPIKey("live-openai", for: .openai)
+
+        let toolCall = AgentToolCall(id: "call_error", name: "read_file", arguments: [
+            "path": AnyAgentToolValue(string: "/missing"),
+        ])
+        let toolResult = AgentToolResult.error(
+            toolCallId: "call_error",
+            error: "file not found",
+        )
+
+        let providerRequest = ProviderRequest(
+            messages: [
+                .user("read the file"),
+                ModelMessage(role: .assistant, content: [.toolCall(toolCall)]),
+                ModelMessage(role: .tool, content: [.toolResult(toolResult)]),
+            ],
+            settings: .init(maxTokens: 32),
+        )
+
+        try await withMockedSession { request in
+            let body = try #require(Self.bodyData(from: request))
+            let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            let input = try #require(json?["input"] as? [[String: Any]])
+
+            let outputEntry = input.first { ($0["type"] as? String) == "function_call_output" }
+            #expect(outputEntry?["call_id"] as? String == "call_error")
+            #expect(outputEntry?["output"] as? String == "file not found")
+            #expect(outputEntry?["status"] == nil)
+
+            return NetworkMocking.jsonResponse(for: request, data: Self.responsesPayload(text: "Handled"))
         } operation: { session in
             let provider = try OpenAIResponsesProvider(model: .gpt5, configuration: config, session: session)
             _ = try await provider.generateText(request: providerRequest)


### PR DESCRIPTION
## Summary

- omit `status` from OpenAI Responses `function_call_output` input items
- preserve tool error diagnostics in the documented `output` string
- cover both successful and failed tool-result request payloads

OpenAI documents tool execution failures as output returned to the model. The API rejects the previous `status: "failed"` value because it is not a valid input-item status.

## Tests

- `swift test --filter OpenAIResponsesProviderTests` (36 tests)
- `TACHIKOMA_TEST_MODE=mock swift test --no-parallel` (806 Tachikoma tests, 43 MCP tests)
- `swift build -c release`
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- `swiftlint lint --fix --quiet` (no diff)
- `mint run "nicklockwood/SwiftFormat@0.61.1" swiftformat --lint .`
- `git diff --check`
- P1 autoreview clean
