### PR TITLE
refactor(mcp): centralize tool result conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- MCP tool responses now preserve metadata consistently across adapter and dynamic-provider execution paths.
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.
 - Audio abort-signal timeouts now handle zero, negative, non-finite, and unrepresentably large durations without trapping.
 - MCP tool arguments now reject non-finite numbers and lossy or overflowing integer conversions instead of truncating or trapping.

--- a/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
@@ -20,8 +20,7 @@ public enum MCPToolAdapter {
                 arguments: self.convertArguments(arguments),
             )
 
-            // Convert response to AnyAgentToolValue
-            return self.convertResponse(response)
+            return response.toAnyAgentToolValue()
         }
     }
 
@@ -179,76 +178,5 @@ public enum MCPToolAdapter {
                 "fallback": String(describing: argument),
             ]
         }
-    }
-
-    /// Convert MCP ToolResponse to AnyAgentToolValue
-    private static func convertResponse(_ response: ToolResponse) -> AnyAgentToolValue {
-        if response.isError {
-            let errorMessage = response.content.compactMap { content -> String? in
-                if case let .text(text, _, _) = content {
-                    return text
-                }
-                return nil
-            }.joined(separator: "\n")
-
-            return AnyAgentToolValue(string: "Error: \(errorMessage)")
-        }
-
-        let contentValue: AnyAgentToolValue = if response.content.isEmpty {
-            AnyAgentToolValue(null: ())
-        } else if response.content.count == 1 {
-            self.convertContent(response.content[0])
-        } else {
-            AnyAgentToolValue(array: response.content.map { self.convertContent($0) })
-        }
-
-        guard let meta = response.meta else {
-            return contentValue
-        }
-
-        var payload: [String: AnyAgentToolValue] = [
-            "result": contentValue,
-            "meta": convertMetaValue(meta),
-        ]
-
-        if let text = contentValue.stringValue {
-            payload["text"] = AnyAgentToolValue(string: text)
-        }
-
-        return AnyAgentToolValue(object: payload)
-    }
-
-    private static func convertMetaValue(_ value: Value) -> AnyAgentToolValue {
-        switch value {
-        case let .string(str):
-            return AnyAgentToolValue(string: str)
-        case let .int(num):
-            return AnyAgentToolValue(int: num)
-        case let .double(num):
-            return AnyAgentToolValue(double: num)
-        case let .bool(flag):
-            return AnyAgentToolValue(bool: flag)
-        case let .array(values):
-            return AnyAgentToolValue(array: values.map { self.convertMetaValue($0) })
-        case let .object(dict):
-            var converted: [String: AnyAgentToolValue] = [:]
-            for (key, entry) in dict {
-                converted[key] = self.convertMetaValue(entry)
-            }
-            return AnyAgentToolValue(object: converted)
-        case .null:
-            return AnyAgentToolValue(null: ())
-        case let .data(mime, data):
-            return AnyAgentToolValue(object: [
-                "type": AnyAgentToolValue(string: "data"),
-                "mimeType": AnyAgentToolValue(string: mime ?? "application/octet-stream"),
-                "size": AnyAgentToolValue(int: data.count),
-            ])
-        }
-    }
-
-    /// Convert MCP Tool.Content to AnyAgentToolValue
-    private static func convertContent(_ content: MCP.Tool.Content) -> AnyAgentToolValue {
-        MCPContentBridge.convert(content)
     }
 }

--- a/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
@@ -68,8 +68,7 @@ public final class MCPToolProvider: DynamicToolProvider {
             arguments: mcpArgs,
         )
 
-        // Convert response back to AnyAgentToolValue
-        return self.convertResponseToAnyAgentToolValue(response)
+        return response.toAnyAgentToolValue()
     }
 
     /// Get all available tools as AgentTools
@@ -155,35 +154,5 @@ public final class MCPToolProvider: DynamicToolProvider {
             type: type,
             description: description,
         )
-    }
-
-    private func convertResponseToAnyAgentToolValue(_ response: ToolResponse) -> AnyAgentToolValue {
-        // If there's an error, return it as a string
-        if response.isError {
-            let errorMessage = response.content.compactMap { content -> String? in
-                if case let .text(text, _, _) = content {
-                    return text
-                }
-                return nil
-            }.joined(separator: "\n")
-
-            return AnyAgentToolValue(string: "Error: \(errorMessage)")
-        }
-
-        // Convert content to appropriate format
-        if response.content.count == 1 {
-            // Single content item
-            return self.convertContentToAnyAgentToolValue(response.content[0])
-        } else if response.content.isEmpty {
-            // No content
-            return AnyAgentToolValue(null: ())
-        } else {
-            // Multiple content items - return as array
-            return AnyAgentToolValue(array: response.content.map { self.convertContentToAnyAgentToolValue($0) })
-        }
-    }
-
-    private func convertContentToAnyAgentToolValue(_ content: MCP.Tool.Content) -> AnyAgentToolValue {
-        MCPContentBridge.convert(content)
     }
 }

