### PR TITLE
refactor(agent): centralize dynamic tool dispatch planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Dynamic tool aggregation now binds execution to the provider that supplied each schema, invalidates stale plans, avoids repeated discovery on registry execution, and rejects duplicate names instead of dispatching nondeterministically.
+- MCP tool arguments now use one typed conversion path across adapters, providers, managers, and transport while preserving Foundation booleans and integers exactly.
 - MCP tool failures now retain their error status, content, structured values, and safe metadata through agent generation instead of being shaped as successful tool results.
 - MCP tool responses now preserve metadata consistently across adapter and dynamic-provider execution paths.
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.

--- a/Sources/TachikomaAgent/DynamicTools.swift
+++ b/Sources/TachikomaAgent/DynamicTools.swift
@@ -20,65 +20,229 @@ public struct ToolParameter: Sendable {
 // Core dynamic tool types (DynamicToolProvider, DynamicTool, DynamicSchema) are now in Core/ToolTypes.swift
 // This file contains additional dynamic tool functionality and extensions
 
+private struct DynamicToolProviderSource: Sendable {
+    let id: String
+    let registrationID: UUID?
+    let provider: DynamicToolProvider
+}
+
+private struct ResolvedDynamicTool: Sendable {
+    let sourceID: String
+    let registrationID: UUID?
+    let registryGeneration: UUID?
+    let provider: DynamicToolProvider
+    let tool: DynamicTool
+
+    func issued(in registryGeneration: UUID) -> ResolvedDynamicTool {
+        ResolvedDynamicTool(
+            sourceID: self.sourceID,
+            registrationID: self.registrationID,
+            registryGeneration: registryGeneration,
+            provider: self.provider,
+            tool: self.tool,
+        )
+    }
+}
+
+private struct DynamicToolBindingIdentity: Sendable, Equatable {
+    let sourceID: String
+    let registrationID: UUID?
+}
+
+private enum DynamicToolBindingLookup: Sendable {
+    case uninitialized
+    case missing
+    case invalidated
+    case bound(ResolvedDynamicTool)
+}
+
+private actor DynamicToolBindingStore {
+    private var bindings: [String: ResolvedDynamicTool]?
+    private var invalidatedNames: Set<String> = []
+
+    func apply(_ resolvedTools: [ResolvedDynamicTool]) -> [String] {
+        let nextBindings = Dictionary(uniqueKeysWithValues: resolvedTools.map { ($0.tool.name, $0) })
+        if let bindings = self.bindings {
+            for (name, previous) in bindings {
+                guard let next = nextBindings[name], next.sourceID == previous.sourceID else {
+                    self.invalidatedNames.insert(name)
+                    continue
+                }
+            }
+        }
+
+        self.bindings = nextBindings
+        return nextBindings.keys.filter { self.invalidatedNames.contains($0) }.sorted()
+    }
+
+    func lookup(name: String) -> DynamicToolBindingLookup {
+        if self.invalidatedNames.contains(name) {
+            return .invalidated
+        }
+        guard let bindings = self.bindings else {
+            return .uninitialized
+        }
+        guard let binding = bindings[name] else {
+            return .missing
+        }
+        return .bound(binding)
+    }
+
+    func invalidateAll() {
+        if let bindings = self.bindings {
+            self.invalidatedNames.formUnion(bindings.keys)
+        }
+        self.bindings = nil
+    }
+}
+
+private enum DynamicToolResolver {
+    static func resolve(_ sources: [DynamicToolProviderSource]) async throws -> [ResolvedDynamicTool] {
+        var resolved: [ResolvedDynamicTool] = []
+
+        for source in sources {
+            let tools = try await source.provider.discoverTools()
+            resolved.append(contentsOf: tools.map { tool in
+                ResolvedDynamicTool(
+                    sourceID: source.id,
+                    registrationID: source.registrationID,
+                    registryGeneration: nil,
+                    provider: source.provider,
+                    tool: tool,
+                )
+            })
+        }
+
+        let duplicateGroups = Dictionary(grouping: resolved, by: \.tool.name)
+            .filter { $0.value.count > 1 }
+        guard duplicateGroups.isEmpty else {
+            let conflicts = duplicateGroups.keys.sorted().map { name in
+                let sources = duplicateGroups[name, default: []]
+                    .map(\.sourceID)
+                    .sorted()
+                    .joined(separator: ", ")
+                return "\(name) [\(sources)]"
+            }.joined(separator: "; ")
+            throw TachikomaError.toolCallFailed("Ambiguous dynamic tool names: \(conflicts)")
+        }
+
+        return resolved
+    }
+}
+
 // MARK: - Dynamic Tool Registry
 
 /// Registry for managing dynamic tool providers
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public actor DynamicToolRegistry {
-    private var providers: [String: DynamicToolProvider] = [:]
+    private struct RegisteredProvider: Sendable {
+        let registrationID: UUID
+        let provider: DynamicToolProvider
+    }
+
+    private var providers: [String: RegisteredProvider] = [:]
+    private var bindingGeneration = UUID()
+    private var bindingPlan: [String: DynamicToolBindingIdentity]?
 
     public init() {}
 
     /// Register a dynamic tool provider
     public func register(_ provider: DynamicToolProvider, id: String) {
-        // Register a dynamic tool provider
-        self.providers[id] = provider
+        self.providers[id] = RegisteredProvider(registrationID: UUID(), provider: provider)
+        self.invalidateBindings()
     }
 
     /// Unregister a provider
     public func unregister(id: String) {
-        // Unregister a provider
-        _ = self.providers.removeValue(forKey: id)
+        if self.providers.removeValue(forKey: id) != nil {
+            self.invalidateBindings()
+        }
     }
 
     /// Get all registered providers
     public var allProviders: [DynamicToolProvider] {
-        Array(self.providers.values)
+        self.providers.sorted { $0.key < $1.key }.map(\.value.provider)
     }
 
     /// Discover all tools from all providers
     public func discoverAllTools() async throws -> [DynamicTool] {
-        // Discover all tools from all providers
-        var allTools: [DynamicTool] = []
-
-        for provider in self.allProviders {
-            let tools = try await provider.discoverTools()
-            allTools.append(contentsOf: tools)
-        }
-
-        return allTools
+        try await self.resolveTools().map(\.tool)
     }
 
     /// Convert all discovered tools to AgentTools
     public func getAllAgentTools() async throws -> [AgentTool] {
-        // Convert all discovered tools to AgentTools
-        let dynamicTools = try await discoverAllTools()
+        let resolvedTools = try await self.resolveTools()
 
-        return dynamicTools.map { tool in
-            tool.toAgentTool { arguments in
-                // Find the provider that owns this tool
-                let providers = await self.allProviders
-                for provider in providers {
-                    if
-                        let providerTools = try? await provider.discoverTools(),
-                        providerTools.contains(where: { $0.name == tool.name })
-                    {
-                        return try await provider.executeTool(name: tool.name, arguments: arguments)
-                    }
-                }
-                throw TachikomaError.toolCallFailed("No provider found for tool: \(tool.name)")
+        return resolvedTools.map { resolved in
+            resolved.tool.toAgentTool { arguments in
+                try await self.execute(resolved, arguments: arguments)
             }
         }
+    }
+
+    private func resolveTools() async throws -> [ResolvedDynamicTool] {
+        let observedGeneration = self.bindingGeneration
+        let sources = self.providers.sorted { $0.key < $1.key }.map { id, registration in
+            DynamicToolProviderSource(
+                id: id,
+                registrationID: registration.registrationID,
+                provider: registration.provider,
+            )
+        }
+
+        do {
+            let resolvedTools = try await DynamicToolResolver.resolve(sources)
+            guard self.bindingGeneration == observedGeneration else {
+                throw TachikomaError.toolCallFailed("Dynamic tool registry changed during discovery")
+            }
+
+            let nextPlan = Dictionary(uniqueKeysWithValues: resolvedTools.map { resolved in
+                (
+                    resolved.tool.name,
+                    DynamicToolBindingIdentity(
+                        sourceID: resolved.sourceID,
+                        registrationID: resolved.registrationID,
+                    ),
+                )
+            })
+            if let bindingPlan = self.bindingPlan, bindingPlan != nextPlan {
+                self.bindingGeneration = UUID()
+            }
+            self.bindingPlan = nextPlan
+            let issuedGeneration = self.bindingGeneration
+            return resolvedTools.map { $0.issued(in: issuedGeneration) }
+        } catch {
+            if self.bindingGeneration == observedGeneration {
+                self.invalidateBindings()
+            }
+            throw error
+        }
+    }
+
+    private func execute(
+        _ resolved: ResolvedDynamicTool,
+        arguments: AgentToolArguments,
+    ) async throws
+        -> AnyAgentToolValue
+    {
+        guard
+            let registrationID = resolved.registrationID,
+            let registryGeneration = resolved.registryGeneration,
+            let current = self.providers[resolved.sourceID],
+            current.registrationID == registrationID,
+            self.bindingGeneration == registryGeneration else
+        {
+            throw TachikomaError.toolCallFailed(
+                "Provider registration changed for tool: \(resolved.tool.name)",
+            )
+        }
+
+        return try await current.provider.executeTool(name: resolved.tool.name, arguments: arguments)
+    }
+
+    private func invalidateBindings() {
+        self.bindingGeneration = UUID()
+        self.bindingPlan = nil
     }
 }
 
@@ -257,32 +421,61 @@ extension DynamicSchema.SchemaProperty {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct CompositeDynamicToolProvider: DynamicToolProvider {
     private let providers: [DynamicToolProvider]
+    private let bindingStore: DynamicToolBindingStore
 
     public init(providers: [DynamicToolProvider]) {
         self.providers = providers
+        self.bindingStore = DynamicToolBindingStore()
     }
 
     public func discoverTools() async throws -> [DynamicTool] {
-        var allTools: [DynamicTool] = []
-
-        for provider in self.providers {
-            let tools = try await provider.discoverTools()
-            allTools.append(contentsOf: tools)
-        }
-
-        return allTools
+        try await self.discoverAndBind().map(\.tool)
     }
 
     public func executeTool(name: String, arguments: AgentToolArguments) async throws -> AnyAgentToolValue {
-        // Try each provider until one can execute the tool
-        for provider in self.providers {
-            let tools = try await provider.discoverTools()
-            if tools.contains(where: { $0.name == name }) {
-                return try await provider.executeTool(name: name, arguments: arguments)
-            }
-        }
+        let resolved = try await self.resolvedTool(named: name)
+        return try await resolved.provider.executeTool(name: name, arguments: arguments)
+    }
 
-        throw TachikomaError.toolCallFailed("Tool not found in any provider: \(name)")
+    private func discoverAndBind() async throws -> [ResolvedDynamicTool] {
+        do {
+            let resolvedTools = try await self.resolveTools()
+            let invalidatedNames = await self.bindingStore.apply(resolvedTools)
+            guard invalidatedNames.isEmpty else {
+                throw TachikomaError.toolCallFailed(
+                    "Composite dynamic tool bindings changed: \(invalidatedNames.joined(separator: ", "))",
+                )
+            }
+            return resolvedTools
+        } catch {
+            await self.bindingStore.invalidateAll()
+            throw error
+        }
+    }
+
+    private func resolvedTool(named name: String) async throws -> ResolvedDynamicTool {
+        switch await self.bindingStore.lookup(name: name) {
+        case .uninitialized:
+            _ = try await self.discoverAndBind()
+            return try await self.resolvedTool(named: name)
+        case .missing:
+            throw TachikomaError.toolCallFailed("Tool not found in any provider: \(name)")
+        case .invalidated:
+            throw TachikomaError.toolCallFailed("Composite dynamic tool binding changed: \(name)")
+        case let .bound(resolved):
+            return resolved
+        }
+    }
+
+    private func resolveTools() async throws -> [ResolvedDynamicTool] {
+        let sources = self.providers.enumerated().map { index, provider in
+            DynamicToolProviderSource(
+                id: "provider[\(index)]",
+                registrationID: nil,
+                provider: provider,
+            )
+        }
+        return try await DynamicToolResolver.resolve(sources)
     }
 }
 

--- a/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
@@ -17,7 +17,7 @@ public enum MCPToolAdapter {
             // Execute the tool via MCP client
             let response = try await client.executeTool(
                 name: mcpTool.name,
-                arguments: self.convertArguments(arguments),
+                arguments: arguments,
             )
 
             return try response.toAgentToolExecutionValue()
@@ -152,31 +152,5 @@ public enum MCPToolAdapter {
             enumValues: enumValues,
             items: items,
         )
-    }
-
-    /// Convert Tachikoma arguments to MCP format
-    private static func convertArguments(_ arguments: AgentToolArguments) -> [String: Any] {
-        // Convert Tachikoma arguments to MCP format
-        var result: [String: Any] = [:]
-
-        for key in arguments.keys {
-            if let value = arguments[key] {
-                result[key] = self.convertArgument(value)
-            }
-        }
-
-        return result
-    }
-
-    /// Convert a single AnyAgentToolValue to Any
-    private static func convertArgument(_ argument: AnyAgentToolValue) -> Any {
-        do {
-            return try argument.toJSON()
-        } catch {
-            return [
-                "serializationError": error.localizedDescription,
-                "fallback": String(describing: argument),
-            ]
-        }
     }
 }

--- a/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolProvider.swift
@@ -54,18 +54,10 @@ public final class MCPToolProvider: DynamicToolProvider {
     ) async throws
         -> AnyAgentToolValue
     {
-        // Convert arguments to MCP format
-        var mcpArgs: [String: Any] = [:]
-        for key in arguments.keys {
-            if let value = arguments[key] {
-                mcpArgs[key] = try value.toJSON()
-            }
-        }
-
         // Execute via MCP client
         let response = try await client.executeTool(
             name: name,
-            arguments: mcpArgs,
+            arguments: arguments,
         )
 
         return try response.toAgentToolExecutionValue()

--- a/Sources/TachikomaMCP/Bridge/TypeConversions.swift
+++ b/Sources/TachikomaMCP/Bridge/TypeConversions.swift
@@ -4,21 +4,26 @@ import Tachikoma
 
 // MARK: - Type Conversion Extensions for TachikomaMCP
 
+// MARK: AgentToolArguments Extensions
+
+extension AgentToolArguments {
+    func toMCPValue() -> Value {
+        var values: [String: Value] = [:]
+        for key in self.keys {
+            if let value = self[key] {
+                values[key] = value.toValue()
+            }
+        }
+        return .object(values)
+    }
+}
+
 // MARK: ToolArguments Extensions
 
 extension ToolArguments {
     /// Initialize from Tachikoma's AgentToolArguments
     public init(from arguments: AgentToolArguments) {
-        var dict: [String: Any] = [:]
-        for key in arguments.keys {
-            guard let value = arguments[key] else { continue }
-            if let json = try? value.toJSON() {
-                dict[key] = json
-            } else {
-                dict[key] = ["serializationFailure": String(describing: value)]
-            }
-        }
-        self.init(raw: dict)
+        self.init(value: arguments.toMCPValue())
     }
 }
 
@@ -54,26 +59,7 @@ extension AnyAgentToolValue {
 extension Value {
     /// Convert from Any type
     public static func from(_ any: Any) -> Value {
-        // Convert from Any type
-        switch any {
-        case let str as String:
-            .string(str)
-        case let num as Int:
-            .int(num)
-        case let num as Double:
-            .double(num)
-        case let bool as Bool:
-            .bool(bool)
-        case let array as [Any]:
-            .array(array.map { Value.from($0) })
-        case let dict as [String: Any]:
-            .object(dict.mapValues { Value.from($0) })
-        case is NSNull:
-            .null
-        default:
-            // Fallback: convert to string representation
-            .string(String(describing: any))
-        }
+        AnyAgentToolValue.from(any).toValue()
     }
 
     /// Convert to Tachikoma's AnyAgentToolValue

--- a/Sources/TachikomaMCP/Client/MCPClient.swift
+++ b/Sources/TachikomaMCP/Client/MCPClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Logging
 import MCP
+import Tachikoma
 
 /// Shared JSON-RPC types for HTTP transport
 struct HTTPJSONRPCRequest<P: Encodable>: Encodable {
@@ -216,6 +217,14 @@ public final class MCPClient: Sendable {
 
     /// Execute a tool by name
     public func executeTool(name: String, arguments: [String: Any]) async throws -> ToolResponse {
+        try await self.executeTool(name: name, arguments: ToolArguments(raw: arguments).rawValue)
+    }
+
+    func executeTool(name: String, arguments: AgentToolArguments) async throws -> ToolResponse {
+        try await self.executeTool(name: name, arguments: arguments.toMCPValue())
+    }
+
+    private func executeTool(name: String, arguments: Value) async throws -> ToolResponse {
         // Execute a tool by name
         guard let transport = await state.getTransport() else {
             throw MCPError.notConnected
@@ -225,15 +234,12 @@ public final class MCPClient: Sendable {
             throw MCPError.notConnected
         }
 
-        // Convert arguments to MCP Value
-        let args = ToolArguments(raw: arguments)
-
         // Send tool execution request
         let response: CallTool.Result = try await transport.sendRequest(
             method: "tools/call",
             params: ToolCallParams(
                 name: name,
-                arguments: args.rawValue,
+                arguments: arguments,
             ),
         )
 

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -220,13 +220,7 @@ public final class TachikomaMCPClientManager {
         }
         // Bridge via TachikomaMCP's adapter to ensure Sendable arguments
         let agentArgs = AgentToolArguments(arguments.mapValues { AnyAgentToolValue.from($0) })
-        var mcpArgs: [String: Any] = [:]
-        for key in agentArgs.keys {
-            if let v = agentArgs[key] {
-                mcpArgs[key] = try v.toJSON()
-            }
-        }
-        return try await client.executeTool(name: toolName, arguments: mcpArgs)
+        return try await client.executeTool(name: toolName, arguments: agentArgs)
     }
 
     /// Get external tools grouped by server name

--- a/Sources/TachikomaMCP/Protocol/MCPTool.swift
+++ b/Sources/TachikomaMCP/Protocol/MCPTool.swift
@@ -24,7 +24,7 @@ public struct ToolArguments: Sendable {
 
     public init(raw: [String: Any]) {
         // Convert [String: Any] to Value for Sendable compliance
-        self.raw = .object(raw.mapValues { convertToValue($0) })
+        self.raw = .object(raw.mapValues { Value.from($0) })
     }
 
     public init(value: Value) {
@@ -172,29 +172,6 @@ private func ValueToAny(_ value: Value) -> Any {
     case let .object(obj): obj.mapValues { ValueToAny($0) }
     case .null: NSNull()
     case let .data(mime, data): ["type": "data", "mimeType": mime ?? "application/octet-stream", "data": data]
-    }
-}
-
-/// Helper function to convert Any to Value
-private func convertToValue(_ value: Any) -> Value {
-    switch value {
-    case let string as String:
-        .string(string)
-    case let number as Int:
-        .int(number)
-    case let number as Double:
-        .double(number)
-    case let bool as Bool:
-        .bool(bool)
-    case let array as [Any]:
-        .array(array.map { convertToValue($0) })
-    case let dict as [String: Any]:
-        .object(dict.mapValues { convertToValue($0) })
-    case is NSNull:
-        .null
-    default:
-        // Fallback for unexpected types
-        .string(String(describing: value))
     }
 }
 

--- a/Tests/TachikomaMCPTests/TypeConversionTests.swift
+++ b/Tests/TachikomaMCPTests/TypeConversionTests.swift
@@ -229,6 +229,27 @@ struct TypeConversionTests {
     }
 
     @Test
+    func `Foundation JSON arguments keep booleans and integers distinct`() throws {
+        let json = Data(
+            #"{"falseFlag":false,"one":1,"trueFlag":true,"zero":0,"largeInteger":9007199254740993}"#
+                .utf8,
+        )
+        let dictionary = try #require(
+            JSONSerialization.jsonObject(with: json) as? [String: Any],
+        )
+
+        let value = Value.from(dictionary)
+        let toolArguments = ToolArguments(raw: dictionary)
+
+        #expect(value == toolArguments.rawValue)
+        #expect(toolArguments.getBool("falseFlag") == false)
+        #expect(toolArguments.getInt("one") == 1)
+        #expect(toolArguments.getBool("trueFlag") == true)
+        #expect(toolArguments.getInt("zero") == 0)
+        #expect(toolArguments.getInt("largeInteger") == 9_007_199_254_740_993)
+    }
+
+    @Test
     func `ToolResponse to AnyAgentToolValue conversion via toAgentToolResult`() {
         // Text response
         let textResponse = ToolResponse.text("Success message")

--- a/Tests/TachikomaTests/Tools/DynamicToolsTests.swift
+++ b/Tests/TachikomaTests/Tools/DynamicToolsTests.swift
@@ -119,6 +119,103 @@ struct DynamicToolsTests {
     }
 
     @Test
+    func `DynamicToolRegistry binds execution to the discovered provider without rediscovery`() async throws {
+        let alphaProvider = TestDynamicToolProvider(toolNames: ["alpha"], resultPrefix: "alpha-provider")
+        let betaProvider = TestDynamicToolProvider(toolNames: ["beta"], resultPrefix: "beta-provider")
+        let registry = DynamicToolRegistry()
+        await registry.register(betaProvider, id: "b-provider")
+        await registry.register(alphaProvider, id: "a-provider")
+
+        let tools = try await registry.getAllAgentTools()
+        #expect(tools.map(\.name) == ["alpha", "beta"])
+
+        let betaTool = try #require(tools.first { $0.name == "beta" })
+        let first = try await betaTool.execute(AgentToolArguments(), context: ToolExecutionContext())
+        let second = try await betaTool.execute(AgentToolArguments(), context: ToolExecutionContext())
+
+        #expect(first.stringValue == "beta-provider:beta")
+        #expect(second.stringValue == "beta-provider:beta")
+        #expect(await alphaProvider.discoveryCount == 1)
+        #expect(await betaProvider.discoveryCount == 1)
+        #expect(await alphaProvider.executionCount == 0)
+        #expect(await betaProvider.executionCount == 2)
+    }
+
+    @Test
+    func `DynamicToolRegistry rejects ambiguous names before execution`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "second")
+        let registry = DynamicToolRegistry()
+        await registry.register(firstProvider, id: "first-provider")
+        await registry.register(secondProvider, id: "second-provider")
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await registry.getAllAgentTools()
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 0)
+    }
+
+    @Test
+    func `DynamicToolRegistry invalidates tools when their provider registration changes`() async throws {
+        let originalProvider = TestDynamicToolProvider(toolNames: ["mutable"], resultPrefix: "original")
+        let replacementProvider = TestDynamicToolProvider(toolNames: ["mutable"], resultPrefix: "replacement")
+        let registry = DynamicToolRegistry()
+        await registry.register(originalProvider, id: "provider")
+        let staleTool = try #require(try await registry.getAllAgentTools().first)
+
+        await registry.register(replacementProvider, id: "provider")
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await staleTool.execute(AgentToolArguments(), context: ToolExecutionContext())
+        }
+        #expect(await originalProvider.executionCount == 0)
+        #expect(await replacementProvider.executionCount == 0)
+    }
+
+    @Test
+    func `DynamicToolRegistry invalidates issued tools when a refresh becomes ambiguous`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let registry = DynamicToolRegistry()
+        await registry.register(firstProvider, id: "first-provider")
+        await registry.register(secondProvider, id: "second-provider")
+        let issuedTool = try #require(try await registry.getAllAgentTools().first)
+
+        await secondProvider.replaceTools(with: ["shared"])
+        await #expect(throws: TachikomaError.self) {
+            _ = try await registry.getAllAgentTools()
+        }
+        await #expect(throws: TachikomaError.self) {
+            _ = try await issuedTool.execute(AgentToolArguments(), context: ToolExecutionContext())
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 0)
+    }
+
+    @Test
+    func `DynamicToolRegistry invalidates issued tools when ownership moves`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let registry = DynamicToolRegistry()
+        await registry.register(firstProvider, id: "first-provider")
+        await registry.register(secondProvider, id: "second-provider")
+        let issuedTool = try #require(try await registry.getAllAgentTools().first)
+
+        await firstProvider.replaceTools(with: [])
+        await secondProvider.replaceTools(with: ["shared"])
+        let replacementTool = try #require(try await registry.getAllAgentTools().first)
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await issuedTool.execute(AgentToolArguments(), context: ToolExecutionContext())
+        }
+        let result = try await replacementTool.execute(AgentToolArguments(), context: ToolExecutionContext())
+        #expect(result.stringValue == "second:shared")
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 1)
+    }
+
+    @Test
     func `DynamicToolProvider discovers tools`() async throws {
         let searchTool = DynamicTool(
             name: "search_web",
@@ -145,6 +242,59 @@ struct DynamicToolsTests {
             arguments: AgentToolArguments(["query": AnyAgentToolValue(string: "Swift")]),
         )
         #expect(result.stringValue?.contains("Mock result for") == true)
+    }
+
+    @Test
+    func `CompositeDynamicToolProvider rejects ambiguous names`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "second")
+        let provider = CompositeDynamicToolProvider(providers: [firstProvider, secondProvider])
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await provider.executeTool(name: "shared", arguments: AgentToolArguments())
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 0)
+    }
+
+    @Test
+    func `CompositeDynamicToolProvider executes through the provider bound during discovery`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let provider = CompositeDynamicToolProvider(providers: [firstProvider, secondProvider])
+
+        let tools = try await provider.discoverTools()
+        #expect(tools.map(\.name) == ["shared"])
+        await firstProvider.replaceTools(with: [])
+        await secondProvider.replaceTools(with: ["shared"])
+
+        let result = try await provider.executeTool(name: "shared", arguments: AgentToolArguments())
+
+        #expect(result.stringValue == "first:shared")
+        #expect(await firstProvider.discoveryCount == 1)
+        #expect(await secondProvider.discoveryCount == 1)
+        #expect(await firstProvider.executionCount == 1)
+        #expect(await secondProvider.executionCount == 0)
+    }
+
+    @Test
+    func `CompositeDynamicToolProvider refuses execution after ownership changes`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let provider = CompositeDynamicToolProvider(providers: [firstProvider, secondProvider])
+        _ = try await provider.discoverTools()
+
+        await firstProvider.replaceTools(with: [])
+        await secondProvider.replaceTools(with: ["shared"])
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await provider.discoverTools()
+        }
+        await #expect(throws: TachikomaError.self) {
+            _ = try await provider.executeTool(name: "shared", arguments: AgentToolArguments())
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 0)
     }
 
     // Commented out - MCPToolProvider doesn't exist in core Tachikoma
