### PR TITLE
feat(anthropic): add claude-opus-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
+
 ### Fixed
 - OpenAI Responses tools now preserve omission-based optional parameters instead of having automatic strict-schema normalization force fabricated argument values.
 - OpenAI Responses tool errors now keep their diagnostic output without sending an unsupported `failed` status that caused request-level errors.

--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -174,6 +174,9 @@ public final class AnthropicProvider: ModelProvider {
             if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
                 return AnthropicThinking(type: "adaptive", budgetTokens: nil)
             }
+            if Self.isOpus5(model: model) {
+                return AnthropicThinking(type: "adaptive", budgetTokens: nil)
+            }
             if case .opus48 = model {
                 return AnthropicThinking(type: "adaptive", budgetTokens: nil)
             }
@@ -215,11 +218,11 @@ public final class AnthropicProvider: ModelProvider {
         case .xhigh:
             Self.isFable(model: model) ||
                 LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) ||
-                model == .opus48 || model == .opus47
+                Self.isOpus5(model: model) || model == .opus48 || model == .opus47
         case .max:
             Self.isFable(model: model) ||
                 LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) ||
-                model == .opus48 || model == .opus47 || model == .sonnet46
+                Self.isOpus5(model: model) || model == .opus48 || model == .opus47 || model == .sonnet46
         }
     }
 
@@ -228,6 +231,9 @@ public final class AnthropicProvider: ModelProvider {
             return true
         }
         if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