--- a/Sources/TachikomaMCP/Bridge/TypeConversions.swift
+++ b/Sources/TachikomaMCP/Bridge/TypeConversions.swift
@@ -78,6 +78,10 @@ extension Value {
 
     /// Convert to Tachikoma's AnyAgentToolValue
     public func toAnyAgentToolValue() -> AnyAgentToolValue {
+        self.toAnyAgentToolValue(dataLengthKey: "dataSize")
+    }
+
+    fileprivate func toAnyAgentToolValue(dataLengthKey: String) -> AnyAgentToolValue {
         // Convert to Tachikoma's AnyAgentToolValue
         switch self {
         case let .string(str):
@@ -89,9 +93,9 @@ extension Value {
         case let .bool(bool):
             AnyAgentToolValue(bool: bool)
         case let .array(array):
-            AnyAgentToolValue(array: array.map { $0.toAnyAgentToolValue() })
+            AnyAgentToolValue(array: array.map { $0.toAnyAgentToolValue(dataLengthKey: dataLengthKey) })
         case let .object(dict):
-            AnyAgentToolValue(object: dict.mapValues { $0.toAnyAgentToolValue() })
+            AnyAgentToolValue(object: dict.mapValues { $0.toAnyAgentToolValue(dataLengthKey: dataLengthKey) })
         case .null:
             AnyAgentToolValue(null: ())
         case let .data(mimeType, data):
@@ -100,7 +104,7 @@ extension Value {
             AnyAgentToolValue(object: [
                 "type": AnyAgentToolValue(string: "data"),
                 "mimeType": AnyAgentToolValue(string: mimeType ?? "application/octet-stream"),
-                "dataSize": AnyAgentToolValue(int: data.count),
+                dataLengthKey: AnyAgentToolValue(int: data.count),
             ])
         }
     }
@@ -146,20 +150,27 @@ extension ToolResponse {
             return AnyAgentToolValue(string: "Error: \(errorMessage)")
         }
 
-        // Convert content to appropriate format
-        if content.count == 1 {
-            // Single content item
-            return self.convertContentToAnyAgentToolValue(content[0])
-        } else if content.isEmpty {
-            // No content
-            return AnyAgentToolValue(null: ())
+        let contentValue: AnyAgentToolValue = if content.isEmpty {
+            AnyAgentToolValue(null: ())
+        } else if content.count == 1 {
+            MCPContentBridge.convert(content[0])
         } else {
-            // Multiple content items - return as array
-            return AnyAgentToolValue(array: content.map { self.convertContentToAnyAgentToolValue($0) })
+            AnyAgentToolValue(array: content.map { MCPContentBridge.convert($0) })
         }
-    }
 
-    private func convertContentToAnyAgentToolValue(_ content: MCP.Tool.Content) -> AnyAgentToolValue {
-        MCPContentBridge.convert(content)
+        guard let meta else {
+            return contentValue
+        }
+
+        var payload: [String: AnyAgentToolValue] = [
+            "result": contentValue,
+            "meta": meta.toAnyAgentToolValue(dataLengthKey: "size"),
+        ]
+
+        if let text = contentValue.stringValue {
+            payload["text"] = AnyAgentToolValue(string: text)
+        }
+
+        return AnyAgentToolValue(object: payload)
     }
 }

--- a/Tests/TachikomaMCPTests/TypeConversionTests.swift
+++ b/Tests/TachikomaMCPTests/TypeConversionTests.swift
@@ -334,6 +334,35 @@ struct TypeConversionTests {
     }
 
     @Test
+    func `ToolResponse conversion preserves response metadata`() {
+        let response = ToolResponse.text(
+            "Result",
+            meta: .object([
+                "duration": .double(1.5),
+                "trace": .data(mimeType: "application/octet-stream", Data([0x01, 0x02, 0x03])),
+            ]),
+        )
+
+        let value = response.toAnyAgentToolValue()
+        let payload = value.objectValue
+
+        #expect(payload?["result"]?.stringValue == "Result")
+        #expect(payload?["text"]?.stringValue == "Result")
+        #expect(payload?["meta"]?.objectValue?["duration"]?.doubleValue == 1.5)
+        #expect(payload?["meta"]?.objectValue?["trace"]?.objectValue?["size"]?.intValue == 3)
+    }
+
+    @Test
+    func `ToolResponse error conversion retains the established string contract`() {
+        let response = ToolResponse.error("Tool failed", meta: .object(["retryable": .bool(true)]))
+
+        let value = response.toAnyAgentToolValue()
+
+        #expect(value.stringValue == "Error: Tool failed")
+        #expect(value.objectValue == nil)
+    }
+
+    @Test
     func `Round-trip conversions`() throws {
         // AnyAgentToolValue -> Value -> AnyAgentToolValue
         let originalVal = AnyAgentToolValue(object: [


### PR DESCRIPTION
## Summary

- make `ToolResponse.toAnyAgentToolValue()` the single owner for MCP error, content-cardinality, and response-metadata semantics
- route both `MCPToolAdapter` and `MCPToolProvider` through that canonical conversion
- preserve the existing adapter envelope and binary-metadata shape while fixing metadata loss in the dynamic-provider path
- remove 120 lines of duplicate result conversion code and document the user-visible fix

## Testing

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter TypeConversionTests` (10 passed)
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (813 Tachikoma tests and 47 MCP tests passed)
- source-blind external Swift-package probe against the public API: metadata-bearing text, metadata-free text, error-with-metadata, and empty-result metadata all passed
- structured autoreview: clean, no accepted/actionable findings

## Scope

No protocol, configuration, dependency, transport, or public signature changed. Error responses intentionally retain their established string form even when metadata is present.
