### PR TITLE
fix(core): preserve numeric agent tool values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Dynamic agent tool values now preserve integer `0` and `1` across Codable and Foundation JSON conversion instead of mistaking them for booleans.
 - MCP tool failures now retain their error status, content, structured values, and safe metadata through agent generation instead of being shaped as successful tool results.
 - MCP tool responses now preserve metadata consistently across adapter and dynamic-provider execution paths.
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
-- Dynamic agent tool values now preserve integer `0` and `1` across Codable and Foundation JSON conversion instead of mistaking them for booleans.
 - MCP tool failures now retain their error status, content, structured values, and safe metadata through agent generation instead of being shaped as successful tool results.
 - MCP tool responses now preserve metadata consistently across adapter and dynamic-provider execution paths.
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.

--- a/Sources/Tachikoma/Core/ToolTypes.swift
+++ b/Sources/Tachikoma/Core/ToolTypes.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 // MARK: - Core Tool Types
@@ -245,14 +246,16 @@ public struct AnyAgentToolValue: AgentToolValue, Equatable, Codable {
     public static func fromJSON(_ json: Any) throws -> Self {
         if json is NSNull {
             return AnyAgentToolValue(null: ())
-        } else if let bool = json as? Bool {
-            return AnyAgentToolValue(bool: bool)
-        } else if let int = json as? Int {
-            return AnyAgentToolValue(int: int)
-        } else if let double = json as? Double {
-            // Check if it's actually an integer
-            if double.truncatingRemainder(dividingBy: 1) == 0, double >= Double(Int.min), double <= Double(Int.max) {
-                return AnyAgentToolValue(int: Int(double))
+        } else if let number = json as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return AnyAgentToolValue(bool: number.boolValue)
+            }
+            if let int = json as? Int {
+                return AnyAgentToolValue(int: int)
+            }
+            let double = number.doubleValue
+            if let int = Int(exactly: double) {
+                return AnyAgentToolValue(int: int)
             }
             return AnyAgentToolValue(double: double)
         } else if let string = json as? String {

--- a/Sources/Tachikoma/Core/ToolTypes.swift
+++ b/Sources/Tachikoma/Core/ToolTypes.swift
@@ -341,12 +341,12 @@ public struct AnyAgentToolValue: AgentToolValue, Equatable, Codable {
 
         if container.decodeNil() {
             self.storage = .null
-        } else if let bool = try? container.decode(Bool.self) {
-            self.storage = .bool(bool)
         } else if let int = try? container.decode(Int.self) {
             self.storage = .int(int)
         } else if let double = try? container.decode(Double.self) {
             self.storage = .double(double)
+        } else if let bool = try? container.decode(Bool.self) {
+            self.storage = .bool(bool)
         } else if let string = try? container.decode(String.self) {
             self.storage = .string(string)
         } else if let array = try? container.decode([AnyAgentToolValue].self) {

--- a/Tests/TachikomaTests/AgentToolValueTests.swift
+++ b/Tests/TachikomaTests/AgentToolValueTests.swift
@@ -248,6 +248,8 @@ struct AgentToolValueTests {
         let original = AnyAgentToolValue(object: [
             "dispatch_state": AnyAgentToolValue(string: "dispatched"),
             "dispatched_unit_count": AnyAgentToolValue(int: 1),
+            "large_integer": AnyAgentToolValue(int: 9_007_199_254_740_993),
+            "maximum_integer": AnyAgentToolValue(int: .max),
             "mutation_dispatched": AnyAgentToolValue(bool: true),
             "retry_safe": AnyAgentToolValue(bool: false),
         ])
@@ -260,6 +262,19 @@ struct AgentToolValueTests {
         #expect(object["dispatched_unit_count"]?.boolValue == nil)
         #expect(object["mutation_dispatched"]?.boolValue == true)
         #expect(object["retry_safe"]?.boolValue == false)
+
+        let serialized = try JSONSerialization.data(withJSONObject: original.toJSON())
+        let foundationJSON = try JSONSerialization.jsonObject(with: serialized)
+        let converted = try AnyAgentToolValue.fromJSON(foundationJSON)
+        let convertedObject = try #require(converted.objectValue)
+        #expect(convertedObject["dispatched_unit_count"]?.intValue == 1)
+        #expect(convertedObject["dispatched_unit_count"]?.boolValue == nil)
+        #expect(convertedObject["large_integer"]?.intValue == 9_007_199_254_740_993)
+        #expect(convertedObject["maximum_integer"]?.intValue == .max)
+        #expect(convertedObject["mutation_dispatched"]?.boolValue == true)
+        #expect(convertedObject["mutation_dispatched"]?.intValue == nil)
+        #expect(convertedObject["retry_safe"]?.boolValue == false)
+        #expect(convertedObject["retry_safe"]?.intValue == nil)
     }
 
     // MARK: - AgentToolCall and AgentToolResult Tests

--- a/Tests/TachikomaTests/AgentToolValueTests.swift
+++ b/Tests/TachikomaTests/AgentToolValueTests.swift
@@ -220,6 +220,48 @@ struct AgentToolValueTests {
         }
     }
 
+    @Test
+    func `AnyAgentToolValue round trip keeps zero and one distinct from booleans`() throws {
+        let original = AnyAgentToolValue(object: [
+            "false_flag": AnyAgentToolValue(bool: false),
+            "one": AnyAgentToolValue(int: 1),
+            "true_flag": AnyAgentToolValue(bool: true),
+            "zero": AnyAgentToolValue(int: 0),
+        ])
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AnyAgentToolValue.self, from: encoded)
+        let object = try #require(decoded.objectValue)
+
+        #expect(object["zero"]?.intValue == 0)
+        #expect(object["zero"]?.boolValue == nil)
+        #expect(object["one"]?.intValue == 1)
+        #expect(object["one"]?.boolValue == nil)
+        #expect(object["false_flag"]?.boolValue == false)
+        #expect(object["false_flag"]?.intValue == nil)
+        #expect(object["true_flag"]?.boolValue == true)
+        #expect(object["true_flag"]?.intValue == nil)
+    }
+
+    @Test
+    func `Canonical dispatch count one remains an integer beside compatibility booleans`() throws {
+        let original = AnyAgentToolValue(object: [
+            "dispatch_state": AnyAgentToolValue(string: "dispatched"),
+            "dispatched_unit_count": AnyAgentToolValue(int: 1),
+            "mutation_dispatched": AnyAgentToolValue(bool: true),
+            "retry_safe": AnyAgentToolValue(bool: false),
+        ])
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AnyAgentToolValue.self, from: encoded)
+        let object = try #require(decoded.objectValue)
+
+        #expect(object["dispatched_unit_count"]?.intValue == 1)
+        #expect(object["dispatched_unit_count"]?.boolValue == nil)
+        #expect(object["mutation_dispatched"]?.boolValue == true)
+        #expect(object["retry_safe"]?.boolValue == false)
+    }
+
     // MARK: - AgentToolCall and AgentToolResult Tests
 
     @Test


### PR DESCRIPTION
## Summary

- decode integer agent tool values before booleans so JSON `0` and `1` retain their numeric type
- distinguish Foundation `CFBoolean` values from numeric `NSNumber` values during dynamic JSON conversion
- cover canonical dispatch metadata, compatibility booleans, large integers, and `Int.max`

This prevents numeric action metadata such as `dispatched_unit_count: 1` from becoming `true` while crossing Tachikoma's dynamic tool-value boundary.

## Proof

- focused `AgentToolValueTests`: 23/23
- full mock suite: 871/871
- SwiftFormat: clean
- strict SwiftLint: clean
- P0-P2 autoreview: clean at 0.94
