### PR TITLE
fix(agent): recover composite tool bindings after outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Composite dynamic tool providers now recover unchanged bindings after transient discovery failures while keeping real ownership changes fail-closed.
 - Dynamic tool aggregation now binds execution to the provider that supplied each schema, invalidates stale plans, avoids repeated discovery on registry execution, and rejects duplicate names instead of dispatching nondeterministically.
 - MCP tool arguments now use one typed conversion path across adapters, providers, managers, and transport while preserving Foundation booleans and integers exactly.
 - MCP tool failures now retain their error status, content, structured values, and safe metadata through agent generation instead of being shaped as successful tool results.

--- a/Sources/TachikomaAgent/DynamicTools.swift
+++ b/Sources/TachikomaAgent/DynamicTools.swift
@@ -58,21 +58,35 @@ private enum DynamicToolBindingLookup: Sendable {
 
 private actor DynamicToolBindingStore {
     private var bindings: [String: ResolvedDynamicTool]?
+    private var bindingPlan: [String: DynamicToolBindingIdentity]?
     private var invalidatedNames: Set<String> = []
 
     func apply(_ resolvedTools: [ResolvedDynamicTool]) -> [String] {
         let nextBindings = Dictionary(uniqueKeysWithValues: resolvedTools.map { ($0.tool.name, $0) })
-        if let bindings = self.bindings {
-            for (name, previous) in bindings {
-                guard let next = nextBindings[name], next.sourceID == previous.sourceID else {
+        let nextPlan = nextBindings.mapValues { binding in
+            DynamicToolBindingIdentity(
+                sourceID: binding.sourceID,
+                registrationID: binding.registrationID,
+            )
+        }
+        if let bindingPlan = self.bindingPlan {
+            for (name, previous) in bindingPlan {
+                guard let next = nextPlan[name], next == previous else {
                     self.invalidatedNames.insert(name)
                     continue
                 }
             }
         }
 
+        let blockedNames = nextBindings.keys.filter { self.invalidatedNames.contains($0) }.sorted()
+        guard blockedNames.isEmpty else {
+            self.bindings = nil
+            return blockedNames
+        }
+
+        self.bindingPlan = nextPlan
         self.bindings = nextBindings
-        return nextBindings.keys.filter { self.invalidatedNames.contains($0) }.sorted()
+        return []
     }
 
     func lookup(name: String) -> DynamicToolBindingLookup {
@@ -88,10 +102,7 @@ private actor DynamicToolBindingStore {
         return .bound(binding)
     }
 
-    func invalidateAll() {
-        if let bindings = self.bindings {
-            self.invalidatedNames.formUnion(bindings.keys)
-        }
+    func suspend() {
         self.bindings = nil
     }
 }
@@ -448,7 +459,7 @@ public struct CompositeDynamicToolProvider: DynamicToolProvider {
             }
             return resolvedTools
         } catch {
-            await self.bindingStore.invalidateAll()
+            await self.bindingStore.suspend()
             throw error
         }
     }

--- a/Tests/TachikomaTests/Tools/DynamicToolsTests.swift
+++ b/Tests/TachikomaTests/Tools/DynamicToolsTests.swift
@@ -278,6 +278,100 @@ struct DynamicToolsTests {
     }
 
     @Test
+    func `CompositeDynamicToolProvider recovers unchanged bindings after a transient discovery failure`() async throws {
+        let provider = TestDynamicToolProvider(toolNames: ["stable"], resultPrefix: "provider")
+        let composite = CompositeDynamicToolProvider(providers: [provider])
+
+        _ = try await composite.discoverTools()
+        await provider.failNextDiscovery()
+        await #expect(throws: TestDynamicToolProviderError.self) {
+            _ = try await composite.discoverTools()
+        }
+
+        let recoveredTools = try await composite.discoverTools()
+        let result = try await composite.executeTool(name: "stable", arguments: AgentToolArguments())
+
+        #expect(recoveredTools.map(\.name) == ["stable"])
+        #expect(result.stringValue == "provider:stable")
+        #expect(await provider.discoveryCount == 3)
+        #expect(await provider.executionCount == 1)
+    }
+
+    @Test
+    func `CompositeDynamicToolProvider detects an ownership move after a transient discovery failure`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let composite = CompositeDynamicToolProvider(providers: [firstProvider, secondProvider])
+        _ = try await composite.discoverTools()
+
+        await secondProvider.failNextDiscovery()
+        await #expect(throws: TestDynamicToolProviderError.self) {
+            _ = try await composite.discoverTools()
+        }
+        await firstProvider.replaceTools(with: [])
+        await secondProvider.replaceTools(with: ["shared"])
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await composite.discoverTools()
+        }
+        await #expect(throws: TachikomaError.self) {
+            _ = try await composite.executeTool(name: "shared", arguments: AgentToolArguments())
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 0)
+    }
+
+    @Test
+    func `CompositeDynamicToolProvider keeps duplicate ownership fail closed after a transient failure`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let composite = CompositeDynamicToolProvider(providers: [firstProvider, secondProvider])
+        _ = try await composite.discoverTools()
+
+        await secondProvider.failNextDiscovery()
+        await #expect(throws: TestDynamicToolProviderError.self) {
+            _ = try await composite.discoverTools()
+        }
+        await secondProvider.replaceTools(with: ["shared"])
+
+        await #expect(throws: TachikomaError.self) {
+            _ = try await composite.executeTool(name: "shared", arguments: AgentToolArguments())
+        }
+        await #expect(throws: TachikomaError.self) {
+            _ = try await composite.executeTool(name: "shared", arguments: AgentToolArguments())
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 0)
+    }
+
+    @Test
+    func `CompositeDynamicToolProvider does not promote a rejected ownership plan`() async throws {
+        let firstProvider = TestDynamicToolProvider(toolNames: ["stable"], resultPrefix: "first")
+        let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
+        let composite = CompositeDynamicToolProvider(providers: [firstProvider, secondProvider])
+        _ = try await composite.discoverTools()
+
+        await firstProvider.replaceTools(with: ["new"])
+        await secondProvider.replaceTools(with: ["stable"])
+        await #expect(throws: TachikomaError.self) {
+            _ = try await composite.discoverTools()
+        }
+
+        await firstProvider.replaceTools(with: [])
+        await secondProvider.replaceTools(with: ["new"])
+        let recoveredTools = try await composite.discoverTools()
+        let result = try await composite.executeTool(name: "new", arguments: AgentToolArguments())
+
+        #expect(recoveredTools.map(\.name) == ["new"])
+        #expect(result.stringValue == "second:new")
+        await #expect(throws: TachikomaError.self) {
+            _ = try await composite.executeTool(name: "stable", arguments: AgentToolArguments())
+        }
+        #expect(await firstProvider.executionCount == 0)
+        #expect(await secondProvider.executionCount == 1)
+    }
+
+    @Test
     func `CompositeDynamicToolProvider refuses execution after ownership changes`() async throws {
         let firstProvider = TestDynamicToolProvider(toolNames: ["shared"], resultPrefix: "first")
         let secondProvider = TestDynamicToolProvider(toolNames: [], resultPrefix: "second")
@@ -431,6 +525,7 @@ private actor TestDynamicToolProvider: DynamicToolProvider {
     private let resultPrefix: String
     private(set) var discoveryCount = 0
     private(set) var executionCount = 0
+    private var shouldFailNextDiscovery = false
 
     init(toolNames: [String], resultPrefix: String) {
         self.tools = Self.makeTools(named: toolNames)
@@ -439,6 +534,10 @@ private actor TestDynamicToolProvider: DynamicToolProvider {
 
     func discoverTools() async throws -> [DynamicTool] {
         self.discoveryCount += 1
+        if self.shouldFailNextDiscovery {
+            self.shouldFailNextDiscovery = false
+            throw TestDynamicToolProviderError.transientDiscoveryFailure
+        }
         return self.tools
     }
 
@@ -451,6 +550,10 @@ private actor TestDynamicToolProvider: DynamicToolProvider {
         self.tools = Self.makeTools(named: names)
     }
 
+    func failNextDiscovery() {
+        self.shouldFailNextDiscovery = true
+    }
+
     private static func makeTools(named names: [String]) -> [DynamicTool] {
         names.map { name in
             DynamicTool(
@@ -460,4 +563,8 @@ private actor TestDynamicToolProvider: DynamicToolProvider {
             )
         }
     }
+}
+
+private enum TestDynamicToolProviderError: Error {
+    case transientDiscoveryFailure
 }


### PR DESCRIPTION
## Summary

- distinguish a transient composite-provider discovery outage from a real ownership-plan change
- suspend executable bindings on failure while retaining the last accepted provider/name plan
- allow an unchanged healthy refresh to recover without permanently poisoning the long-lived composite
- keep ownership moves, duplicate names, and previously invalidated names fail closed

## Regression coverage

- outage followed by an unchanged healthy refresh and successful execution
- ownership move after an outage remains refused
- duplicate ownership after an outage remains refused
- a rejected ownership plan is never promoted as the next compatibility baseline

## Proof

- `DynamicToolsTests` (20/20)
- full mock suite (832 core/agent/audio + 52 MCP)
- SwiftFormat lint: clean
- strict SwiftLint: 0 violations
- P0-P2 autoreview: clean, no findings