@@ -273,5 +423,41 @@ struct DynamicToolsTests {
 
         let toolsAfter = try await registry.getAllAgentTools()
         #expect(toolsAfter.isEmpty)
+    }
+}
+
+private actor TestDynamicToolProvider: DynamicToolProvider {
+    private var tools: [DynamicTool]
+    private let resultPrefix: String
+    private(set) var discoveryCount = 0
+    private(set) var executionCount = 0
+
+    init(toolNames: [String], resultPrefix: String) {
+        self.tools = Self.makeTools(named: toolNames)
+        self.resultPrefix = resultPrefix
+    }
+
+    func discoverTools() async throws -> [DynamicTool] {
+        self.discoveryCount += 1
+        return self.tools
+    }
+
+    func executeTool(name: String, arguments _: AgentToolArguments) async throws -> AnyAgentToolValue {
+        self.executionCount += 1
+        return AnyAgentToolValue(string: "\(self.resultPrefix):\(name)")
+    }
+
+    func replaceTools(with names: [String]) {
+        self.tools = Self.makeTools(named: names)
+    }
+
+    private static func makeTools(named names: [String]) -> [DynamicTool] {
+        names.map { name in
+            DynamicTool(
+                name: name,
+                description: "Tool \(name)",
+                schema: DynamicSchema(type: .object),
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

- bind each dynamic/composite tool to the provider and registration generation that supplied its schema
- invalidate stale plans on registry mutation, provider ownership changes, concurrent discovery changes, failed refreshes, and duplicate tool names
- collapse MCP adapter/provider/manager/client argument conversion onto one typed `Value` path while retaining the public raw dictionary API
- deduplicate shared provider fixtures and add state-change regressions

## Safety and compatibility

- issued tools fail closed rather than silently switching provider when ownership changes
- registries with duplicate tool names must namespace or rename the conflicting provider tools; the error lists every conflicting name and source instead of dispatching through unspecified provider order
- composite bindings remain permanently invalid after an observed rebind
- Foundation booleans, integers, and large integers retain their exact value kind
- no public API removal

## Proof

- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (828 core/agent/audio + 52 MCP)
- `DynamicToolsTests` (16/16)
- `TypeConversionTests` (14/14)
- SwiftFormat lint (0/184)
- strict SwiftLint (0 violations)
- P0-P2 autoreview and TruffleHog: clean; patch correct at 0.93