+            return true
+        }
+        if Self.isOpus5(model: model) {
             return true
         }
         if case .opus48 = model {
@@ -247,6 +253,9 @@ public final class AnthropicProvider: ModelProvider {
             return true
         }
         if LanguageModel.Anthropic.isSonnet5(modelId: model.modelId) {
+            return true
+        }
+        if Self.isOpus5(model: model) {
             return true
         }
         switch model {
@@ -307,6 +316,16 @@ public final class AnthropicProvider: ModelProvider {
         {
             throw TachikomaError.invalidConfiguration(
                 "Claude Fable 5 always uses adaptive thinking; disabled thinking is not supported",
+            )
+        }
+        if
+            Self.isOpus5(model: self.model),
+            case .disabled = thinkingMode,
+            let reasoningEffort = validatedSettings.reasoningEffort,
+            reasoningEffort == .xhigh || reasoningEffort == .max
+        {
+            throw TachikomaError.invalidConfiguration(
+                "Claude Opus 5 only supports disabled thinking at high effort or below",
             )
         }
         if
@@ -568,6 +587,10 @@ public final class AnthropicProvider: ModelProvider {
 
     private static func isFable(model: LanguageModel.Anthropic) -> Bool {
         LanguageModel.Anthropic.isFable(modelId: model.modelId)
+    }
+
+    private static func isOpus5(model: LanguageModel.Anthropic) -> Bool {
+        LanguageModel.Anthropic.isOpus5(modelId: model.modelId)
     }
 
     private static func hasStreamingRefusalRisk(model: LanguageModel.Anthropic) -> Bool {

--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -319,16 +319,6 @@ public final class AnthropicProvider: ModelProvider {
             )
         }
         if
-            Self.isOpus5(model: self.model),
-            case .disabled = thinkingMode,
-            let reasoningEffort = validatedSettings.reasoningEffort,
-            reasoningEffort == .xhigh || reasoningEffort == .max
-        {
-            throw TachikomaError.invalidConfiguration(
-                "Claude Opus 5 only supports disabled thinking at high effort or below",
-            )
-        }
-        if
             LanguageModel.Anthropic.hasDefaultAdaptiveThinking(modelId: self.model.modelId),
             request.messages.last?.role == .assistant
         {

--- a/Sources/Tachikoma/Core/ModelCapabilities.swift
+++ b/Sources/Tachikoma/Core/ModelCapabilities.swift
@@ -278,6 +278,7 @@ public final class ModelCapabilityRegistry: @unchecked Sendable {
             ),
             excludedParameters: ["temperature", "topP", "topK"],
         )
+        self.capabilities["anthropic:claude-opus-5"] = claudeAdaptiveThinkingCapabilities
         self.capabilities["anthropic:claude-fable-5"] = claudeAdaptiveThinkingCapabilities
         self.capabilities["anthropic:claude-sonnet-5"] = claudeAdaptiveThinkingCapabilities
         self.capabilities["anthropic:claude-opus-4-8"] = claudeAdaptiveThinkingCapabilities

--- a/Sources/Tachikoma/Models/Model.swift
+++ b/Sources/Tachikoma/Models/Model.swift
@@ -205,6 +205,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
     public enum Anthropic: Sendable, Hashable, CaseIterable {
         // Claude 5 / 4.x Series
+        case opus5
         case fable5
         case sonnet5
         case opus48
@@ -220,6 +221,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public static var allCases: [Anthropic] {
             [
+                .opus5,
                 .fable5,
                 .sonnet5,
                 .opus48,
@@ -235,6 +237,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         public var modelId: String {
             switch self {
             case let .custom(id): id
+            case .opus5: "claude-opus-5"
             case .fable5: "claude-fable-5"
             case .sonnet5: "claude-sonnet-5"
             case .opus48: "claude-opus-4-8"
@@ -249,7 +252,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public var supportsVision: Bool {
             switch self {
-            case .fable5, .sonnet5, .opus48, .opus47, .opus45, .opus4, .sonnet46, .sonnet45, .haiku45:
+            case .opus5, .fable5, .sonnet5, .opus48, .opus47, .opus45, .opus4, .sonnet46, .sonnet45, .haiku45:
                 true
             case .custom: true // Assume custom models support vision
             }
@@ -271,7 +274,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public var contextLength: Int {
             switch self {
-            case .fable5, .sonnet5, .opus48, .opus47, .sonnet46: 1_000_000
+            case .opus5, .fable5, .sonnet5, .opus48, .opus47, .sonnet46: 1_000_000
             case .haiku45: 200_000
             case .opus45, .opus4, .sonnet45: 500_000
             case let .custom(id):
@@ -281,7 +284,7 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
         public var maxOutputTokens: Int {
             switch self {
-            case .fable5, .sonnet5, .opus48, .opus47: 128_000
+            case .opus5, .fable5, .sonnet5, .opus48, .opus47: 128_000
             case .sonnet46, .haiku45: 64000
             case let .custom(id):
                 Self.has128KOutput(modelId: id) ? 128_000 : 8192
@@ -344,12 +347,43 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
             }
         }
 
+        public static func isOpus5(modelId: String) -> Bool {
+            let normalized = modelId.lowercased()
+            let compactExact = normalized
+                .replacingOccurrences(of: "-", with: "")
+                .replacingOccurrences(of: "_", with: "")
+                .replacingOccurrences(of: ".", with: "")
+            let pathSegments = normalized
+                .components(separatedBy: CharacterSet(charactersIn: "/:@"))
+                .filter { !$0.isEmpty }
+            let dotSegments = pathSegments.flatMap { $0.components(separatedBy: ".") }
+                .filter { !$0.isEmpty }
+            let segments = pathSegments + dotSegments
+            let canonicalSegments: Set = [
+                "claude-opus-5",
+                "claude-opus5",
+                "opus-5",
+                "opus5",
+                "claude-opus-5-latest",
+            ]
+            return normalized == Self.opus5.modelId || segments.contains { segment in
+                if canonicalSegments.contains(segment) {
+                    return true
+                }
+                let compactSegment = segment
+                    .replacingOccurrences(of: "-", with: "")
+                    .replacingOccurrences(of: "_", with: "")
+                    .replacingOccurrences(of: ".", with: "")
+                return compactSegment == "claudeopus5" || compactSegment == "opus5"
+            } || compactExact == "claudeopus5" || compactExact == "opus5"
+        }
+
         public static func hasMillionTokenContext(modelId: String) -> Bool {
-            self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId)
+            self.isOpus5(modelId: modelId) || self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId)
         }
 
         public static func hasDefaultAdaptiveThinking(modelId: String) -> Bool {
-            self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId)
+            self.isOpus5(modelId: modelId) || self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId)
         }
 
         public static func has128KOutput(modelId: String) -> Bool {
@@ -386,7 +420,8 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
         }
 
         public static func hasStreamingRefusalRisk(modelId: String) -> Bool {
-            self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId) || self.isOpus48(modelId: modelId)
+            self.isOpus5(modelId: modelId) || self.isFable(modelId: modelId) || self.isSonnet5(modelId: modelId) ||
+                self.isOpus48(modelId: modelId)
         }
     }
 
@@ -1090,13 +1125,13 @@ public enum LanguageModel: Sendable, CustomStringConvertible, Hashable {
 
     // MARK: - Default Model
 
-    public static let `default`: LanguageModel = .anthropic(.opus48)
+    public static let `default`: LanguageModel = .anthropic(.opus5)
     public static let defaultStreaming: LanguageModel = .openai(.gpt55)
 
     // MARK: - Convenience Static Properties
 
-    /// Default Claude model (Opus 4.8)
-    public static let claude: LanguageModel = .anthropic(.opus48)
+    /// Default Claude model (Opus 5)
+    public static let claude: LanguageModel = .anthropic(.opus5)
 
     /// Default Grok model (Grok 4.3)
     public static let grok4: LanguageModel = .grok(.grok43)
@@ -1592,6 +1627,22 @@ extension LanguageModel {
         if
             matchesExactAlias(
                 [
+                    "claude-opus-5",
+                    "claude-opus5",
+                    "claude-opus-5-latest",
+                    "opus-5",
+                    "opus.5",
+                    "opus5",
+                ],
+                compactAliases: ["claudeopus5", "opus5"],
+            )
+        {
+            return .anthropic(.opus5)
+        }
+
+        if
+            matchesExactAlias(
+                [
                     "claude-opus-4-8",
                     "claude-opus-4.8",
                     "opus-4-8",
@@ -1665,17 +1716,20 @@ extension LanguageModel {
         }
 
         let genericClaudeIdentifiers: Set = [
+            "anthropic",
             "claude",
+            "claude-opus",
             "claudelatest",
             "claude-latest",
             "claude_latest",
             "claude-default",
             "claude_default",
+            "opus",
         ]
 
         let canonicalForms = [normalized, dashed, compact]
         if canonicalForms.contains(where: { genericClaudeIdentifiers.contains($0) }) {
-            return .anthropic(.opus48)
+            return .anthropic(.opus5)
         }
 
         // MARK: Google models

--- a/Sources/Tachikoma/Models/ModelSelection.swift
+++ b/Sources/Tachikoma/Models/ModelSelection.swift
@@ -180,6 +180,8 @@ public struct ModelSelector {
     private static func parseAnthropicModel(_ input: String) -> Model.Anthropic? {
         switch input {
         // Direct matches
+        case "claude-opus-5", "claude-opus5", "claude-opus-5-latest", "opus-5", "opus.5", "opus5":
+            return .opus5
         case "claude-fable-5", "claude-fable-5-latest", "fable-5", "fable.5", "fable5", "fable":
             return .fable5
         case "claude-sonnet-5", "sonnet-5", "sonnet.5", "sonnet5":
@@ -196,16 +198,16 @@ public struct ModelSelector {
         case "claude-sonnet-4-5-20250929", "claude-sonnet-4.5":
             return .sonnet45
         // Shortcuts
-        case "claude":
-            return .opus48
+        case "claude", "claude-latest", "claude_latest", "claudelatest", "claude-default", "claude_default":
+            return .opus5
         case "claude-opus", "opus":
-            return .opus48
+            return .opus5
         case "claude-sonnet", "sonnet":
             return .sonnet5
         case "claude-haiku", "haiku":
             return .haiku45
         case "anthropic":
-            return .opus48
+            return .opus5
         default:
             // Check if it's a Claude model ID
             if self.isUnsupportedLegacyAnthropicModel(input) {
@@ -583,7 +585,7 @@ public func getAllAvailableModels() -> String {
     )
 
     output += "\nShortcuts:\n"
-    output += "  • claude, claude-opus, opus → claude-opus-4-8\n"
+    output += "  • claude, claude-opus, opus → claude-opus-5\n"
     output += "  • fable → claude-fable-5\n"
     output += "  • gpt → gpt-5.5\n"
     output += "  • gemini → gemini-3.5-flash\n"

--- a/Sources/Tachikoma/Providers/ProviderParser.swift
+++ b/Sources/Tachikoma/Providers/ProviderParser.swift
@@ -286,13 +286,18 @@ public enum ProviderParser {
         }
 
         return switch normalized {
+        case "claude-opus-5", "claude-opus5", "claude-opus-5-latest", "opus-5", "opus.5", "opus5":
+            .anthropic(.opus5)
         case "claude-fable-5", "claude-fable-5-latest", "fable-5", "fable.5", "fable5", "fable":
             .anthropic(.fable5)
         case "claude-sonnet-5", "sonnet-5", "sonnet.5", "sonnet5", "sonnet":
             .anthropic(.sonnet5)
         case "claude-opus-4-8", "claude-opus-4.8", "claude-opus-4-8-latest", "opus-4-8", "opus-4.8",
-             "opus48", "claude", "claude-latest", "claude_latest", "claudelatest", "claude-default", "claude_default":
+             "opus48":
             .anthropic(.opus48)
+        case "anthropic", "claude", "claude-opus", "opus", "claude-latest", "claude_latest", "claudelatest",
+             "claude-default", "claude_default":
+            .anthropic(.opus5)
         case "claude-opus-4-7", "claude-opus-4.7", "claude-opus-4-7-latest", "opus-4-7", "opus-4.7", "opus47":
             .anthropic(.opus47)
         case "claude-opus-4-5", "claude-opus-4.5", "claude-opus-4-5-latest", "opus-4-5", "opus-4.5", "opus45":
@@ -427,7 +432,7 @@ public enum ProviderParser {
         -> LanguageModel
     {
         if hasAnthropic {
-            .anthropic(.opus48)
+            .anthropic(.opus5)
         } else if hasOpenAI {
             .openai(.gpt55)
         } else if hasGrok {

--- a/Sources/Tachikoma/Utilities/UsageTracking.swift
+++ b/Sources/Tachikoma/Utilities/UsageTracking.swift
@@ -566,6 +566,7 @@ public struct ModelCostCalculator: Sendable {
         // Anthropic Pricing (as of 2026)
         case let .anthropic(anthropicModel):
             switch anthropicModel {
+            case .opus5: (5.00, 25.00)
             case .fable5: (10.00, 50.00)
             case .sonnet5: self.sonnet5Pricing()
             case .opus48: (5.00, 25.00)
@@ -576,7 +577,9 @@ public struct ModelCostCalculator: Sendable {
             case .sonnet45: (4.00, 18.00)
             case .haiku45: (1.20, 6.00)
             case let .custom(id):
-                if LanguageModel.Anthropic.isFable(modelId: id) {
+                if LanguageModel.Anthropic.isOpus5(modelId: id) {
+                    (5.00, 25.00)
+                } else if LanguageModel.Anthropic.isFable(modelId: id) {
                     (10.00, 50.00)
                 } else if LanguageModel.Anthropic.isSonnet5(modelId: id) {
                     self.sonnet5Pricing()

--- a/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
+++ b/Tests/TachikomaTests/Core/LanguageModelCoverageTests.swift
@@ -34,6 +34,7 @@ struct LanguageModelCoverageTests {
 
     @Test
     func `Anthropic enum exposes properties`() {
+        #expect(LanguageModel.Anthropic.allCases.first == .opus5)
         #expect(LanguageModel.Anthropic.allCases.contains(.sonnet5))
         for model in LanguageModel.Anthropic.allCases {
             #expect(!model.modelId.isEmpty)

--- a/Tests/TachikomaTests/Core/MinimalModernAPITests.swift
+++ b/Tests/TachikomaTests/Core/MinimalModernAPITests.swift
@@ -35,10 +35,10 @@ struct MinimalModernAPITests {
         let defaultModel = Model.default
         // Should compile without errors
         switch defaultModel {
-        case .anthropic(.opus48):
+        case .anthropic(.opus5):
             break // Expected default
         default:
-            Issue.record("Expected default to be Anthropic Opus 4.8")
+            Issue.record("Expected default to be Anthropic Opus 5")
         }
     }
 

--- a/Tests/TachikomaTests/Core/ModelCapabilitiesTests.swift
+++ b/Tests/TachikomaTests/Core/ModelCapabilitiesTests.swift
@@ -64,6 +64,7 @@ enum ModelCapabilitiesTests {
         @Test
         func `Claude models support thinking`() {
             let models: [LanguageModel] = [
+                .anthropic(.opus5),
                 .anthropic(.fable5),
                 .anthropic(.sonnet5),
                 .anthropic(.opus47),
@@ -84,6 +85,7 @@ enum ModelCapabilitiesTests {
         @Test
         func `Current adaptive Claude models reject sampling options`() {
             for model in [
+                LanguageModel.anthropic(.opus5),
                 LanguageModel.anthropic(.fable5),
                 .anthropic(.sonnet5),
                 .anthropic(.opus47),

--- a/Tests/TachikomaTests/Core/ModelParsingTests.swift
+++ b/Tests/TachikomaTests/Core/ModelParsingTests.swift
@@ -90,6 +90,35 @@ struct ModelParsingTests {
     }
 
     @Test
+    func `parse Claude Opus 5 aliases and properties`() throws {
+        let aliases = [
+            "claude-opus-5",
+            "claude-opus5",
+            "opus-5",
+            "opus5",
+            "claude-opus-5-latest",
+        ]
+
+        for alias in aliases {
+            #expect(LanguageModel.parse(from: alias) == .anthropic(.opus5))
+            #expect(try ModelSelector.parseModel(alias) == .anthropic(.opus5))
+            #expect(ProviderParser.determineDefaultModel(
+                from: "anthropic/\(alias)",
+                hasOpenAI: false,
+                hasAnthropic: true,
+            ) == .anthropic(.opus5))
+        }
+
+        #expect(LanguageModel.Anthropic.opus5.modelId == "claude-opus-5")
+        #expect(LanguageModel.Anthropic.opus5.contextLength == 1_000_000)
+        #expect(LanguageModel.Anthropic.opus5.maxOutputTokens == 128_000)
+        #expect(LanguageModel.Anthropic.opus5.supportsVision)
+        #expect(LanguageModel.Anthropic.opus5.supportsTools)
+        #expect(LanguageModel.Anthropic.allCases.first == .opus5)
+        #expect(LanguageModel.Anthropic.allCases.contains(.opus5))
+    }
+
+    @Test
     func `parse Claude Sonnet 5 model id`() throws {
         #expect(LanguageModel.parse(from: "claude-sonnet-5") == .anthropic(.sonnet5))
         #expect(LanguageModel.parse(from: "anthropic/claude-sonnet-5") == .anthropic(.sonnet5))
@@ -100,9 +129,16 @@ struct ModelParsingTests {
     }
 
     @Test
-    func `parse Claude Opus 4.8 model id`() {
-        let parsed = LanguageModel.parse(from: "claude-opus-4-8")
-        #expect(parsed == .anthropic(.opus48))
+    func `parse Claude Opus 4.8 model id`() throws {
+        for alias in ["claude-opus-4-8", "claude-opus-4.8", "opus-4-8", "opus-4.8", "opus48"] {
+            #expect(LanguageModel.parse(from: alias) == .anthropic(.opus48))
+            #expect(try ModelSelector.parseModel(alias) == .anthropic(.opus48))
+            #expect(ProviderParser.determineDefaultModel(
+                from: "anthropic/\(alias)",
+                hasOpenAI: false,
+                hasAnthropic: true,
+            ) == .anthropic(.opus48))
+        }
         #expect(LanguageModel.parse(from: "my-opus48-distill") == nil)
     }
 
@@ -114,9 +150,13 @@ struct ModelParsingTests {
 
     @Test
     func `parse shorthand Claude alias`() throws {
-        let parsed = LanguageModel.parse(from: "claude")
-        #expect(parsed == .anthropic(.opus48))
-        #expect(try ModelSelector.parseModel("anthropic") == .anthropic(.opus48))
+        for alias in ["claude", "opus", "claude-latest", "claude-default"] {
+            #expect(LanguageModel.parse(from: alias) == .anthropic(.opus5))
+            #expect(try ModelSelector.parseModel(alias) == .anthropic(.opus5))
+        }
+        #expect(try ModelSelector.parseModel("anthropic") == .anthropic(.opus5))
+        #expect(LanguageModel.default == .anthropic(.opus5))
+        #expect(LanguageModel.claude == .anthropic(.opus5))
     }
 
     @Test

--- a/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
+++ b/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
@@ -148,6 +148,86 @@ struct AnthropicInterleavedDefaultsTests {
     }
 
     @Test
+    func `Opus 5 request strips unsupported sampling and uses adaptive thinking`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .opus5, configuration: config)
+
+        let settings = GenerationSettings(
+            maxTokens: 128_000,
+            temperature: 0.7,
+            topP: 0.9,
+            topK: 40,
+            reasoningEffort: .max,
+            providerOptions: .init(anthropic: .init(thinking: .enabled(budgetTokens: 12000))),
+        )
+
+        let request = ProviderRequest(
+            messages: [.user("hi")],
+            settings: settings,
+        )
+
+        let urlRequest = try provider.makeURLRequest(for: request, stream: false)
+        let body = try #require(urlRequest.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        #expect(json["model"] as? String == "claude-opus-5")
+        #expect(json["temperature"] == nil)
+        #expect(json["top_p"] == nil)
+        #expect(json["top_k"] == nil)
+        let thinking = try #require(json["thinking"] as? [String: Any])
+        #expect(thinking["type"] as? String == "adaptive")
+        #expect(thinking["budget_tokens"] == nil)
+        let outputConfig = try #require(json["output_config"] as? [String: Any])
+        #expect(outputConfig["effort"] as? String == "max")
+        #expect(json["max_tokens"] as? Int == 128_000)
+    }
+
+    @Test
+    func `Opus 5 rejects disabled thinking above high effort`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .opus5, configuration: config)
+
+        for effort in [ReasoningEffort.xhigh, .max] {
+            #expect(throws: TachikomaError.self) {
+                _ = try provider.makeURLRequest(
+                    for: ProviderRequest(
+                        messages: [.user("hi")],
+                        settings: GenerationSettings(
+                            maxTokens: 64,
+                            reasoningEffort: effort,
+                            providerOptions: .init(anthropic: .init(thinking: .disabled)),
+                        ),
+                    ),
+                    stream: false,
+                )
+            }
+        }
+    }
+
+    @Test
+    func `Custom Opus 5 model id uses adaptive thinking and extended effort`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .custom("claude-opus-5"), configuration: config)
+        let request = ProviderRequest(
+            messages: [.user("hi")],
+            settings: GenerationSettings(
+                maxTokens: 64,
+                reasoningEffort: .max,
+                providerOptions: .init(anthropic: .init(thinking: .enabled(budgetTokens: 12000))),
+            ),
+        )
+
+        let body = try #require(provider.makeURLRequest(for: request, stream: false).httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let thinking = try #require(json["thinking"] as? [String: Any])
+        let outputConfig = try #require(json["output_config"] as? [String: Any])
+
+        #expect(thinking["type"] as? String == "adaptive")
+        #expect(thinking["budget_tokens"] == nil)
+        #expect(outputConfig["effort"] as? String == "max")
+    }
+
+    @Test
     func `Fable 5 request omits thinking config and uses effort output config`() throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
         let provider = try AnthropicProvider(model: .fable5, configuration: config)
@@ -215,7 +295,7 @@ struct AnthropicInterleavedDefaultsTests {
     func `Opus long output requests extend non-streaming timeout`() throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
 
-        for model in [LanguageModel.Anthropic.opus47, .opus48] {
+        for model in [LanguageModel.Anthropic.opus5, .opus47, .opus48] {
             let provider = try AnthropicProvider(model: model, configuration: config)
             let urlRequest = try provider.makeURLRequest(
                 for: ProviderRequest(
@@ -456,7 +536,8 @@ struct AnthropicInterleavedDefaultsTests {
     func `Extended effort levels follow the Anthropic model support matrix`() throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
         for (model, effort) in [
-            (LanguageModel.Anthropic.fable5, ReasoningEffort.xhigh),
+            (LanguageModel.Anthropic.opus5, ReasoningEffort.max),
+            (.fable5, .xhigh),
             (.opus48, .xhigh),
             (.opus47, .xhigh),
             (.sonnet46, .max),
@@ -943,6 +1024,7 @@ struct AnthropicInterleavedDefaultsTests {
 
     @Test
     func `Current Anthropic models expose documented output caps`() {
+        #expect(LanguageModel.Anthropic.opus5.maxOutputTokens == 128_000)
         #expect(LanguageModel.Anthropic.fable5.maxOutputTokens == 128_000)
         #expect(LanguageModel.Anthropic.sonnet5.maxOutputTokens == 128_000)
         #expect(LanguageModel.Anthropic.opus47.maxOutputTokens == 128_000)
@@ -954,11 +1036,14 @@ struct AnthropicInterleavedDefaultsTests {
     @Test
     func `Refusal-prone Anthropic streaming is disabled until rollback is supported`() async throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let opus5Provider = try AnthropicProvider(model: .opus5, configuration: config)
         let provider = try AnthropicProvider(model: .fable5, configuration: config)
         let sonnetProvider = try AnthropicProvider(model: .sonnet5, configuration: config)
         let opusProvider = try AnthropicProvider(model: .opus48, configuration: config)
 
+        #expect(opus5Provider.capabilities.supportsStreaming == false)
         #expect(provider.capabilities.supportsStreaming == false)
+        #expect(LanguageModel.anthropic(.opus5).supportsStreaming == false)
         #expect(LanguageModel.anthropic(.fable5).supportsStreaming == false)
         #expect(sonnetProvider.capabilities.supportsStreaming == false)
         #expect(opusProvider.capabilities.supportsStreaming == false)
@@ -968,6 +1053,9 @@ struct AnthropicInterleavedDefaultsTests {
         #expect(LanguageModel.anthropic(.sonnet46).supportsStreaming == true)
         #expect(LanguageModel.anthropic(.sonnet45).supportsStreaming == true)
         #expect(LanguageModel.anthropic(.haiku45).supportsStreaming == true)
+        await #expect(throws: TachikomaError.self) {
+            _ = try await opus5Provider.streamText(request: ProviderRequest(messages: [.user("hi")]))
+        }
         await #expect(throws: TachikomaError.self) {
             _ = try await provider.streamText(request: ProviderRequest(messages: [.user("hi")]))
         }
@@ -985,6 +1073,14 @@ struct AnthropicInterleavedDefaultsTests {
         #expect(LanguageModel.Anthropic.isOpus48(modelId: "anthropic/claude-opus-4.8") == true)
         #expect(LanguageModel.Anthropic.isOpus48(modelId: "my-opus48-distill") == false)
         #expect(LanguageModel.Anthropic.isOpus48(modelId: "opus480") == false)
+    }
+
+    @Test
+    func `Opus 5 detection avoids substring false positives`() {
+        #expect(LanguageModel.Anthropic.isOpus5(modelId: "claude-opus-5") == true)
+        #expect(LanguageModel.Anthropic.isOpus5(modelId: "anthropic/claude-opus5") == true)
+        #expect(LanguageModel.Anthropic.isOpus5(modelId: "my-opus5-distill") == false)
+        #expect(LanguageModel.Anthropic.isOpus5(modelId: "opus50") == false)
     }
 
     @Test

--- a/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
+++ b/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
@@ -183,28 +183,6 @@ struct AnthropicInterleavedDefaultsTests {
     }
 
     @Test
-    func `Opus 5 rejects disabled thinking above high effort`() throws {
-        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
-        let provider = try AnthropicProvider(model: .opus5, configuration: config)
-
-        for effort in [ReasoningEffort.xhigh, .max] {
-            #expect(throws: TachikomaError.self) {
-                _ = try provider.makeURLRequest(
-                    for: ProviderRequest(
-                        messages: [.user("hi")],
-                        settings: GenerationSettings(
-                            maxTokens: 64,
-                            reasoningEffort: effort,
-                            providerOptions: .init(anthropic: .init(thinking: .disabled)),
-                        ),
-                    ),
-                    stream: false,
-                )
-            }
-        }
-    }
-
-    @Test
     func `Custom Opus 5 model id uses adaptive thinking and extended effort`() throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
         let provider = try AnthropicProvider(model: .custom("claude-opus-5"), configuration: config)

--- a/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
+++ b/Tests/TachikomaTests/Utilities/UsageTrackingTests.swift
@@ -163,6 +163,11 @@ struct UsageTrackingTests {
         #expect(customClaudeFableCost.output == 50.00)
         #expect(customClaudeFableCost.total == 60.00)
 
+        let claudeOpus5Cost = calculator.calculateCost(for: .anthropic(.opus5), usage: usage)
+        #expect(claudeOpus5Cost.input == 5.00)
+        #expect(claudeOpus5Cost.output == 25.00)
+        #expect(claudeOpus5Cost.total == 30.00)
+
         let claudeOpusCost = calculator.calculateCost(for: .anthropic(.opus48), usage: usage)
         #expect(claudeOpusCost.input == 5.00)
         #expect(claudeOpusCost.output == 25.00)

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,7 +4,7 @@ Tachikoma ships with a built-in model catalog (`CaseIterable` enums) plus suppor
 
 ## Default
 
-- `LanguageModel.default`: `claude-opus-4-8`
+- `LanguageModel.default`: `claude-opus-5`
 - `LanguageModel.defaultStreaming`: `gpt-5.5`
 
 ## OpenAI (`LanguageModel.OpenAI`)
@@ -19,6 +19,7 @@ Notes:
 
 ## Anthropic (`LanguageModel.Anthropic`)
 
+- `claude-opus-5` (1M context, 128K max output, non-streaming until refusal rollback is streaming-safe)
 - `claude-sonnet-5` (1M context, 128K max output)
 - `claude-fable-5` (1M context, 128K max output, non-streaming, explicit opt-in)
 - `claude-opus-4-8` (1M context, 128K max output, non-streaming until refusal rollback is streaming-safe)


### PR DESCRIPTION
## Summary

- add first-class `claude-opus-5` model metadata, capabilities, pricing, parsing aliases, and Anthropic request behavior
- make Opus 5 the default Anthropic flagship while preserving every explicit Opus 4.8 alias
- cover adaptive thinking, extended effort, custom model IDs, output limits, streaming safety, and invalid disabled-thinking combinations

## Default alias change

The generation-agnostic aliases `claude`, `claude-latest`, `claude-default`, and `opus` now resolve to `.opus5`. Explicit `claude-opus-4-8`, `opus-4-8`, and `opus48` spellings continue to resolve to `.opus48` unchanged.

## Proof

- `swift build`
- `swift test`
- `swiftformat --lint .`
- `swiftlint lint --strict`
- `/Users/steipete/.codex/skills/agent-scripts/autoreview/scripts/autoreview --mode local --stream-engine-output`
