### PR TITLE
chore(deps): refresh Swift and CI tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
     name: SwiftFormat
     runs-on: macos-15
     env:
-      SWIFTFORMAT_VERSION: 0.61.1
+      SWIFTFORMAT_VERSION: 0.62.1
     steps:
     - name: Checkout
       uses: actions/checkout@v7

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b651ba776bd26221f0ce2158d7bfaf5dad08e41241bf6fd08c2ab85014dbc361",
+  "originHash" : "992714bc117e56e988b1b9d0167f6efd811276f66672fee12f1e937bad1fc3b5",
   "pins" : [
     {
       "identity" : "commander",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
-        "version" : "1.14.0"
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
-        "version" : "1.7.5"
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
     ],
     dependencies: [
         commanderDependency,
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.15.0"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
         .package(url: "https://github.com/apple/swift-configuration", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),

--- a/Sources/Tachikoma/Core/CustomProviders.swift
+++ b/Sources/Tachikoma/Core/CustomProviders.swift
@@ -35,7 +35,9 @@ public final class CustomProviderRegistry: @unchecked Sendable {
             var models: [String: String] = [:]
             if let modelsDict = dict["models"] as? [String: Any] {
                 for (k, v) in modelsDict {
-                    if let m = (v as? [String: Any])?["name"] as? String { models[k] = m }
+                    if let m = (v as? [String: Any])?["name"] as? String {
+                        models[k] = m
+                    }
                 }
             }
             out[id] = CustomProviderInfo(
@@ -79,43 +81,53 @@ public final class CustomProviderRegistry: @unchecked Sendable {
         while i < chars.count {
             let c = chars[i]
             let n: Character? = i + 1 < chars.count ? chars[i + 1] : nil
-            if escape { result.append(c)
+            if escape {
+                result.append(c)
                 escape = false
                 i += 1
                 continue
             }
-            if c == "\\", inString { escape = true
+            if c == "\\", inString {
+                escape = true
                 result.append(c)
                 i += 1
                 continue
             }
-            if c == "\"", !inSL, !inML { inString.toggle()
+            if c == "\"", !inSL, !inML {
+                inString.toggle()
                 result.append(c)
                 i += 1
                 continue
             }
-            if inString { result.append(c)
-                i += 1
-                continue
-            }
-            if c == "/", n == "/", !inML { inSL = true
-                i += 2
-                continue
-            }
-            if c == "/", n == "*", !inSL { inML = true
-                i += 2
-                continue
-            }
-            if c == "\n", inSL { inSL = false
+            if inString {
                 result.append(c)
                 i += 1
                 continue
             }
-            if c == "*", n == "/", inML { inML = false
+            if c == "/", n == "/", !inML {
+                inSL = true
                 i += 2
                 continue
             }
-            if !inSL, !inML { result.append(c) }
+            if c == "/", n == "*", !inSL {
+                inML = true
+                i += 2
+                continue
+            }
+            if c == "\n", inSL {
+                inSL = false
+                result.append(c)
+                i += 1
+                continue
+            }
+            if c == "*", n == "/", inML {
+                inML = false
+                i += 2
+                continue
+            }
+            if !inSL, !inML {
+                result.append(c)
+            }
             i += 1
         }
         return result

--- a/Sources/Tachikoma/Core/StopConditions.swift
+++ b/Sources/Tachikoma/Core/StopConditions.swift
@@ -337,7 +337,9 @@ public actor RepetitionStopCondition: StopCondition {
         guard !s1.isEmpty, !s2.isEmpty else { return 0 }
 
         // If strings are exactly the same, return 1.0
-        if s1 == s2 { return 1.0 }
+        if s1 == s2 {
+            return 1.0
+        }
 
         // Calculate Jaccard similarity based on characters
         let set1 = Set(s1)

--- a/Sources/Tachikoma/Core/ToolTypes.swift
+++ b/Sources/Tachikoma/Core/ToolTypes.swift
@@ -285,12 +285,16 @@ public struct AnyAgentToolValue: AgentToolValue, Equatable, Codable {
 
     /// Convenience accessors
     public var stringValue: String? {
-        if case let .string(value) = storage { return value }
+        if case let .string(value) = storage {
+            return value
+        }
         return nil
     }
 
     public var intValue: Int? {
-        if case let .int(value) = storage { return value }
+        if case let .int(value) = storage {
+            return value
+        }
         return nil
     }
 
@@ -303,22 +307,30 @@ public struct AnyAgentToolValue: AgentToolValue, Equatable, Codable {
     }
 
     public var boolValue: Bool? {
-        if case let .bool(value) = storage { return value }
+        if case let .bool(value) = storage {
+            return value
+        }
         return nil
     }
 
     public var arrayValue: [AnyAgentToolValue]? {
-        if case let .array(value) = storage { return value }
+        if case let .array(value) = storage {
+            return value
+        }
         return nil
     }
 
     public var objectValue: [String: AnyAgentToolValue]? {
-        if case let .object(value) = storage { return value }
+        if case let .object(value) = storage {
+            return value
+        }
         return nil
     }
 
     public var isNull: Bool {
-        if case .null = self.storage { return true }
+        if case .null = self.storage {
+            return true
+        }
         return false
     }
 

--- a/Sources/Tachikoma/Core/TypedValue.swift
+++ b/Sources/Tachikoma/Core/TypedValue.swift
@@ -42,13 +42,17 @@ public enum TypedValue: Codable, Sendable, Equatable, Hashable {
 
     /// Returns the value as a Bool if it is one
     public var boolValue: Bool? {
-        if case let .bool(value) = self { return value }
+        if case let .bool(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Returns the value as an Int if it is one
     public var intValue: Int? {
-        if case let .int(value) = self { return value }
+        if case let .int(value) = self {
+            return value
+        }
         return nil
     }
 
@@ -63,25 +67,33 @@ public enum TypedValue: Codable, Sendable, Equatable, Hashable {
 
     /// Returns the value as a String if it is one
     public var stringValue: String? {
-        if case let .string(value) = self { return value }
+        if case let .string(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Returns the value as an array if it is one
     public var arrayValue: [TypedValue]? {
-        if case let .array(value) = self { return value }
+        if case let .array(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Returns the value as an object/dictionary if it is one
     public var objectValue: [String: TypedValue]? {
-        if case let .object(value) = self { return value }
+        if case let .object(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Returns true if this is a null value
     public var isNull: Bool {
-        if case .null = self { return true }
+        if case .null = self {
+            return true
+        }
         return false
     }
 

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -308,7 +308,9 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
                 "fable",
             ]
             return normalized == Self.fable5.modelId || segments.contains { segment in
-                if canonicalSegments.contains(segment) { return true }
+                if canonicalSegments.contains(segment) {
+                    return true
+                }
                 let compactSegment = segment
                     .replacingOccurrences(of: "-", with: "")
                     .replacingOccurrences(of: "_", with: "")
@@ -331,7 +333,9 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
                 "sonnet5",
             ]
             return normalized == Self.sonnet5.modelId || segments.contains { segment in
-                if canonicalSegments.contains(segment) { return true }
+                if canonicalSegments.contains(segment) {
+                    return true
+                }
                 let compactSegment = segment
                     .replacingOccurrences(of: "-", with: "")
                     .replacingOccurrences(of: "_", with: "")
@@ -370,7 +374,9 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
                 "opus48",
             ]
             return normalized == Self.opus48.modelId || segments.contains { segment in
-                if canonicalSegments.contains(segment) { return true }
+                if canonicalSegments.contains(segment) {
+                    return true
+                }
                 let compactSegment = segment
                     .replacingOccurrences(of: "-", with: "")
                     .replacingOccurrences(of: "_", with: "")
@@ -746,10 +752,18 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
                 let lower = id.lowercased()
                 // Heuristic: many Ollama vision models include "vision", "vl", or well-known model names.
                 // Keep this permissive so `ollama/<anything-vision>` works from config strings.
-                if lower.contains("llava") || lower.contains("bakllava") { return true }
-                if lower.contains("vision") { return true }
-                if lower.contains("qwen2.5vl") || lower.contains("qwen25vl") { return true }
-                if lower.contains("vl:") || lower.contains("-vl") || lower.contains("_vl") { return true }
+                if lower.contains("llava") || lower.contains("bakllava") {
+                    return true
+                }
+                if lower.contains("vision") {
+                    return true
+                }
+                if lower.contains("qwen2.5vl") || lower.contains("qwen25vl") {
+                    return true
+                }
+                if lower.contains("vl:") || lower.contains("-vl") || lower.contains("_vl") {
+                    return true
+                }
                 return false
             default:
                 return false
@@ -774,10 +788,18 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             case let .custom(id):
                 // Heuristic: treat likely-vision models as tool-less unless explicitly modeled.
                 let lower = id.lowercased()
-                if lower.contains("llava") || lower.contains("bakllava") { return false }
-                if lower.contains("vision") { return false }
-                if lower.contains("qwen2.5vl") || lower.contains("qwen25vl") { return false }
-                if lower.contains("vl:") || lower.contains("-vl") || lower.contains("_vl") { return false }
+                if lower.contains("llava") || lower.contains("bakllava") {
+                    return false
+                }
+                if lower.contains("vision") {
+                    return false
+                }
+                if lower.contains("qwen2.5vl") || lower.contains("qwen25vl") {
+                    return false
+                }
+                if lower.contains("vl:") || lower.contains("-vl") || lower.contains("_vl") {
+                    return false
+                }
                 return true
             }
         }
@@ -1486,14 +1508,22 @@ extension LanguageModel {
 
         if dotted.contains("gpt-5-5") || compact.contains("gpt55") {
             // GPT-5.5 currently has no mini/nano variants; map those suffixes to GPT-5 mini/nano.
-            if dotted.contains("nano") || compact.contains("nano") { return .openai(.gpt5Nano) }
-            if dotted.contains("mini") || compact.contains("mini") { return .openai(.gpt5Mini) }
+            if dotted.contains("nano") || compact.contains("nano") {
+                return .openai(.gpt5Nano)
+            }
+            if dotted.contains("mini") || compact.contains("mini") {
+                return .openai(.gpt5Mini)
+            }
             return .openai(.gpt55)
         }
 
         if dotted.contains("gpt-5-4") || compact.contains("gpt54") {
-            if dotted.contains("nano") || compact.contains("nano") { return .openai(.gpt54Nano) }
-            if dotted.contains("mini") || compact.contains("mini") { return .openai(.gpt54Mini) }
+            if dotted.contains("nano") || compact.contains("nano") {
+                return .openai(.gpt54Nano)
+            }
+            if dotted.contains("mini") || compact.contains("mini") {
+                return .openai(.gpt54Mini)
+            }
             return .openai(.gpt54)
         }
 
@@ -1908,7 +1938,13 @@ extension LanguageModel {
             guard !Self.looksAnthropic(normalized), !Self.looksGoogle(normalized), !Self.looksGrok(normalized) else {
                 return nil
             }
-            return unqualifiedModel { if case .openai = $0 { true } else { false } }
+            return unqualifiedModel {
+                if case .openai = $0 {
+                    true
+                } else {
+                    false
+                }
+            }
                 ??
                 (Self.looksOpenAI(normalized) && !Self
                     .isUnsupportedOpenAI(normalized) ? .openai(.custom(model)) : nil)
@@ -1916,7 +1952,13 @@ extension LanguageModel {
             guard !Self.looksOpenAI(normalized), !Self.looksGoogle(normalized), !Self.looksGrok(normalized) else {
                 return nil
             }
-            return unqualifiedModel { if case .anthropic = $0 { true } else { false } }
+            return unqualifiedModel {
+                if case .anthropic = $0 {
+                    true
+                } else {
+                    false
+                }
+            }
                 ??
                 (Self.looksAnthropic(normalized) && !Self
                     .isUnsupportedAnthropic(normalized) ? .anthropic(.custom(model)) : nil)
@@ -1924,12 +1966,24 @@ extension LanguageModel {
             guard !Self.looksOpenAI(normalized), !Self.looksAnthropic(normalized), !Self.looksGrok(normalized) else {
                 return nil
             }
-            return unqualifiedModel { if case .google = $0 { true } else { false } }
+            return unqualifiedModel {
+                if case .google = $0 {
+                    true
+                } else {
+                    false
+                }
+            }
         case "grok", "xai":
             guard !Self.looksOpenAI(normalized), !Self.looksAnthropic(normalized), !Self.looksGoogle(normalized) else {
                 return nil
             }
-            return unqualifiedModel { if case .grok = $0 { true } else { false } }
+            return unqualifiedModel {
+                if case .grok = $0 {
+                    true
+                } else {
+                    false
+                }
+            }
                 ?? (Self.looksGrok(normalized) && !Self.isUnsupportedGrok(normalized) ? .grok(.custom(model)) : nil)
         default:
             return nil

--- a/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
+++ b/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
@@ -472,7 +472,11 @@ private struct GoogleSSEParser {
     }
 
     func makeDoneDelta() -> TextStreamDelta {
-        let finishReason: FinishReason? = if self.sawToolCall { .toolCalls } else { self.finishReason }
+        let finishReason: FinishReason? = if self.sawToolCall {
+            .toolCalls
+        } else {
+            self.finishReason
+        }
         return TextStreamDelta.done(usage: self.usage, finishReason: finishReason)
     }
 

--- a/Sources/Tachikoma/Providers/ProviderParser.swift
+++ b/Sources/Tachikoma/Providers/ProviderParser.swift
@@ -143,7 +143,9 @@ public enum ProviderParser {
             default:
                 continue
             }
-            if environmentModel != nil { break }
+            if environmentModel != nil {
+                break
+            }
         }
 
         // Determine if there's a conflict

--- a/Sources/TachikomaAudio/Realtime/Audio/AudioProcessor.swift
+++ b/Sources/TachikomaAudio/Realtime/Audio/AudioProcessor.swift
@@ -291,7 +291,9 @@ public final class RealtimeAudioProcessor: @unchecked Sendable {
 
         var s = max(-CLIP, min(sample, CLIP))
         let sign: UInt8 = s < 0 ? 0x80 : 0x00
-        if s < 0 { s = -s }
+        if s < 0 {
+            s = -s
+        }
 
         s += BIAS
 

--- a/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
+++ b/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
@@ -369,37 +369,49 @@ public enum RealtimeToolArgument: Sendable, Codable {
 
     /// Get string value if available
     public var stringValue: String? {
-        if case let .string(value) = self { return value }
+        if case let .string(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Get number value if available
     public var numberValue: Double? {
-        if case let .number(value) = self { return value }
+        if case let .number(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Get integer value if available
     public var integerValue: Int? {
-        if case let .integer(value) = self { return value }
+        if case let .integer(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Get boolean value if available
     public var booleanValue: Bool? {
-        if case let .boolean(value) = self { return value }
+        if case let .boolean(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Get array value if available
     public var arrayValue: [RealtimeToolArgument]? {
-        if case let .array(value) = self { return value }
+        if case let .array(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Get object value if available
     public var objectValue: String? {
-        if case let .object(value) = self { return value }
+        if case let .object(value) = self {
+            return value
+        }
         return nil
     }
 }

--- a/Sources/TachikomaConfigCLI/main.swift
+++ b/Sources/TachikomaConfigCLI/main.swift
@@ -141,17 +141,27 @@ struct TKConfigCLI {
     private static func envSource(pid: TKProviderId, env: [String: String]) -> (key: String, value: String)? {
         switch pid {
         case .openai:
-            if let v = env["OPENAI_API_KEY"], !v.isEmpty { return ("OPENAI_API_KEY", v) }
+            if let v = env["OPENAI_API_KEY"], !v.isEmpty {
+                return ("OPENAI_API_KEY", v)
+            }
         case .anthropic:
-            if let v = env["ANTHROPIC_API_KEY"], !v.isEmpty { return ("ANTHROPIC_API_KEY", v) }
+            if let v = env["ANTHROPIC_API_KEY"], !v.isEmpty {
+                return ("ANTHROPIC_API_KEY", v)
+            }
         case .grok:
             for k in ["GROK_API_KEY", "X_AI_API_KEY", "XAI_API_KEY"] {
-                if let v = env[k], !v.isEmpty { return (k, v) }
+                if let v = env[k], !v.isEmpty {
+                    return (k, v)
+                }
             }
         case .gemini:
-            if let v = env["GEMINI_API_KEY"], !v.isEmpty { return ("GEMINI_API_KEY", v) }
+            if let v = env["GEMINI_API_KEY"], !v.isEmpty {
+                return ("GEMINI_API_KEY", v)
+            }
         case .openrouter:
-            if let v = env["OPENROUTER_API_KEY"], !v.isEmpty { return ("OPENROUTER_API_KEY", v) }
+            if let v = env["OPENROUTER_API_KEY"], !v.isEmpty {
+                return ("OPENROUTER_API_KEY", v)
+            }
         }
         return nil
     }
@@ -160,19 +170,33 @@ struct TKConfigCLI {
         let manager = TKAuthManager.shared
         switch pid {
         case .openai:
-            if let v = manager.credentialValue(for: "OPENAI_ACCESS_TOKEN") { return ("OPENAI_ACCESS_TOKEN", v) }
-            if let v = manager.credentialValue(for: "OPENAI_API_KEY") { return ("OPENAI_API_KEY", v) }
+            if let v = manager.credentialValue(for: "OPENAI_ACCESS_TOKEN") {
+                return ("OPENAI_ACCESS_TOKEN", v)
+            }
+            if let v = manager.credentialValue(for: "OPENAI_API_KEY") {
+                return ("OPENAI_API_KEY", v)
+            }
         case .anthropic:
-            if let v = manager.credentialValue(for: "ANTHROPIC_ACCESS_TOKEN") { return ("ANTHROPIC_ACCESS_TOKEN", v) }
-            if let v = manager.credentialValue(for: "ANTHROPIC_API_KEY") { return ("ANTHROPIC_API_KEY", v) }
+            if let v = manager.credentialValue(for: "ANTHROPIC_ACCESS_TOKEN") {
+                return ("ANTHROPIC_ACCESS_TOKEN", v)
+            }
+            if let v = manager.credentialValue(for: "ANTHROPIC_API_KEY") {
+                return ("ANTHROPIC_API_KEY", v)
+            }
         case .grok:
             for k in ["GROK_API_KEY", "X_AI_API_KEY", "XAI_API_KEY"] {
-                if let v = manager.credentialValue(for: k) { return (k, v) }
+                if let v = manager.credentialValue(for: k) {
+                    return (k, v)
+                }
             }
         case .gemini:
-            if let v = manager.credentialValue(for: "GEMINI_API_KEY") { return ("GEMINI_API_KEY", v) }
+            if let v = manager.credentialValue(for: "GEMINI_API_KEY") {
+                return ("GEMINI_API_KEY", v)
+            }
         case .openrouter:
-            if let v = manager.credentialValue(for: "OPENROUTER_API_KEY") { return ("OPENROUTER_API_KEY", v) }
+            if let v = manager.credentialValue(for: "OPENROUTER_API_KEY") {
+                return ("OPENROUTER_API_KEY", v)
+            }
         }
         return nil
     }

--- a/Sources/TachikomaMCP/Client/HTTPTransport.swift
+++ b/Sources/TachikomaMCP/Client/HTTPTransport.swift
@@ -137,13 +137,17 @@ public final class HTTPTransport: MCPTransport {
             }
 
             let decoded = try JSONDecoder().decode(HTTPJSONRPCResponse<R>.self, from: jsonData)
-            if let err = decoded.error { throw MCPError.executionFailed(err.message) }
+            if let err = decoded.error {
+                throw MCPError.executionFailed(err.message)
+            }
             guard let result = decoded.result else { throw MCPError.invalidResponse }
             return result
         } else {
             // Standard JSON response
             let decoded = try JSONDecoder().decode(HTTPJSONRPCResponse<R>.self, from: data)
-            if let err = decoded.error { throw MCPError.executionFailed(err.message) }
+            if let err = decoded.error {
+                throw MCPError.executionFailed(err.message)
+            }
             guard let result = decoded.result else { throw MCPError.invalidResponse }
             return result
         }

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -47,9 +47,15 @@ private enum AutoConnectPolicy {
         ProcessInfo.processInfo.environment["PEEKABOO_DISABLE_MCP_AUTOCONNECT"] == "true"
     private static let isTestEnvironment: Bool = {
         let env = ProcessInfo.processInfo.environment
-        if env["PEEKABOO_DISABLE_MCP_AUTOCONNECT"] == "true" { return true }
-        if env["SWIFT_PACKAGE_TESTING"] == "1" { return true }
-        if env["XCTestConfigurationFilePath"] != nil { return true }
+        if env["PEEKABOO_DISABLE_MCP_AUTOCONNECT"] == "true" {
+            return true
+        }
+        if env["SWIFT_PACKAGE_TESTING"] == "1" {
+            return true
+        }
+        if env["XCTestConfigurationFilePath"] != nil {
+            return true
+        }
         let processName = ProcessInfo.processInfo.processName.lowercased()
         let argv0 = CommandLine.arguments.first?.lowercased() ?? ""
         return processName.contains("xctest")
@@ -62,8 +68,12 @@ private enum AutoConnectPolicy {
         if let override = overrideLock.withLock({ $0 }) {
             return override
         }
-        if forceEnable { return true }
-        if forceDisable { return false }
+        if forceEnable {
+            return true
+        }
+        if forceDisable {
+            return false
+        }
         return !isTestEnvironment
     }
 
@@ -125,7 +135,9 @@ public final class TachikomaMCPClientManager {
 
     public func addServer(name: String, config: MCPServerConfig) async throws {
         self.effectiveConfigs[name] = config
-        if self.connections[name] == nil { self.connections[name] = MCPClient(name: name, config: config) }
+        if self.connections[name] == nil {
+            self.connections[name] = MCPClient(name: name, config: config)
+        }
         if config.enabled, AutoConnectPolicy.shouldConnect {
             try await self.connections[name]?.connect()
         }
@@ -143,7 +155,9 @@ public final class TachikomaMCPClientManager {
         guard var cfg = effectiveConfigs[name] else { return }
         cfg.enabled = true
         self.effectiveConfigs[name] = cfg
-        if self.connections[name] == nil { self.connections[name] = MCPClient(name: name, config: cfg) }
+        if self.connections[name] == nil {
+            self.connections[name] = MCPClient(name: name, config: cfg)
+        }
         if AutoConnectPolicy.shouldConnect {
             try await self.connections[name]?.connect()
         }
@@ -153,7 +167,9 @@ public final class TachikomaMCPClientManager {
         guard var cfg = effectiveConfigs[name] else { return }
         cfg.enabled = false
         self.effectiveConfigs[name] = cfg
-        if let client = connections[name] { await client.disconnect() }
+        if let client = connections[name] {
+            await client.disconnect()
+        }
     }
 
     public func listServerNames() -> [String] {
@@ -184,7 +200,9 @@ public final class TachikomaMCPClientManager {
         var all: [Tool] = []
         for name in self.listServerNames() {
             let tools = await getServerTools(name: name)
-            if !tools.isEmpty { all.append(contentsOf: tools) }
+            if !tools.isEmpty {
+                all.append(contentsOf: tools)
+            }
         }
         return all
     }
@@ -204,7 +222,9 @@ public final class TachikomaMCPClientManager {
         let agentArgs = AgentToolArguments(arguments.mapValues { AnyAgentToolValue.from($0) })
         var mcpArgs: [String: Any] = [:]
         for key in agentArgs.keys {
-            if let v = agentArgs[key] { mcpArgs[key] = try v.toJSON() }
+            if let v = agentArgs[key] {
+                mcpArgs[key] = try v.toJSON()
+            }
         }
         return try await client.executeTool(name: toolName, arguments: mcpArgs)
     }
@@ -215,7 +235,9 @@ public final class TachikomaMCPClientManager {
         var result: [String: [Tool]] = [:]
         for (name, client) in self.connections {
             let tools = await client.tools
-            if !tools.isEmpty { result[name] = tools }
+            if !tools.isEmpty {
+                result[name] = tools
+            }
         }
         return result
     }
@@ -424,16 +446,30 @@ public final class TachikomaMCPClientManager {
         let keys = Set(D.keys).union(F.keys)
         for k in keys {
             if let f = F[k] {
-                if f.enabled == false { continue }
+                if f.enabled == false {
+                    continue
+                }
                 if let d = D[k] {
                     // Fill missing fields from defaults
                     var merged = f
-                    if merged.transport.isEmpty { merged.transport = d.transport }
-                    if merged.command.isEmpty { merged.command = d.command }
-                    if merged.args.isEmpty { merged.args = d.args }
-                    if merged.env.isEmpty { merged.env = d.env }
-                    if merged.timeout <= 0 { merged.timeout = d.timeout }
-                    if merged.description == nil { merged.description = d.description }
+                    if merged.transport.isEmpty {
+                        merged.transport = d.transport
+                    }
+                    if merged.command.isEmpty {
+                        merged.command = d.command
+                    }
+                    if merged.args.isEmpty {
+                        merged.args = d.args
+                    }
+                    if merged.env.isEmpty {
+                        merged.env = d.env
+                    }
+                    if merged.timeout <= 0 {
+                        merged.timeout = d.timeout
+                    }
+                    if merged.description == nil {
+                        merged.description = d.description
+                    }
                     result[k] = merged
                 } else {
                     result[k] = f
@@ -519,43 +555,53 @@ public final class TachikomaMCPClientManager {
         while i < chars.count {
             let c = chars[i]
             let n: Character? = i + 1 < chars.count ? chars[i + 1] : nil
-            if escapeNext { result.append(c)
+            if escapeNext {
+                result.append(c)
                 escapeNext = false
                 i += 1
                 continue
             }
-            if c == "\\", inString { escapeNext = true
+            if c == "\\", inString {
+                escapeNext = true
                 result.append(c)
                 i += 1
                 continue
             }
-            if c == "\"", !inSingle, !inMulti { inString.toggle()
+            if c == "\"", !inSingle, !inMulti {
+                inString.toggle()
                 result.append(c)
                 i += 1
                 continue
             }
-            if inString { result.append(c)
-                i += 1
-                continue
-            }
-            if c == "/", n == "/", !inMulti { inSingle = true
-                i += 2
-                continue
-            }
-            if c == "/", n == "*", !inSingle { inMulti = true
-                i += 2
-                continue
-            }
-            if c == "\n", inSingle { inSingle = false
+            if inString {
                 result.append(c)
                 i += 1
                 continue
             }
-            if c == "*", n == "/", inMulti { inMulti = false
+            if c == "/", n == "/", !inMulti {
+                inSingle = true
                 i += 2
                 continue
             }
-            if !inSingle, !inMulti { result.append(c) }
+            if c == "/", n == "*", !inSingle {
+                inMulti = true
+                i += 2
+                continue
+            }
+            if c == "\n", inSingle {
+                inSingle = false
+                result.append(c)
+                i += 1
+                continue
+            }
+            if c == "*", n == "/", inMulti {
+                inMulti = false
+                i += 2
+                continue
+            }
+            if !inSingle, !inMulti {
+                result.append(c)
+            }
             i += 1
         }
         return result

--- a/Sources/TachikomaMCP/Client/SSETransport.swift
+++ b/Sources/TachikomaMCP/Client/SSETransport.swift
@@ -125,7 +125,9 @@ public final class SSETransport: MCPTransport {
 
     public func disconnect() async {
         self.logger.info("Disconnecting SSE transport")
-        if let t = await state.getTransport() { await t.disconnect() }
+        if let t = await state.getTransport() {
+            await t.disconnect()
+        }
         await self.state.cancelAll(MCPError.notConnected)
         await self.state.setTransport(nil)
     }
@@ -216,7 +218,9 @@ public final class SSETransport: MCPTransport {
 
         // Decode JSON-RPC response when SSE delivers it
         let response = try JSONDecoder().decode(JSONRPCResponse<R>.self, from: responseData)
-        if let error = response.error { throw MCPError.executionFailed(error.message) }
+        if let error = response.error {
+            throw MCPError.executionFailed(error.message)
+        }
         guard let result = response.result else { throw MCPError.invalidResponse }
         return result
     }
@@ -362,13 +366,16 @@ private struct JSONRPCResponse<R: Decodable>: Decodable {
 private enum JSONRPCID: Decodable { case int(Int), string(String), null
     init(from decoder: Decoder) throws {
         let c = try decoder.singleValueContainer()
-        if let i = try? c.decode(Int.self) { self = .int(i)
+        if let i = try? c.decode(Int.self) {
+            self = .int(i)
             return
         }
-        if let s = try? c.decode(String.self) { self = .string(s)
+        if let s = try? c.decode(String.self) {
+            self = .string(s)
             return
         }
-        if c.decodeNil() { self = .null
+        if c.decodeNil() {
+            self = .null
             return
         }
         throw DecodingError.typeMismatch(

--- a/Sources/TachikomaMCP/Client/StdioTransport.swift
+++ b/Sources/TachikomaMCP/Client/StdioTransport.swift
@@ -572,13 +572,16 @@ private enum JSONRPCID: Decodable {
     case null
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let i = try? container.decode(Int.self) { self = .int(i)
+        if let i = try? container.decode(Int.self) {
+            self = .int(i)
             return
         }
-        if let s = try? container.decode(String.self) { self = .string(s)
+        if let s = try? container.decode(String.self) {
+            self = .string(s)
             return
         }
-        if container.decodeNil() { self = .null
+        if container.decodeNil() {
+            self = .null
             return
         }
         throw DecodingError.typeMismatch(

--- a/Tests/TachikomaTests/Auth/AuthManagerTests.swift
+++ b/Tests/TachikomaTests/Auth/AuthManagerTests.swift
@@ -797,7 +797,9 @@ private final class OAuthMockURLProtocol: URLProtocol {
                 let read = stream.read(&buffer, maxLength: bufferSize)
                 if read > 0 {
                     data.append(buffer, count: read)
-                } else { break }
+                } else {
+                    break
+                }
             }
             OAuthMockURLProtocol.lastBody = data
         }

--- a/Tests/TachikomaTests/Providers/Integration/ProviderSystemTests.swift
+++ b/Tests/TachikomaTests/Providers/Integration/ProviderSystemTests.swift
@@ -105,17 +105,27 @@ struct ProviderSystemTests {
             setenv("ANTHROPIC_COMPATIBLE_API_KEY", "generic-compatible-key", 1)
             setenv("API_KEY", "generic-key", 1)
             defer {
-                if let previousOpenAI { setenv("OPENAI_API_KEY", previousOpenAI, 1) }
-                if let previousAnthropic { setenv("ANTHROPIC_API_KEY", previousAnthropic, 1) }
-                // swiftlint:disable:next statement_position
-                if let previousMiniMax { setenv("MINIMAX_API_KEY", previousMiniMax, 1) }
-                else { unsetenv("MINIMAX_API_KEY") }
+                if let previousOpenAI {
+                    setenv("OPENAI_API_KEY", previousOpenAI, 1)
+                }
+                if let previousAnthropic {
+                    setenv("ANTHROPIC_API_KEY", previousAnthropic, 1)
+                }
+                if let previousMiniMax {
+                    setenv("MINIMAX_API_KEY", previousMiniMax, 1)
+                } else {
+                    unsetenv("MINIMAX_API_KEY")
+                }
                 if let previousAnthropicCompatible {
                     setenv("ANTHROPIC_COMPATIBLE_API_KEY", previousAnthropicCompatible, 1)
                 } else {
                     unsetenv("ANTHROPIC_COMPATIBLE_API_KEY")
                 }
-                if let previousGeneric { setenv("API_KEY", previousGeneric, 1) } else { unsetenv("API_KEY") }
+                if let previousGeneric {
+                    setenv("API_KEY", previousGeneric, 1)
+                } else {
+                    unsetenv("API_KEY")
+                }
             }
 
             #expect(throws: TachikomaError.self) {

--- a/Tests/TachikomaTests/UnifiedErrorsTests.swift
+++ b/Tests/TachikomaTests/UnifiedErrorsTests.swift
@@ -39,7 +39,9 @@ struct UnifiedErrorsTests {
         #expect(unifiedError.code == .rateLimited)
         #expect(unifiedError.details?.retryAfter == 60)
         #expect(unifiedError.recovery?.actions.contains {
-            if case .retry(after: 60) = $0 { return true }
+            if case .retry(after: 60) = $0 {
+                return true
+            }
             return false
         } == true)
     }


### PR DESCRIPTION
## Summary

- update swift-log from 1.14.0 to 1.15.0 and refresh the transitive swift-system pin from 1.7.5 to 1.8.0
- update the CI SwiftFormat pin from 0.61.1 to 0.62.1
- apply the formatter-required wrapping migration and remove the resulting obsolete SwiftLint suppression

## Verification

- `swift package update --dry-run` — 0 dependencies would change
- `swift build -c release`
- `swift build -Xswiftc -swift-version -Xswiftc 6 -Xswiftc -warn-concurrency`
- `TACHIKOMA_TEST_MODE=mock swift test --parallel` — 849 tests in 104 suites passed
- `swiftlint lint --strict --quiet`
- `swiftlint lint --fix --quiet`
- `mint run "nicklockwood/SwiftFormat@0.62.1" swiftformat --lint .` — 0/182 files require formatting
- built release CLI proof: `tachikoma config init` and `ai-cli --help`
- GitHub Dependabot audit — 0 open alerts
- Codex autoreview — clean, no accepted/actionable findings
