### PR TITLE
fix(mcp): reject unsafe numeric arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- MCP tool arguments now reject non-finite numbers and lossy or overflowing integer conversions instead of truncating or trapping.
 - OpenAI Responses tools now preserve omission-based optional parameters instead of having automatic strict-schema normalization force fabricated argument values.
 - OpenAI Responses tool errors now keep their diagnostic output without sending an unsupported `failed` status that caused request-level errors.
 

--- a/Sources/TachikomaMCP/Protocol/MCPTool.swift
+++ b/Sources/TachikomaMCP/Protocol/MCPTool.swift
@@ -100,9 +100,10 @@ public struct ToolArguments: Sendable {
         case let .int(num):
             return Double(num)
         case let .double(num):
-            return num
+            return num.isFinite ? num : nil
         case let .string(str):
-            return Double(str)
+            guard let number = Double(str), number.isFinite else { return nil }
+            return number
         default:
             return nil
         }
@@ -116,7 +117,7 @@ public struct ToolArguments: Sendable {
         case let .int(num):
             return num
         case let .double(num):
-            return Int(num)
+            return Int(exactly: num)
         case let .string(str):
             return Int(str)
         default:

--- a/Tests/TachikomaMCPTests/MCPClientTests.swift
+++ b/Tests/TachikomaMCPTests/MCPClientTests.swift
@@ -82,7 +82,7 @@ struct MCPClientTests {
 
         // Test getInt
         #expect(args.getInt("number") == 42)
-        #expect(args.getInt("float") == 3)
+        #expect(args.getInt("float") == nil)
         #expect(args.getInt("missing") == nil)
 
         // Test getNumber

--- a/Tests/TachikomaMCPTests/MCPToolAdapterTests.swift
+++ b/Tests/TachikomaMCPTests/MCPToolAdapterTests.swift
@@ -40,16 +40,37 @@ struct MCPToolAdapterTests {
     func `ToolArguments getInt`() {
         let args = ToolArguments(raw: [
             "int": 42,
+            "wholeDouble": 42.0,
             "double": 3.14,
             "string": "25",
             "invalid": "abc",
         ])
 
         #expect(args.getInt("int") == 42)
-        #expect(args.getInt("double") == 3)
+        #expect(args.getInt("wholeDouble") == 42)
+        #expect(args.getInt("double") == nil)
         #expect(args.getInt("string") == 25)
         #expect(args.getInt("invalid") == nil)
         #expect(args.getInt("missing") == nil)
+    }
+
+    @Test
+    func `ToolArguments reject unsafe numeric conversions`() {
+        let args = ToolArguments(value: .object([
+            "fractional": .double(1234.9),
+            "overflow": .double(1e20),
+            "infinity": .double(.infinity),
+            "nan": .double(.nan),
+            "stringOverflow": .string("100000000000000000000"),
+        ]))
+
+        #expect(args.getInt("fractional") == nil)
+        #expect(args.getInt("overflow") == nil)
+        #expect(args.getInt("infinity") == nil)
+        #expect(args.getInt("nan") == nil)
+        #expect(args.getInt("stringOverflow") == nil)
+        #expect(args.getNumber("infinity") == nil)
+        #expect(args.getNumber("nan") == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- reject non-finite MCP numeric arguments before tool execution
- require exact, in-range integer conversion instead of truncating fractional doubles
- cover whole-number compatibility plus fractional, overflow, infinity, and NaN regressions

## Why

Peekaboo uses `ToolArguments` at its MCP dispatch boundary. Lossy conversion could silently turn a fractional PID into another process identifier, while oversized doubles could reach trapping `Int` conversions in downstream automation tools. Keeping the policy in Tachikoma gives every MCP consumer the same safe numeric boundary.

## Validation

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- `TACHIKOMA_DISABLE_API_TESTS=true TACHIKOMA_TEST_MODE=mock swift test --filter TachikomaMCPTests` (44 tests)
- `TACHIKOMA_DISABLE_API_TESTS=true TACHIKOMA_TEST_MODE=mock swift test --parallel` (854 tests)
- `swift build -c release`
- autoreview clean with no accepted/actionable findings
