### PR TITLE
fix(mcp): preserve structured tool failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- MCP tool failures now retain their error status, content, structured values, and safe metadata through agent generation instead of being shaped as successful tool results.
 - MCP tool responses now preserve metadata consistently across adapter and dynamic-provider execution paths.
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.
 - Audio abort-signal timeouts now handle zero, negative, non-finite, and unrepresentably large durations without trapping.

--- a/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
+++ b/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
@@ -157,16 +157,13 @@ enum AnthropicMessageConversion {
                     switch part {
                     case let .toolResult(result):
                         // Convert tool result to Anthropic format
-                        let resultContent: String = if result.isError {
-                            result.result.stringValue ?? "Error occurred"
-                        } else {
-                            AnthropicMessageEncoding.encodeToolResult(result.result)
-                        }
+                        let resultContent = AnthropicMessageEncoding.encodeToolResult(result.result)
 
                         // Tool results need to be sent as user messages with tool_result blocks
                         content.append(.toolResult(AnthropicContent.ToolResultContent(
                             toolUseId: result.toolCallId,
                             content: resultContent,
+                            isError: result.isError ? true : nil,
                         )))
                     case let .text(text):
                         // Sometimes tool messages include text

--- a/Sources/Tachikoma/Core/Generation.swift
+++ b/Sources/Tachikoma/Core/Generation.swift
@@ -159,6 +159,7 @@ public func generateText(
             var toolResults: [AgentToolResult] = []
             for toolCall in responseToolCalls {
                 if let tool = tools?.first(where: { $0.name == toolCall.name }) {
+                    let toolResult: AgentToolResult
                     do {
                         // Debug: Log tool call details in verbose mode
                         if
@@ -186,26 +187,23 @@ public func generateText(
                         // Convert arguments to AgentToolArguments
                         let toolArguments = AgentToolArguments(toolCall.arguments)
                         let result = try await tool.execute(toolArguments, context: context)
-                        let toolResult = AgentToolResult.success(toolCallId: toolCall.id, result: result)
-                        toolResults.append(toolResult)
-
-                        // Add tool result message
-                        currentMessages.append(ModelMessage(
-                            role: .tool,
-                            content: [.toolResult(toolResult)],
-                        ))
+                        toolResult = AgentToolResult.success(toolCallId: toolCall.id, result: result)
+                    } catch let failure as AgentToolExecutionFailure {
+                        toolResult = AgentToolResult.error(
+                            toolCallId: toolCall.id,
+                            failure: failure,
+                        )
                     } catch {
-                        let errorResult = AgentToolResult.error(
+                        toolResult = AgentToolResult.error(
                             toolCallId: toolCall.id,
                             error: error.localizedDescription,
                         )
-                        toolResults.append(errorResult)
-
-                        currentMessages.append(ModelMessage(
-                            role: .tool,
-                            content: [.toolResult(errorResult)],
-                        ))
                     }
+                    toolResults.append(toolResult)
+                    currentMessages.append(ModelMessage(
+                        role: .tool,
+                        content: [.toolResult(toolResult)],
+                    ))
                 }
             }
 

--- a/Sources/Tachikoma/Core/ToolTypes.swift
+++ b/Sources/Tachikoma/Core/ToolTypes.swift
@@ -425,17 +425,66 @@ public struct AgentToolCall: Sendable, Codable, Equatable {
     }
 }
 
+/// A typed tool failure that preserves structured execution output without treating it as a success value.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public struct AgentToolExecutionFailure: Error, LocalizedError, Sendable, Codable, Equatable {
+    public let message: String
+    public let content: [AnyAgentToolValue]
+    public let structuredValue: AnyAgentToolValue?
+    public let metadata: AnyAgentToolValue?
+
+    public init(
+        message: String,
+        content: [AnyAgentToolValue] = [],
+        structuredValue: AnyAgentToolValue? = nil,
+        metadata: AnyAgentToolValue? = nil,
+    ) {
+        self.message = message
+        self.content = content
+        self.structuredValue = structuredValue
+        self.metadata = metadata
+    }
+
+    public var errorDescription: String? {
+        self.message
+    }
+
+    /// A structured result payload for preserving the failure in conversation history.
+    public var resultValue: AnyAgentToolValue {
+        var payload: [String: AnyAgentToolValue] = [
+            "error": AnyAgentToolValue(string: self.message),
+            "content": AnyAgentToolValue(array: self.content),
+        ]
+        if let structuredValue {
+            payload["structuredValue"] = structuredValue
+        }
+        if let metadata {
+            payload["metadata"] = metadata
+        }
+        return AnyAgentToolValue(object: payload)
+    }
+}
+
 /// Result of executing a tool
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct AgentToolResult: Sendable, Codable, Equatable {
     public let toolCallId: String
     public let result: AnyAgentToolValue
     public let isError: Bool
+    public let failure: AgentToolExecutionFailure?
 
     public init(toolCallId: String, result: AnyAgentToolValue, isError: Bool = false) {
         self.toolCallId = toolCallId
         self.result = result
         self.isError = isError
+        self.failure = nil
+    }
+
+    public init(toolCallId: String, failure: AgentToolExecutionFailure) {
+        self.toolCallId = toolCallId
+        self.result = failure.resultValue
+        self.isError = true
+        self.failure = failure
     }
 
     public static func success(toolCallId: String, result: AnyAgentToolValue) -> AgentToolResult {
@@ -444,6 +493,10 @@ public struct AgentToolResult: Sendable, Codable, Equatable {
 
     public static func error(toolCallId: String, error: String) -> AgentToolResult {
         AgentToolResult(toolCallId: toolCallId, result: AnyAgentToolValue(string: error), isError: true)
+    }
+
+    public static func error(toolCallId: String, failure: AgentToolExecutionFailure) -> AgentToolResult {
+        AgentToolResult(toolCallId: toolCallId, failure: failure)
     }
 }
 

--- a/Sources/Tachikoma/Providers/Anthropic/AnthropicTypes.swift
+++ b/Sources/Tachikoma/Providers/Anthropic/AnthropicTypes.swift
@@ -219,17 +219,20 @@ enum AnthropicContent: Codable {
         let type: String
         let toolUseId: String
         let content: String
+        let isError: Bool?
 
-        init(type: String = "tool_result", toolUseId: String, content: String) {
+        init(type: String = "tool_result", toolUseId: String, content: String, isError: Bool? = nil) {
             self.type = type
             self.toolUseId = toolUseId
             self.content = content
+            self.isError = isError
         }
 
         enum CodingKeys: String, CodingKey {
             case type
             case toolUseId = "tool_use_id"
             case content
+            case isError = "is_error"
         }
     }
 

--- a/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
@@ -20,7 +20,7 @@ public enum MCPToolAdapter {
                 arguments: self.convertArguments(arguments),
             )
 
-            return response.toAnyAgentToolValue()
+            return try response.toAgentToolExecutionValue()
         }
     }
 

--- a/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
@@ -68,7 +68,7 @@ public final class MCPToolProvider: DynamicToolProvider {
             arguments: mcpArgs,
         )
 
-        return response.toAnyAgentToolValue()
+        return try response.toAgentToolExecutionValue()
     }
 
     /// Get all available tools as AgentTools

--- a/Sources/TachikomaMCP/Bridge/TypeConversions.swift
+++ b/Sources/TachikomaMCP/Bridge/TypeConversions.swift
@@ -138,39 +138,80 @@ extension ToolResponse {
 
     /// Convert to Tachikoma's AnyAgentToolValue for more complex results
     public func toAnyAgentToolValue() -> AnyAgentToolValue {
-        // If there's an error, return it as a string
-        if isError {
-            let errorMessage = content.compactMap { content -> String? in
-                if case let .text(text, _, _) = content {
-                    return text
-                }
-                return nil
-            }.joined(separator: "\n")
-
-            return AnyAgentToolValue(string: "Error: \(errorMessage)")
+        if self.isError {
+            return self.legacyErrorValue()
         }
 
-        let contentValue: AnyAgentToolValue = if content.isEmpty {
+        return self.successValue(contentValues: self.convertedContent())
+    }
+
+    /// Convert a response for AgentTool execution, throwing typed MCP failures instead of returning success values.
+    public func toAgentToolExecutionValue() throws -> AnyAgentToolValue {
+        let contentValues = self.convertedContent()
+        guard !self.isError else {
+            throw AgentToolExecutionFailure(
+                message: self.failureMessage(),
+                content: contentValues,
+                structuredValue: self.structuredContent?.toAnyAgentToolValue(),
+                metadata: self.meta?.toAnyAgentToolValue(dataLengthKey: "size"),
+            )
+        }
+        return self.successValue(contentValues: contentValues)
+    }
+
+    private func convertedContent() -> [AnyAgentToolValue] {
+        self.content.map { MCPContentBridge.convert($0) }
+    }
+
+    private func successValue(contentValues: [AnyAgentToolValue]) -> AnyAgentToolValue {
+        let contentValue: AnyAgentToolValue = if contentValues.isEmpty {
             AnyAgentToolValue(null: ())
-        } else if content.count == 1 {
-            MCPContentBridge.convert(content[0])
+        } else if contentValues.count == 1 {
+            contentValues[0]
         } else {
-            AnyAgentToolValue(array: content.map { MCPContentBridge.convert($0) })
+            AnyAgentToolValue(array: contentValues)
         }
 
-        guard let meta else {
+        guard self.meta != nil || self.structuredContent != nil else {
             return contentValue
         }
 
-        var payload: [String: AnyAgentToolValue] = [
-            "result": contentValue,
-            "meta": meta.toAnyAgentToolValue(dataLengthKey: "size"),
-        ]
+        var payload: [String: AnyAgentToolValue] = ["result": contentValue]
+        if let meta = self.meta {
+            payload["meta"] = meta.toAnyAgentToolValue(dataLengthKey: "size")
+        }
+        if let structuredContent = self.structuredContent {
+            payload["structuredContent"] = structuredContent.toAnyAgentToolValue()
+        }
 
         if let text = contentValue.stringValue {
             payload["text"] = AnyAgentToolValue(string: text)
         }
 
         return AnyAgentToolValue(object: payload)
+    }
+
+    private func legacyErrorValue() -> AnyAgentToolValue {
+        let errorMessage = self.content.compactMap { content -> String? in
+            if case let .text(text, _, _) = content {
+                return text
+            }
+            return nil
+        }.joined(separator: "\n")
+        return AnyAgentToolValue(string: "Error: \(errorMessage)")
+    }
+
+    private func failureMessage() -> String {
+        let errorMessage = self.content.compactMap { content -> String? in
+            switch content {
+            case let .text(text, _, _):
+                text
+            case let .resource(resource, _, _):
+                resource.text
+            default:
+                nil
+            }
+        }.joined(separator: "\n")
+        return errorMessage.isEmpty ? "Tool execution failed" : errorMessage
     }
 }

--- a/Sources/TachikomaMCP/Client/MCPClient.swift
+++ b/Sources/TachikomaMCP/Client/MCPClient.swift
@@ -229,7 +229,7 @@ public final class MCPClient: Sendable {
         let args = ToolArguments(raw: arguments)
 
         // Send tool execution request
-        let response: ToolCallResponse = try await transport.sendRequest(
+        let response: CallTool.Result = try await transport.sendRequest(
             method: "tools/call",
             params: ToolCallParams(
                 name: name,
@@ -238,10 +238,7 @@ public final class MCPClient: Sendable {
         )
 
         // Convert response to ToolResponse
-        return ToolResponse(
-            content: response.content,
-            isError: response.isError ?? false,
-        )
+        return ToolResponse(callToolResult: response)
     }
 }
 
@@ -303,11 +300,6 @@ struct ToolsListResponse: Codable {
 struct ToolCallParams: Codable {
     let name: String
     let arguments: Value
-}
-
-struct ToolCallResponse: Codable {
-    let content: [MCP.Tool.Content]
-    let isError: Bool?
 }
 
 // MARK: - Errors

--- a/Sources/TachikomaMCP/Protocol/MCPTool.swift
+++ b/Sources/TachikomaMCP/Protocol/MCPTool.swift
@@ -203,11 +203,34 @@ public struct ToolResponse: Sendable {
     public let content: [MCP.Tool.Content]
     public let isError: Bool
     public let meta: Value?
+    public let structuredContent: Value?
 
     public init(content: [MCP.Tool.Content], isError: Bool = false, meta: Value? = nil) {
         self.content = content
         self.isError = isError
         self.meta = meta
+        self.structuredContent = nil
+    }
+
+    public init(
+        content: [MCP.Tool.Content],
+        isError: Bool = false,
+        meta: Value? = nil,
+        structuredContent: Value?,
+    ) {
+        self.content = content
+        self.isError = isError
+        self.meta = meta
+        self.structuredContent = structuredContent
+    }
+
+    public init(callToolResult result: CallTool.Result) {
+        self.init(
+            content: result.content,
+            isError: result.isError ?? false,
+            meta: result._meta.map { .object($0.fields) },
+            structuredContent: result.structuredContent,
+        )
     }
 
     /// Create a text response

--- a/Tests/TachikomaMCPTests/MCPClientTests.swift
+++ b/Tests/TachikomaMCPTests/MCPClientTests.swift
@@ -168,6 +168,8 @@ struct MCPClientTests {
 
     @Test
     func `ToolResponse creation methods`() {
+        let legacyInitializer: ([MCP.Tool.Content], Bool, Value?) -> ToolResponse =
+            ToolResponse.init(content:isError:meta:)
         // Text response
         let textResponse = ToolResponse.text("Success")
         #expect(textResponse.content.count == 1)
@@ -204,6 +206,7 @@ struct MCPClientTests {
             .text(text: "Part 2", annotations: nil, _meta: nil),
         ])
         #expect(multiResponse.content.count == 2)
+        #expect(legacyInitializer([], false, nil).content.isEmpty)
     }
 
     @Test
@@ -222,6 +225,22 @@ struct MCPClientTests {
         } else {
             Issue.record("Expected metadata object")
         }
+    }
+
+    @Test
+    func `CallTool result conversion preserves structured content and metadata`() {
+        let result = CallTool.Result(
+            content: [.text(text: "failed", annotations: nil, _meta: nil)],
+            structuredContent: .object(["code": .int(42)]),
+            isError: true,
+            _meta: Metadata(additionalFields: ["retrySafe": .bool(false)]),
+        )
+
+        let response = ToolResponse(callToolResult: result)
+
+        #expect(response.isError == true)
+        #expect(response.structuredContent == .object(["code": .int(42)]))
+        #expect(response.meta == .object(["retrySafe": .bool(false)]))
     }
 
     @Test

--- a/Tests/TachikomaMCPTests/TypeConversionTests.swift
+++ b/Tests/TachikomaMCPTests/TypeConversionTests.swift
@@ -353,6 +353,77 @@ struct TypeConversionTests {
     }
 
     @Test
+    func `Agent tool success conversion preserves cardinality`() throws {
+        let empty = try ToolResponse(content: []).toAgentToolExecutionValue()
+        let single = try ToolResponse.text("one").toAgentToolExecutionValue()
+        let multiple = try ToolResponse.multiContent([
+            .text(text: "one", annotations: nil, _meta: nil),
+            .text(text: "two", annotations: nil, _meta: nil),
+        ]).toAgentToolExecutionValue()
+
+        #expect(empty.isNull)
+        #expect(single.stringValue == "one")
+        #expect(multiple.arrayValue?.map(\.stringValue) == ["one", "two"])
+    }
+
+    @Test
+    func `Agent tool success conversion preserves structured content and metadata`() throws {
+        let response = ToolResponse(
+            content: [.text(text: "complete", annotations: nil, _meta: nil)],
+            meta: .object(["duration": .double(0.25)]),
+            structuredContent: .object(["count": .int(2)]),
+        )
+
+        let payload = try response.toAgentToolExecutionValue().objectValue
+
+        #expect(payload?["result"]?.stringValue == "complete")
+        #expect(payload?["text"]?.stringValue == "complete")
+        #expect(payload?["structuredContent"]?.objectValue?["count"]?.intValue == 2)
+        #expect(payload?["meta"]?.objectValue?["duration"]?.doubleValue == 0.25)
+    }
+
+    @Test
+    func `Agent tool error conversion throws complete typed failure`() throws {
+        let response = ToolResponse(
+            content: [
+                .text(text: "permission denied", annotations: nil, _meta: nil),
+                .image(data: "AQID", mimeType: "image/png", annotations: nil, _meta: nil),
+                .resource(
+                    resource: .text("operator guidance", uri: "https://example.com/help", mimeType: "text/plain"),
+                    annotations: nil,
+                    _meta: nil,
+                ),
+            ],
+            isError: true,
+            meta: .object([
+                "retrySafe": .bool(false),
+                "diagnostic": .data(mimeType: "application/octet-stream", Data([1, 2, 3, 4])),
+            ]),
+            structuredContent: .object(["code": .string("permission_denied")]),
+        )
+
+        do {
+            _ = try response.toAgentToolExecutionValue()
+            Issue.record("Expected a typed tool failure")
+        } catch let failure as AgentToolExecutionFailure {
+            #expect(failure.message == "permission denied\noperator guidance")
+            #expect(failure.content.count == 3)
+            #expect(failure.content[0].stringValue == "permission denied")
+            #expect(failure.content[1].objectValue?["type"]?.stringValue == "image")
+            #expect(failure.content[1].objectValue?["data"]?.stringValue == "AQID")
+            #expect(failure.content[2].objectValue?["type"]?.stringValue == "resource")
+            #expect(failure.structuredValue?.objectValue?["code"]?.stringValue == "permission_denied")
+            #expect(failure.metadata?.objectValue?["retrySafe"]?.boolValue == false)
+            #expect(failure.metadata?.objectValue?["diagnostic"]?.objectValue?["size"]?.intValue == 4)
+            #expect(failure.metadata?.objectValue?["diagnostic"]?.objectValue?["data"] == nil)
+            #expect(failure.resultValue.objectValue?["success"] == nil)
+            #expect(failure.resultValue.objectValue?["result"] == nil)
+        } catch {
+            Issue.record("Expected AgentToolExecutionFailure, got \(error)")
+        }
+    }
+
+    @Test
     func `ToolResponse error conversion retains the established string contract`() {
         let response = ToolResponse.error("Tool failed", meta: .object(["retryable": .bool(true)]))
 

--- a/Tests/TachikomaTests/AgentToolValueTests.swift
+++ b/Tests/TachikomaTests/AgentToolValueTests.swift
@@ -264,6 +264,8 @@ struct AgentToolValueTests {
 
     @Test
     func `AgentToolResult uses AnyAgentToolValue`() {
+        let legacyInitializer: (String, AnyAgentToolValue, Bool) -> AgentToolResult =
+            AgentToolResult.init(toolCallId:result:isError:)
         let successResult = AgentToolResult.success(
             toolCallId: "call_123",
             result: AnyAgentToolValue(string: "Success!"),
@@ -281,6 +283,44 @@ struct AgentToolValueTests {
         #expect(errorResult.toolCallId == "call_456")
         #expect(errorResult.isError == true)
         #expect(errorResult.result.stringValue == "Something went wrong")
+        #expect(legacyInitializer("call_legacy", AnyAgentToolValue(string: "ok"), false).isError == false)
+    }
+
+    @Test
+    func `AgentToolExecutionFailure survives AgentToolResult coding`() throws {
+        let failure = AgentToolExecutionFailure(
+            message: "Permission denied",
+            content: [
+                AnyAgentToolValue(string: "Permission denied"),
+                AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "resource"),
+                    "uri": AnyAgentToolValue(string: "file:///redacted"),
+                ]),
+            ],
+            structuredValue: AnyAgentToolValue(object: ["code": AnyAgentToolValue(int: 403)]),
+            metadata: AnyAgentToolValue(object: ["retrySafe": AnyAgentToolValue(bool: true)]),
+        )
+        let result = AgentToolResult.error(toolCallId: "call_failure", failure: failure)
+
+        #expect(failure.errorDescription == "Permission denied")
+        #expect(result.isError == true)
+        #expect(result.failure == failure)
+        #expect(result.result.objectValue?["error"]?.stringValue == "Permission denied")
+        #expect(result.result.objectValue?["content"]?.arrayValue?.count == 2)
+        #expect(result.result.objectValue?["structuredValue"]?.objectValue?["code"]?.intValue == 403)
+        #expect(result.result.objectValue?["metadata"]?.objectValue?["retrySafe"]?.boolValue == true)
+        #expect(result.result.objectValue?["success"] == nil)
+        #expect(result.result.objectValue?["result"] == nil)
+
+        let encoded = try JSONEncoder().encode(result)
+        #expect(try JSONDecoder().decode(AgentToolResult.self, from: encoded) == result)
+
+        let legacyJSON = try #require(
+            #"{"toolCallId":"legacy","result":"failed","isError":true}"#.data(using: .utf8),
+        )
+        let legacyResult = try JSONDecoder().decode(AgentToolResult.self, from: legacyJSON)
+        #expect(legacyResult.failure == nil)
+        #expect(legacyResult.result.stringValue == "failed")
     }
 
     // MARK: - AgentToolArguments Tests

--- a/Tests/TachikomaTests/Core/AgentToolExecutionFailureTests.swift
+++ b/Tests/TachikomaTests/Core/AgentToolExecutionFailureTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import Tachikoma
+
+struct AgentToolExecutionFailureTests {
+    @Test
+    func `GenerateText preserves typed tool failures`() async throws {
+        let call = AgentToolCall(id: "call-failure", name: "failing_tool", arguments: [:])
+        let providerResponse = ProviderResponse(
+            text: "",
+            finishReason: .toolCalls,
+            toolCalls: [call],
+            assistantMessages: [ModelMessage(role: .assistant, content: [.toolCall(call)])],
+        )
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setProviderFactoryOverride { _, _ in FailureProvider(response: providerResponse) }
+        let failure = AgentToolExecutionFailure(
+            message: "Background action denied",
+            content: [AnyAgentToolValue(string: "Background action denied")],
+            structuredValue: AnyAgentToolValue(object: ["code": AnyAgentToolValue(string: "denied")]),
+            metadata: AnyAgentToolValue(object: ["retrySafe": AnyAgentToolValue(bool: false)]),
+        )
+        let tool = AgentTool(
+            name: "failing_tool",
+            description: "Fail with structured context",
+            parameters: AgentToolParameters(),
+        ) { _ in
+            throw failure
+        }
+
+        let result = try await generateText(
+            model: .openai(.gpt55),
+            messages: [.user("run")],
+            tools: [tool],
+            maxSteps: 1,
+            configuration: configuration,
+        )
+
+        let toolResult = try #require(result.steps.first?.toolResults.first)
+        #expect(toolResult.isError == true)
+        #expect(toolResult.failure == failure)
+        #expect(toolResult.result == failure.resultValue)
+        #expect(result.messages.contains { message in
+            message.content.contains { part in
+                if case let .toolResult(messageResult) = part {
+                    return messageResult == toolResult
+                }
+                return false
+            }
+        })
+    }
+}
+
+private struct FailureProvider: ModelProvider {
+    let response: ProviderResponse
+    let modelId = "failure-provider"
+    let baseURL: String? = nil
+    let apiKey: String? = nil
+    let capabilities = ModelCapabilities()
+
+    func generateText(request _: ProviderRequest) async throws -> ProviderResponse {
+        self.response
+    }
+
+    func streamText(request _: ProviderRequest) async throws -> AsyncThrowingStream<TextStreamDelta, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish()
+        }
+    }
+}

--- a/Tests/TachikomaTests/Core/AnthropicMessageEncodingTests.swift
+++ b/Tests/TachikomaTests/Core/AnthropicMessageEncodingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Tachikoma
 
@@ -31,5 +32,65 @@ struct AnthropicMessageEncodingTests {
 
         let nullValue = AnyAgentToolValue(null: ())
         #expect(AnthropicMessageEncoding.encodeToolResult(nullValue) == "null")
+    }
+
+    @Test
+    func `encodes structured tool failures with error status`() throws {
+        let failure = AgentToolExecutionFailure(
+            message: "permission denied",
+            content: [AnyAgentToolValue(string: "permission denied")],
+            structuredValue: AnyAgentToolValue(object: ["code": AnyAgentToolValue(int: 403)]),
+            metadata: AnyAgentToolValue(object: ["retrySafe": AnyAgentToolValue(bool: false)]),
+        )
+        let result = AgentToolResult.error(toolCallId: "call-failure", failure: failure)
+        let messages = [ModelMessage(role: .tool, content: [.toolResult(result)])]
+
+        let converted = try AnthropicMessageConversion.convertMessagesToAnthropic(
+            messages,
+            thinkingEnabled: false,
+        ).1
+        let message = try #require(converted.first)
+        guard case let .toolResult(toolResult) = try #require(message.content.first) else {
+            Issue.record("Expected an Anthropic tool result")
+            return
+        }
+
+        #expect(toolResult.toolUseId == "call-failure")
+        #expect(toolResult.isError == true)
+        #expect(toolResult.content.contains("permission denied"))
+        #expect(toolResult.content.contains("structuredValue"))
+        #expect(toolResult.content.contains("retrySafe"))
+
+        let encoded = try JSONEncoder().encode(message)
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let content = try #require(json["content"] as? [[String: Any]])
+        #expect(content.first?["is_error"] as? Bool == true)
+    }
+
+    @Test
+    func `keeps successful Anthropic tool result shape`() throws {
+        let result = AgentToolResult.success(
+            toolCallId: "call-success",
+            result: AnyAgentToolValue(string: "complete"),
+        )
+        let messages = [ModelMessage(role: .tool, content: [.toolResult(result)])]
+
+        let converted = try AnthropicMessageConversion.convertMessagesToAnthropic(
+            messages,
+            thinkingEnabled: false,
+        ).1
+        let message = try #require(converted.first)
+        guard case let .toolResult(toolResult) = try #require(message.content.first) else {
+            Issue.record("Expected an Anthropic tool result")
+            return
+        }
+
+        #expect(toolResult.content == "complete")
+        #expect(toolResult.isError == nil)
+
+        let encoded = try JSONEncoder().encode(message)
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let content = try #require(json["content"] as? [[String: Any]])
+        #expect(content.first?["is_error"] == nil)
     }
 }

--- a/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
+++ b/Tests/TachikomaTests/Providers/AnthropicInterleavedDefaultsTests.swift
@@ -79,6 +79,45 @@ struct AnthropicInterleavedDefaultsTests {
     }
 
     @Test
+    func `Provider request preserves structured tool failure`() throws {
+        let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
+        let provider = try AnthropicProvider(model: .opus45, configuration: config)
+        let call = AgentToolCall(id: "call-failure", name: "background_action", arguments: [:])
+        let failure = AgentToolExecutionFailure(
+            message: "permission denied",
+            content: [AnyAgentToolValue(string: "permission denied")],
+            structuredValue: AnyAgentToolValue(object: ["code": AnyAgentToolValue(int: 403)]),
+            metadata: AnyAgentToolValue(object: ["retrySafe": AnyAgentToolValue(bool: false)]),
+        )
+        let request = ProviderRequest(messages: [
+            .user("run"),
+            ModelMessage(role: .assistant, content: [.toolCall(call)]),
+            ModelMessage(
+                role: .tool,
+                content: [.toolResult(.error(toolCallId: call.id, failure: failure))],
+            ),
+        ])
+
+        let body = try #require(provider.makeURLRequest(for: request, stream: false).httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let toolMessage = try #require(messages.last)
+        let content = try #require(toolMessage["content"] as? [[String: Any]])
+        let toolResult = try #require(content.first)
+        let resultContent = try #require(toolResult["content"] as? String)
+        let resultJSON = try #require(
+            try JSONSerialization.jsonObject(with: Data(resultContent.utf8)) as? [String: Any],
+        )
+
+        #expect(toolResult["type"] as? String == "tool_result")
+        #expect(toolResult["tool_use_id"] as? String == call.id)
+        #expect(toolResult["is_error"] as? Bool == true)
+        #expect(resultJSON["error"] as? String == "permission denied")
+        #expect((resultJSON["structuredValue"] as? [String: Any])?["code"] as? Int == 403)
+        #expect((resultJSON["metadata"] as? [String: Any])?["retrySafe"] as? Bool == false)
+    }
+
+    @Test
     func `Opus 4_7 request strips unsupported sampling and uses adaptive thinking`() throws {
         let config = TachikomaConfiguration(apiKeys: ["anthropic": "test-key"])
         let provider = try AnthropicProvider(model: .opus47, configuration: config)


### PR DESCRIPTION
## Summary

- add one public `AgentToolExecutionFailure` owner for structured tool errors and retain it on `AgentToolResult`
- preserve MCP `content`, `structuredContent`, `_meta`, and `isError` from the wire through `MCPToolAdapter`, `MCPToolProvider`, and Generation
- make MCP-backed agent execution throw typed failures instead of returning error payloads through the success path
- preserve structured failures in Anthropic tool-result JSON and send the documented `is_error: true` marker
- keep the legacy `AgentToolResult` and `ToolResponse` three-argument initializer function symbols plus the legacy string error projection

## Compatibility

- Existing `AgentToolResult.init(toolCallId:result:isError:)` and `ToolResponse.init(content:isError:meta:)` call sites and function references remain valid.
- Existing encoded `AgentToolResult` values without a failure field still decode.
- `ToolResponse.toAnyAgentToolValue()` retains its historical `Error: ...` string result for callers using it as a non-execution projection.
- Successful MCP results retain null, raw-single, and array cardinalities; structured success adds an envelope only when metadata or structured content exists.
- Typed failures use `AgentToolResult.isError` as the authority and do not add `success` or `result` fields that could make the error look successful.

## Testing

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- focused MCP conversion, core value/Codable, Generation, Anthropic encoding, and provider request suites
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (818 Tachikoma tests and 51 MCP tests passed)
- `swift build -c release -Xswiftc -warn-concurrency`
- `swift package dump-package`
- source-blind external Swift package exercised public compatibility, success cardinality, mixed text/image/resource errors, safe binary metadata, structured content, Generation persistence, and Codable round-trip
- structured autoreview: clean, no accepted/actionable findings

## Scope

No dependency, transport, configuration, or model-selection contract changed. The provider follow-up is limited to preserving structured error output already present in `AgentToolResult`.
