### PR TITLE
fix(audio): bound abort-signal timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ### Fixed
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.
-- Audio abort-signal timeouts now handle zero, negative, and non-finite durations without trapping.
+- Audio abort-signal timeouts now handle zero, negative, non-finite, and unrepresentably large durations without trapping.
 - MCP tool arguments now reject non-finite numbers and lossy or overflowing integer conversions instead of truncating or trapping.
 - OpenAI Responses tools now preserve omission-based optional parameters instead of having automatic strict-schema normalization force fabricated argument values.
 - OpenAI Responses tool errors now keep their diagnostic output without sending an unsupported `failed` status that caused request-level errors.

--- a/Sources/TachikomaAudio/Types/AudioTypes.swift
+++ b/Sources/TachikomaAudio/Types/AudioTypes.swift
@@ -337,6 +337,9 @@ public struct SpeechRequest: Sendable {
 /// Simple abort signal implementation for cancelling audio operations
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public final class AbortSignal: @unchecked Sendable {
+    // Task.sleep(for:) adds the duration to its current Int64-second clock value.
+    private static let maximumTimeoutSeconds = Double(Int64.max / 2)
+
     private var _cancelled = false
     private let lock = NSLock()
 
@@ -360,7 +363,7 @@ public final class AbortSignal: @unchecked Sendable {
     /// Create an abort signal that cancels after a timeout
     public static func timeout(_ timeInterval: TimeInterval) -> AbortSignal {
         let signal = AbortSignal()
-        guard timeInterval.isFinite, timeInterval > 0 else {
+        guard timeInterval.isFinite, timeInterval > 0, timeInterval <= Self.maximumTimeoutSeconds else {
             signal.cancel()
             return signal
         }

--- a/Tests/TachikomaTests/Audio/AudioTypesTests.swift
+++ b/Tests/TachikomaTests/Audio/AudioTypesTests.swift
@@ -358,6 +358,20 @@ struct AudioTypesTests {
         }
 
         @Test
+        func `AbortSignal accepts the maximum supported timeout`() {
+            let signal = AbortSignal.timeout(Double(Int64.max / 2))
+
+            #expect(signal.cancelled == false)
+        }
+
+        @Test(arguments: [Double(Int64.max / 2).nextUp, Double.greatestFiniteMagnitude])
+        func `AbortSignal overflowing timeouts cancel immediately`(timeout: TimeInterval) {
+            let signal = AbortSignal.timeout(timeout)
+
+            #expect(signal.cancelled == true)
+        }
+
+        @Test
         func `AbortSignal thread safety`() async {
             let signal = AbortSignal()
 


### PR DESCRIPTION
## Summary

- Reject audio abort-signal timeouts that cannot safely fit the clock deadline representation.
- Preserve delayed cancellation for ordinary positive durations and synchronous cancellation for invalid inputs.
- Cover the supported upper boundary, its next representable `Double`, and `Double.greatestFiniteMagnitude`.
- Extend the existing Unreleased changelog entry.

## Why

The existing finite-and-positive guard still allowed extremely large finite values. Passing `Double.greatestFiniteMagnitude` to `Duration.seconds` traps during integer conversion instead of returning an error, so an untrusted timeout value could terminate the process. The bound fails closed before duration construction while retaining an operational range far beyond any meaningful timeout.

## Proof

- `swift test --filter AudioTypesTests` — 27 passed
- `TACHIKOMA_DISABLE_API_TESTS=true TACHIKOMA_TEST_MODE=mock swift test` — 813 Tachikoma tests and 45 MCP tests passed
- `swiftformat --lint .`
- `swiftlint lint --strict --quiet`
- External public-API probe confirmed delayed cancellation for normal values and immediate cancellation without a crash for invalid, adjacent-boundary, and maximum-finite values.
- Structured autoreview completed with no actionable findings.
