### PR TITLE
fix(tools): preserve schema fidelity across providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.
 - MCP tool discovery now uses one schema conversion path so static and dynamic tools preserve matching descriptions, enums, array item types, and required fields.
 - Composite dynamic tool providers now recover unchanged bindings after transient discovery failures while keeping real ownership changes fail-closed.
 - Dynamic tool aggregation now binds execution to the provider that supplied each schema, invalidates stale plans, avoids repeated discovery on registry execution, and rejects duplicate names instead of dispatching nondeterministically.

--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -1070,44 +1070,22 @@ public final class AnthropicProvider: ModelProvider {
     }
 
     private func convertToolToAnthropic(_ tool: AgentTool) throws -> AnthropicTool {
-        // Convert AgentToolParameters to [String: Any]
-        var properties: [String: Any] = [:]
-        for (key, prop) in tool.parameters.properties {
-            var propDict: [String: Any] = [
-                "type": prop.type.rawValue,
-                "description": prop.description,
-            ]
-
-            if let enumValues = prop.enumValues {
-                propDict["enum"] = enumValues
-            }
-
-            // Add items for array type
-            if prop.type == .array {
-                if let items = prop.items {
-                    // Convert items to dictionary
-                    var itemsDict: [String: Any] = ["type": items.type]
-                    // Add description if present
-                    if let itemDescription = items.description {
-                        itemsDict["description"] = itemDescription
-                    }
-                    propDict["items"] = itemsDict
-                } else {
-                    // Default items for array
-                    propDict["items"] = ["type": "string"]
-                }
-            }
-
-            properties[key] = propDict
+        let schema = try tool.parameters.jsonSchema(options: [.defaultStringArrayItems])
+        guard
+            let type = schema["type"] as? String,
+            let properties = schema["properties"] as? [String: Any],
+            let required = schema["required"] as? [String] else
+        {
+            throw TachikomaError.invalidInput("Failed to encode tool parameters for '\(tool.name)'")
         }
 
         return AnthropicTool(
             name: tool.name,
             description: tool.description,
             inputSchema: AnthropicInputSchema(
-                type: tool.parameters.type,
+                type: type,
                 properties: properties,
-                required: tool.parameters.required,
+                required: required,
             ),
         )
     }
@@ -1969,37 +1947,11 @@ public final class OllamaProvider: ModelProvider {
     }
 
     private func convertToolToOllama(_ tool: AgentTool) throws -> OllamaTool {
-        var properties: [String: AnyAgentToolValue] = [:]
-        for (key, prop) in tool.parameters.properties {
-            var propDict: [String: AnyAgentToolValue] = [
-                "type": AnyAgentToolValue(string: prop.type.rawValue),
-                "description": AnyAgentToolValue(string: prop.description),
-            ]
-
-            if let enumValues = prop.enumValues {
-                propDict["enum"] = AnyAgentToolValue(array: enumValues.map { AnyAgentToolValue(string: $0) })
-            }
-
-            if let items = prop.items {
-                var itemSchema = [
-                    "type": AnyAgentToolValue(string: items.type),
-                ]
-                if let description = items.description {
-                    itemSchema["description"] = AnyAgentToolValue(string: description)
-                }
-                propDict["items"] = AnyAgentToolValue(object: itemSchema)
-            }
-
-            properties[key] = AnyAgentToolValue(object: propDict)
+        let schema = try tool.parameters.jsonSchema()
+        var parameters: [String: AnyAgentToolValue] = [:]
+        for (key, value) in schema {
+            parameters[key] = try AnyAgentToolValue.fromJSON(value)
         }
-
-        let parameters: [String: AnyAgentToolValue] = [
-            "type": AnyAgentToolValue(string: tool.parameters.type),
-            "properties": AnyAgentToolValue(object: properties),
-            "required": AnyAgentToolValue(
-                array: tool.parameters.required.map { AnyAgentToolValue(string: $0) },
-            ),
-        ]
 
         return OllamaTool(
             type: "function",

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -839,54 +839,10 @@ struct OpenAICompatibleHelper {
     }
 
     private static func convertTool(_ tool: AgentTool) throws -> OpenAITool {
-        // Convert AgentToolParameters to [String: Any]
-        var parameters: [String: Any] = [
-            "type": tool.parameters.type,
-        ]
-
-        // Convert properties
-        var properties: [String: Any] = [:]
-        for (key, prop) in tool.parameters.properties {
-            var propDict: [String: Any] = [
-                "type": prop.type.rawValue,
-                "description": prop.description,
-            ]
-
-            if let enumValues = prop.enumValues {
-                propDict["enum"] = enumValues
-            }
-
-            // Handle array items if present
-            if prop.type == .array {
-                if let items = prop.items {
-                    var itemsDict: [String: Any] = [
-                        "type": items.type,
-                    ]
-                    if let itemDescription = items.description {
-                        itemsDict["description"] = itemDescription
-                    }
-                    propDict["items"] = itemsDict
-                } else {
-                    // OpenAI requires items for array types - default to string
-                    propDict["items"] = ["type": "string"]
-                    if
-                        ProcessInfo.processInfo.arguments.contains("--verbose") ||
-                        ProcessInfo.processInfo.arguments.contains("-v")
-                    {
-                        print("DEBUG: Adding default string items for array property '\(key)' in tool '\(tool.name)'")
-                    }
-                }
-            }
-
-            properties[key] = propDict
-        }
-
-        parameters["properties"] = properties
-
-        // Only include required field if it's not empty
-        if !tool.parameters.required.isEmpty {
-            parameters["required"] = tool.parameters.required
-        }
+        let parameters = try tool.parameters.jsonSchema(options: [
+            .defaultStringArrayItems,
+            .omitEmptyRequired,
+        ])
 
         // Debug logging
         if

--- a/Sources/Tachikoma/Core/ToolTypes.swift
+++ b/Sources/Tachikoma/Core/ToolTypes.swift
@@ -564,6 +564,16 @@ public struct AgentToolParameters: Sendable, Codable {
         self.properties = properties
         self.required = required
     }
+
+    init(
+        type: String,
+        properties: [String: AgentToolParameterProperty],
+        required: [String],
+    ) {
+        self.type = type
+        self.properties = properties
+        self.required = required
+    }
 }
 
 /// Tool parameter property definition
@@ -574,6 +584,13 @@ public struct AgentToolParameterProperty: Sendable, Codable {
     public let description: String
     public let enumValues: [String]?
     public let items: AgentToolParameterItems?
+    public let properties: [String: AgentToolParameterProperty]?
+    public let required: [String]?
+    public let format: String?
+    public let minimum: Double?
+    public let maximum: Double?
+    public let minLength: Int?
+    public let maxLength: Int?
 
     public enum ParameterType: String, Sendable, Codable {
         case string
@@ -592,11 +609,48 @@ public struct AgentToolParameterProperty: Sendable, Codable {
         enumValues: [String]? = nil,
         items: AgentToolParameterItems? = nil,
     ) {
+        self.init(
+            name: name,
+            type: type,
+            description: description,
+            enumValues: enumValues,
+            items: items,
+            properties: nil,
+            required: nil,
+            format: nil,
+            minimum: nil,
+            maximum: nil,
+            minLength: nil,
+            maxLength: nil,
+        )
+    }
+
+    public init(
+        name: String,
+        type: ParameterType,
+        description: String,
+        enumValues: [String]? = nil,
+        items: AgentToolParameterItems? = nil,
+        properties: [String: AgentToolParameterProperty]? = nil,
+        required: [String]? = nil,
+        format: String? = nil,
+        minimum: Double? = nil,
+        maximum: Double? = nil,
+        minLength: Int? = nil,
+        maxLength: Int? = nil,
+    ) {
         self.name = name
         self.type = type
         self.description = description
         self.enumValues = enumValues
         self.items = items
+        self.properties = properties
+        self.required = required
+        self.format = format
+        self.minimum = minimum
+        self.maximum = maximum
+        self.minLength = minLength
+        self.maxLength = maxLength
     }
 }
 
@@ -605,10 +659,116 @@ public struct AgentToolParameterProperty: Sendable, Codable {
 public struct AgentToolParameterItems: Sendable, Codable {
     public let type: String
     public let description: String?
+    public let enumValues: [String]?
+    private let itemsBox: ToolSchemaIndirectBox<AgentToolParameterItems>?
+    public let properties: [String: AgentToolParameterProperty]?
+    public let required: [String]?
+    public let format: String?
+    public let minimum: Double?
+    public let maximum: Double?
+    public let minLength: Int?
+    public let maxLength: Int?
+
+    public var items: AgentToolParameterItems? {
+        self.itemsBox?.value
+    }
 
     public init(type: String, description: String? = nil) {
+        self.init(
+            type: type,
+            description: description,
+            enumValues: nil,
+            items: nil,
+            properties: nil,
+            required: nil,
+            format: nil,
+            minimum: nil,
+            maximum: nil,
+            minLength: nil,
+            maxLength: nil,
+        )
+    }
+
+    public init(
+        type: String,
+        description: String? = nil,
+        enumValues: [String]? = nil,
+        items: AgentToolParameterItems? = nil,
+        properties: [String: AgentToolParameterProperty]? = nil,
+        required: [String]? = nil,
+        format: String? = nil,
+        minimum: Double? = nil,
+        maximum: Double? = nil,
+        minLength: Int? = nil,
+        maxLength: Int? = nil,
+    ) {
         self.type = type
         self.description = description
+        self.enumValues = enumValues
+        self.itemsBox = items.map(ToolSchemaIndirectBox.init)
+        self.properties = properties
+        self.required = required
+        self.format = format
+        self.minimum = minimum
+        self.maximum = maximum
+        self.minLength = minLength
+        self.maxLength = maxLength
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case description
+        case enumValues
+        case items
+        case properties
+        case required
+        case format
+        case minimum
+        case maximum
+        case minLength
+        case maxLength
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(String.self, forKey: .type)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.enumValues = try container.decodeIfPresent([String].self, forKey: .enumValues)
+        self.itemsBox = try container.decodeIfPresent(AgentToolParameterItems.self, forKey: .items)
+            .map(ToolSchemaIndirectBox.init)
+        self.properties = try container.decodeIfPresent(
+            [String: AgentToolParameterProperty].self,
+            forKey: .properties,
+        )
+        self.required = try container.decodeIfPresent([String].self, forKey: .required)
+        self.format = try container.decodeIfPresent(String.self, forKey: .format)
+        self.minimum = try container.decodeIfPresent(Double.self, forKey: .minimum)
+        self.maximum = try container.decodeIfPresent(Double.self, forKey: .maximum)
+        self.minLength = try container.decodeIfPresent(Int.self, forKey: .minLength)
+        self.maxLength = try container.decodeIfPresent(Int.self, forKey: .maxLength)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.type, forKey: .type)
+        try container.encodeIfPresent(self.description, forKey: .description)
+        try container.encodeIfPresent(self.enumValues, forKey: .enumValues)
+        try container.encodeIfPresent(self.items, forKey: .items)
+        try container.encodeIfPresent(self.properties, forKey: .properties)
+        try container.encodeIfPresent(self.required, forKey: .required)
+        try container.encodeIfPresent(self.format, forKey: .format)
+        try container.encodeIfPresent(self.minimum, forKey: .minimum)
+        try container.encodeIfPresent(self.maximum, forKey: .maximum)
+        try container.encodeIfPresent(self.minLength, forKey: .minLength)
+        try container.encodeIfPresent(self.maxLength, forKey: .maxLength)
+    }
+}
+
+private final class ToolSchemaIndirectBox<Value: Sendable>: Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
     }
 }
 
@@ -808,10 +968,105 @@ public struct DynamicSchema: Sendable, Codable {
     public struct SchemaItems: Sendable, Codable {
         public let type: SchemaType
         public let description: String?
+        public let enumValues: [String]?
+        private let itemsBox: ToolSchemaIndirectBox<SchemaItems>?
+        public let properties: [String: SchemaProperty]?
+        public let required: [String]?
+        public let format: String?
+        public let minimum: Double?
+        public let maximum: Double?
+        public let minLength: Int?
+        public let maxLength: Int?
+
+        public var items: SchemaItems? {
+            self.itemsBox?.value
+        }
 
         public init(type: SchemaType, description: String? = nil) {
+            self.init(
+                type: type,
+                description: description,
+                enumValues: nil,
+                items: nil,
+                properties: nil,
+                required: nil,
+                format: nil,
+                minimum: nil,
+                maximum: nil,
+                minLength: nil,
+                maxLength: nil,
+            )
+        }
+
+        public init(
+            type: SchemaType,
+            description: String? = nil,
+            enumValues: [String]? = nil,
+            items: SchemaItems? = nil,
+            properties: [String: SchemaProperty]? = nil,
+            required: [String]? = nil,
+            format: String? = nil,
+            minimum: Double? = nil,
+            maximum: Double? = nil,
+            minLength: Int? = nil,
+            maxLength: Int? = nil,
+        ) {
             self.type = type
             self.description = description
+            self.enumValues = enumValues
+            self.itemsBox = items.map(ToolSchemaIndirectBox.init)
+            self.properties = properties
+            self.required = required
+            self.format = format
+            self.minimum = minimum
+            self.maximum = maximum
+            self.minLength = minLength
+            self.maxLength = maxLength
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case description
+            case enumValues
+            case items
+            case properties
+            case required
+            case format
+            case minimum
+            case maximum
+            case minLength
+            case maxLength
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.type = try container.decode(SchemaType.self, forKey: .type)
+            self.description = try container.decodeIfPresent(String.self, forKey: .description)
+            self.enumValues = try container.decodeIfPresent([String].self, forKey: .enumValues)
+            self.itemsBox = try container.decodeIfPresent(SchemaItems.self, forKey: .items)
+                .map(ToolSchemaIndirectBox.init)
+            self.properties = try container.decodeIfPresent([String: SchemaProperty].self, forKey: .properties)
+            self.required = try container.decodeIfPresent([String].self, forKey: .required)
+            self.format = try container.decodeIfPresent(String.self, forKey: .format)
+            self.minimum = try container.decodeIfPresent(Double.self, forKey: .minimum)
+            self.maximum = try container.decodeIfPresent(Double.self, forKey: .maximum)
+            self.minLength = try container.decodeIfPresent(Int.self, forKey: .minLength)
+            self.maxLength = try container.decodeIfPresent(Int.self, forKey: .maxLength)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.type, forKey: .type)
+            try container.encodeIfPresent(self.description, forKey: .description)
+            try container.encodeIfPresent(self.enumValues, forKey: .enumValues)
+            try container.encodeIfPresent(self.items, forKey: .items)
+            try container.encodeIfPresent(self.properties, forKey: .properties)
+            try container.encodeIfPresent(self.required, forKey: .required)
+            try container.encodeIfPresent(self.format, forKey: .format)
+            try container.encodeIfPresent(self.minimum, forKey: .minimum)
+            try container.encodeIfPresent(self.maximum, forKey: .maximum)
+            try container.encodeIfPresent(self.minLength, forKey: .minLength)
+            try container.encodeIfPresent(self.maxLength, forKey: .maxLength)
         }
     }
 
@@ -829,34 +1084,59 @@ public struct DynamicSchema: Sendable, Codable {
 
     /// Convert to AgentToolParameters
     public func toAgentToolParameters() -> AgentToolParameters {
-        // Convert to AgentToolParameters
-        var props: [String: AgentToolParameterProperty] = [:]
-
-        if let properties {
-            for (key, prop) in properties {
-                let items = prop.items.map { schemaItems in
-                    AgentToolParameterItems(
-                        type: schemaItems.type.rawValue,
-                        description: schemaItems.description,
-                    )
-                }
-
-                // Convert SchemaType to ParameterType
-                let paramType = AgentToolParameterProperty.ParameterType(rawValue: prop.type.rawValue) ?? .string
-
-                props[key] = AgentToolParameterProperty(
-                    name: key,
-                    type: paramType,
-                    description: prop.description ?? "",
-                    enumValues: prop.enumValues,
-                    items: items,
-                )
-            }
-        }
-
-        return AgentToolParameters(
-            properties: props,
+        AgentToolParameters(
+            type: self.type.rawValue,
+            properties: Self.agentProperties(self.properties) ?? [:],
             required: self.required ?? [],
+        )
+    }
+
+    private static func agentProperties(
+        _ properties: [String: SchemaProperty]?,
+    )
+        -> [String: AgentToolParameterProperty]?
+    {
+        guard let properties else { return nil }
+        return Dictionary(uniqueKeysWithValues: properties.map { name, property in
+            (name, Self.agentProperty(name: name, property: property))
+        })
+    }
+
+    private static func agentProperty(
+        name: String,
+        property: SchemaProperty,
+    )
+        -> AgentToolParameterProperty
+    {
+        AgentToolParameterProperty(
+            name: name,
+            type: AgentToolParameterProperty.ParameterType(rawValue: property.type.rawValue) ?? .string,
+            description: property.description ?? "",
+            enumValues: property.enumValues,
+            items: property.items.map(self.agentItems),
+            properties: self.agentProperties(property.properties),
+            required: property.required,
+            format: property.format,
+            minimum: property.minimum,
+            maximum: property.maximum,
+            minLength: property.minLength,
+            maxLength: property.maxLength,
+        )
+    }
+
+    private static func agentItems(_ items: SchemaItems) -> AgentToolParameterItems {
+        AgentToolParameterItems(
+            type: items.type.rawValue,
+            description: items.description,
+            enumValues: items.enumValues,
+            items: items.items.map(self.agentItems),
+            properties: self.agentProperties(items.properties),
+            required: items.required,
+            format: items.format,
+            minimum: items.minimum,
+            maximum: items.maximum,
+            minLength: items.minLength,
+            maxLength: items.maxLength,
         )
     }
 }

--- a/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
+++ b/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
@@ -286,39 +286,14 @@ extension GoogleProvider {
     }
 
     private static func convertTool(_ tool: AgentTool) throws -> GoogleGenerateRequest.Tool.FunctionDeclaration {
-        var properties: [String: Any] = [:]
-        for (key, prop) in tool.parameters.properties {
-            var propDict: [String: Any] = [
-                "type": prop.type.rawValue,
-                "description": prop.description,
-            ]
-            if let enumValues = prop.enumValues {
-                propDict["enum"] = enumValues
-            }
-            if let items = prop.items {
-                var itemsDict: [String: Any] = ["type": items.type]
-                if let itemDescription = items.description {
-                    itemsDict["description"] = itemDescription
-                }
-                propDict["items"] = itemsDict
-            }
-            properties[key] = propDict
-        }
-
         // Gemini validates that every name in `required` exists in `properties`. Tools occasionally
         // ship with a `required` entry whose property got filtered out during MCP→Agent conversion
         // (e.g. anyOf/oneOf schemas that don't survive the simplified MCP→Agent translation). Drop
         // any orphan `required` names so we never send Gemini an invalid schema.
-        let declaredKeys = Set(properties.keys)
-        let sanitizedRequired = tool.parameters.required.filter { declaredKeys.contains($0) }
-
-        var parameters: [String: Any] = [
-            "type": "object",
-            "properties": properties,
-        ]
-        if !sanitizedRequired.isEmpty {
-            parameters["required"] = sanitizedRequired
-        }
+        let parameters = try tool.parameters.jsonSchema(options: [
+            .filterUndeclaredRequired,
+            .omitEmptyRequired,
+        ])
 
         guard let schema = JSONValue(value: parameters) else {
             throw TachikomaError.invalidInput("Failed to encode tool parameters for '\(tool.name)'")

--- a/Sources/Tachikoma/Providers/LMStudioProvider.swift
+++ b/Sources/Tachikoma/Providers/LMStudioProvider.swift
@@ -259,23 +259,13 @@ public actor LMStudioProvider: ModelProvider {
 
         // Add tools if present
         if let tools = request.tools {
-            body["tools"] = tools.map { tool in
-                [
+            body["tools"] = try tools.map { tool in
+                try [
                     "type": "function",
                     "function": [
                         "name": tool.name,
                         "description": tool.description,
-                        "parameters": [
-                            "type": "object",
-                            "properties": tool.parameters.properties.reduce(into: [String: Any]()) { result, element in
-                                let (key, prop) = element
-                                result[key] = [
-                                    "type": prop.type.rawValue,
-                                    "description": prop.description,
-                                ]
-                            },
-                            "required": tool.parameters.required,
-                        ],
+                        "parameters": tool.parameters.jsonSchema(),
                     ],
                 ]
             }

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -1028,37 +1028,9 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
     }
 
     private func convertTool(_ tool: AgentTool) throws -> ResponsesTool {
-        // Convert AgentToolParameters to [String: Any] for the API
-        var parameters: [String: Any] = [
-            "type": "object",
-            "properties": [:],
-        ]
+        var parameters = try tool.parameters.jsonSchema()
 
-        // Convert properties
-        var properties: [String: Any] = [:]
-        for (key, prop) in tool.parameters.properties {
-            var propDict: [String: Any] = [
-                "type": prop.type.rawValue,
-                "description": prop.description,
-            ]
-            if let enumValues = prop.enumValues {
-                propDict["enum"] = enumValues
-            }
-            if let items = prop.items {
-                var itemsDict: [String: Any] = ["type": items.type]
-                if let itemDescription = items.description {
-                    itemsDict["description"] = itemDescription
-                }
-                propDict["items"] = itemsDict
-            }
-            properties[key] = propDict
-        }
-        parameters["properties"] = properties
-
-        // Add required fields (even if empty to satisfy Responses API validation)
-        parameters["required"] = tool.parameters.required
-
-        // Responses API requires additionalProperties=false for strict schemas
+        // Keep rejecting unknown root arguments without opting into the provider's recursive strict-schema dialect.
         parameters["additionalProperties"] = false
 
         let function = ResponsesTool.ToolFunction(

--- a/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
+++ b/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+struct AgentToolSchemaSerializationOptions: OptionSet, Sendable {
+    let rawValue: Int
+
+    static let omitEmptyRequired = Self(rawValue: 1 << 0)
+    static let defaultStringArrayItems = Self(rawValue: 1 << 1)
+    static let filterUndeclaredRequired = Self(rawValue: 1 << 2)
+}
+
+extension AgentToolParameters {
+    func jsonSchema(
+        options: AgentToolSchemaSerializationOptions = [],
+    ) throws
+        -> [String: Any]
+    {
+        guard self.type == "object" else {
+            throw TachikomaError.invalidInput("Tool parameter schema root must be an object")
+        }
+        var serializedProperties: [String: Any] = [:]
+        for (name, property) in self.properties {
+            serializedProperties[name] = try AgentToolSchemaNode(property).jsonSchema(
+                options: options,
+                path: "properties.\(name)",
+            )
+        }
+
+        let required = try Self.serializedRequired(
+            self.required,
+            declaredNames: Set(self.properties.keys),
+            options: options,
+            path: "required",
+        )
+        var schema: [String: Any] = [
+            "type": self.type,
+            "properties": serializedProperties,
+        ]
+        if !required.isEmpty || !options.contains(.omitEmptyRequired) {
+            schema["required"] = required
+        }
+        return schema
+    }
+
+    private static func serializedRequired(
+        _ required: [String],
+        declaredNames: Set<String>,
+        options: AgentToolSchemaSerializationOptions,
+        path: String,
+    ) throws
+        -> [String]
+    {
+        guard Set(required).count == required.count else {
+            throw TachikomaError.invalidInput("Duplicate property name in tool schema \(path)")
+        }
+
+        let undeclared = required.filter { !declaredNames.contains($0) }
+        guard undeclared.isEmpty else {
+            if options.contains(.filterUndeclaredRequired) {
+                return required.filter(declaredNames.contains)
+            }
+            throw TachikomaError.invalidInput(
+                "Tool schema \(path) references undeclared properties: \(undeclared.joined(separator: ", "))",
+            )
+        }
+        return required
+    }
+
+    fileprivate static func serializedRequired(
+        _ required: [String]?,
+        properties: [String: AgentToolParameterProperty]?,
+        options: AgentToolSchemaSerializationOptions,
+        path: String,
+    ) throws
+        -> [String]?
+    {
+        guard let required else { return nil }
+        return try Self.serializedRequired(
+            required,
+            declaredNames: Set(properties?.keys.map(\.self) ?? []),
+            options: options,
+            path: path,
+        )
+    }
+}
+
+private struct AgentToolSchemaNode {
+    let type: AgentToolParameterProperty.ParameterType
+    let description: String?
+    let enumValues: [String]?
+    let items: AgentToolParameterItems?
+    let properties: [String: AgentToolParameterProperty]?
+    let required: [String]?
+    let format: String?
+    let minimum: Double?
+    let maximum: Double?
+    let minLength: Int?
+    let maxLength: Int?
+
+    init(_ property: AgentToolParameterProperty) {
+        self.type = property.type
+        self.description = property.description
+        self.enumValues = property.enumValues
+        self.items = property.items
+        self.properties = property.properties
+        self.required = property.required
+        self.format = property.format
+        self.minimum = property.minimum
+        self.maximum = property.maximum
+        self.minLength = property.minLength
+        self.maxLength = property.maxLength
+    }
+
+    init(_ items: AgentToolParameterItems, path: String = "items") throws {
+        guard let type = AgentToolParameterProperty.ParameterType(rawValue: items.type) else {
+            throw TachikomaError.invalidInput("Unsupported tool schema type '\(items.type)' at \(path)")
+        }
+        self.type = type
+        self.description = items.description
+        self.enumValues = items.enumValues
+        self.items = items.items
+        self.properties = items.properties
+        self.required = items.required
+        self.format = items.format
+        self.minimum = items.minimum
+        self.maximum = items.maximum
+        self.minLength = items.minLength
+        self.maxLength = items.maxLength
+    }
+
+    func jsonSchema(
+        options: AgentToolSchemaSerializationOptions,
+        path: String,
+    ) throws
+        -> [String: Any]
+    {
+        try self.validate(path: path)
+
+        var schema: [String: Any] = ["type": self.type.rawValue]
+        if let description {
+            schema["description"] = description
+        }
+        if let enumValues {
+            schema["enum"] = enumValues
+        }
+        if let format {
+            schema["format"] = format
+        }
+        if let minimum {
+            schema["minimum"] = minimum
+        }
+        if let maximum {
+            schema["maximum"] = maximum
+        }
+        if let minLength {
+            schema["minLength"] = minLength
+        }
+        if let maxLength {
+            schema["maxLength"] = maxLength
+        }
+
+        if self.type == .array {
+            if let items {
+                schema["items"] = try AgentToolSchemaNode(items, path: "\(path).items").jsonSchema(
+                    options: options,
+                    path: "\(path).items",
+                )
+            } else if options.contains(.defaultStringArrayItems) {
+                schema["items"] = ["type": "string"]
+            }
+        }
+
+        if self.type == .object {
+            var nestedProperties: [String: Any] = [:]
+            for (name, property) in self.properties ?? [:] {
+                nestedProperties[name] = try Self(property).jsonSchema(
+                    options: options,
+                    path: "\(path).properties.\(name)",
+                )
+            }
+            if self.properties != nil {
+                schema["properties"] = nestedProperties
+            }
+            if
+                let required = try AgentToolParameters.serializedRequired(
+                    self.required,
+                    properties: self.properties,
+                    options: options,
+                    path: "\(path).required",
+                ),
+                !required.isEmpty || !options.contains(.omitEmptyRequired)
+            {
+                schema["required"] = required
+            }
+        }
+        return schema
+    }
+
+    private func validate(path: String) throws {
+        if self.items != nil, self.type != .array {
+            throw TachikomaError.invalidInput("Tool schema \(path) has items but is not an array")
+        }
+        if self.properties != nil || self.required != nil, self.type != .object {
+            throw TachikomaError.invalidInput("Tool schema \(path) has object fields but is not an object")
+        }
+        if self.enumValues != nil, self.type != .string {
+            throw TachikomaError.invalidInput("Tool schema \(path) has string enum values but is not a string")
+        }
+        if let enumValues, enumValues.isEmpty {
+            throw TachikomaError.invalidInput("Tool schema \(path) has an empty enum")
+        }
+        if let enumValues, Set(enumValues).count != enumValues.count {
+            throw TachikomaError.invalidInput("Tool schema \(path) has duplicate enum values")
+        }
+        if let format, format.isEmpty {
+            throw TachikomaError.invalidInput("Tool schema \(path) has an empty format")
+        }
+        if
+            self.minimum != nil || self.maximum != nil,
+            self.type != .number,
+            self.type != .integer
+        {
+            throw TachikomaError.invalidInput("Tool schema \(path) has numeric constraints but is not numeric")
+        }
+        if let minimum, !minimum.isFinite {
+            throw TachikomaError.invalidInput("Tool schema \(path) has a non-finite minimum")
+        }
+        if let maximum, !maximum.isFinite {
+            throw TachikomaError.invalidInput("Tool schema \(path) has a non-finite maximum")
+        }
+        if let minimum, let maximum, minimum > maximum {
+            throw TachikomaError.invalidInput("Tool schema \(path) has minimum greater than maximum")
+        }
+        if
+            self.minLength != nil || self.maxLength != nil,
+            self.type != .string
+        {
+            throw TachikomaError.invalidInput("Tool schema \(path) has length constraints but is not a string")
+        }
+        if let minLength, minLength < 0 {
+            throw TachikomaError.invalidInput("Tool schema \(path) has a negative minLength")
+        }
+        if let maxLength, maxLength < 0 {
+            throw TachikomaError.invalidInput("Tool schema \(path) has a negative maxLength")
+        }
+        if let minLength, let maxLength, minLength > maxLength {
+            throw TachikomaError.invalidInput("Tool schema \(path) has minLength greater than maxLength")
+        }
+    }
+}

--- a/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
+++ b/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
@@ -54,13 +54,8 @@ extension AgentToolParameters {
         }
 
         let undeclared = required.filter { !declaredNames.contains($0) }
-        guard undeclared.isEmpty else {
-            if options.contains(.filterUndeclaredRequired) {
-                return required.filter(declaredNames.contains)
-            }
-            throw TachikomaError.invalidInput(
-                "Tool schema \(path) references undeclared properties: \(undeclared.joined(separator: ", "))",
-            )
+        if !undeclared.isEmpty, options.contains(.filterUndeclaredRequired) {
+            return required.filter(declaredNames.contains)
         }
         return required
     }

--- a/Sources/Tachikoma/Tools/ToolCompatibility.swift
+++ b/Sources/Tachikoma/Tools/ToolCompatibility.swift
@@ -97,37 +97,7 @@ public let weatherTool = createTool(
 
 /// Convert AgentToolParameters to JSON schema format
 public func toolParametersToJSON(_ parameters: AgentToolParameters) throws -> [String: Any] {
-    // Convert AgentToolParameters to JSON schema format
-    var schema: [String: Any] = [
-        "type": "object",
-        "properties": [:],
-        "required": parameters.required,
-    ]
-
-    var properties: [String: Any] = [:]
-    for (propertyName, property) in parameters.properties {
-        var propSchema: [String: Any] = [
-            "type": property.type.rawValue,
-            "description": property.description,
-        ]
-
-        if let enumValues = property.enumValues {
-            propSchema["enum"] = enumValues
-        }
-
-        // Handle array items if present
-        if property.type == .array, let items = property.items {
-            let itemsSchema: [String: Any] = [
-                "type": items.type,
-            ]
-            propSchema["items"] = itemsSchema
-        }
-
-        properties[propertyName] = propSchema
-    }
-
-    schema["properties"] = properties
-    return schema
+    try parameters.jsonSchema()
 }
 
 /// Convert JSON arguments to AgentToolArguments

--- a/Sources/TachikomaMCP/Bridge/MCPToolSchemaBridge.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolSchemaBridge.swift
@@ -15,9 +15,14 @@ enum MCPToolSchemaBridge {
         } else {
             [:]
         }
+        let type: DynamicSchema.SchemaType = if schema["type"] == nil {
+            .object
+        } else {
+            Self.schemaType(schema["type"])
+        }
 
         return DynamicSchema(
-            type: .object,
+            type: type,
             properties: properties,
             required: Self.stringArray(schema["required"]),
         )
@@ -48,10 +53,25 @@ enum MCPToolSchemaBridge {
         guard case let .object(schema)? = value else {
             return DynamicSchema.SchemaItems(type: .string)
         }
+        let type = Self.schemaType(schema["type"])
         return DynamicSchema.SchemaItems(
-            type: Self.schemaType(schema["type"]),
+            type: type,
             description: Self.string(schema["description"]),
+            enumValues: Self.optionalStringArray(schema["enum"]),
+            items: type == .array ? Self.optionalSchemaItems(from: schema["items"]) : nil,
+            properties: Self.nestedProperties(schema["properties"]),
+            required: Self.optionalStringArray(schema["required"]),
+            format: Self.string(schema["format"]),
+            minimum: Self.double(schema["minimum"]),
+            maximum: Self.double(schema["maximum"]),
+            minLength: Self.int(schema["minLength"]),
+            maxLength: Self.int(schema["maxLength"]),
         )
+    }
+
+    private static func optionalSchemaItems(from value: Value?) -> DynamicSchema.SchemaItems? {
+        guard case .object? = value else { return nil }
+        return self.schemaItems(from: value)
     }
 
     private static func nestedProperties(_ value: Value?) -> [String: DynamicSchema.SchemaProperty]? {

--- a/Tests/TachikomaMCPTests/MCPToolAdapterTests.swift
+++ b/Tests/TachikomaMCPTests/MCPToolAdapterTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MCP
 import Tachikoma
 import Testing
@@ -22,8 +23,42 @@ struct MCPToolAdapterTests {
                         "description": .string("Tag identifier"),
                     ]),
                 ]),
+                "settings": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "retries": .object([
+                            "type": .string("integer"),
+                            "minimum": .int(0),
+                            "maximum": .int(3),
+                        ]),
+                    ]),
+                    "required": .array([.string("retries")]),
+                ]),
+                "matrix": .object([
+                    "type": .string("array"),
+                    "items": .object([
+                        "type": .string("array"),
+                        "items": .object([
+                            "type": .string("number"),
+                            "minimum": .double(0.25),
+                            "maximum": .int(1),
+                        ]),
+                    ]),
+                ]),
+                "openMatrix": .object([
+                    "type": .string("array"),
+                    "items": .object([
+                        "type": .string("array"),
+                    ]),
+                ]),
             ]),
-            "required": .array([.string("mode"), .int(42), .string("tags")]),
+            "required": .array([
+                .string("mode"),
+                .int(42),
+                .string("tags"),
+                .string("settings"),
+                .string("matrix"),
+            ]),
         ])
         let mcpTool = MCP.Tool(name: "run", description: "Run work", inputSchema: inputSchema)
         let client = MCPClient(name: "test", config: MCPServerConfig(command: "unused"))
@@ -32,7 +67,7 @@ struct MCPToolAdapterTests {
         let dynamicTool = try #require(MCPToolProvider.makeDynamicTools(from: [mcpTool]).first)
         let dynamicParameters = dynamicTool.schema.toAgentToolParameters()
 
-        #expect(staticTool.parameters.required == ["mode", "tags"])
+        #expect(staticTool.parameters.required == ["mode", "tags", "settings", "matrix"])
         #expect(dynamicParameters.required == staticTool.parameters.required)
         #expect(dynamicParameters.properties["mode"]?.type == staticTool.parameters.properties["mode"]?.type)
         #expect(dynamicParameters.properties["mode"]?.description == "Execution mode")
@@ -45,6 +80,69 @@ struct MCPToolAdapterTests {
         #expect(
             dynamicParameters.properties["tags"]?.items?.type == staticTool.parameters.properties["tags"]?.items?.type,
         )
+        let settings = try #require(dynamicParameters.properties["settings"])
+        #expect(settings.required == ["retries"])
+        #expect(settings.properties?["retries"]?.minimum == 0)
+        #expect(settings.properties?["retries"]?.maximum == 3)
+        #expect(settings.properties?["retries"]?.minimum == staticTool.parameters.properties["settings"]?
+            .properties?["retries"]?.minimum)
+        let matrixItems = try #require(dynamicParameters.properties["matrix"]?.items)
+        #expect(matrixItems.type == "array")
+        #expect(matrixItems.items?.type == "number")
+        #expect(matrixItems.items?.minimum == 0.25)
+        #expect(matrixItems.items?.maximum == 1)
+        #expect(matrixItems.items?.minimum == staticTool.parameters.properties["matrix"]?.items?.items?.minimum)
+        let openMatrixItems = try #require(dynamicParameters.properties["openMatrix"]?.items)
+        #expect(openMatrixItems.type == "array")
+        #expect(openMatrixItems.items == nil)
+        #expect(staticTool.parameters.properties["openMatrix"]?.items?.items == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Real stdio discovery preserves nested schema for static and dynamic tools`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tachikoma-schema-\(UUID().uuidString)", isDirectory: true)
+        let script = directory.appendingPathComponent("server.sh")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(Self.schemaServerScript.utf8).write(to: script)
+
+        let client = MCPClient(
+            name: "schema-stdio",
+            config: MCPServerConfig(
+                command: "/bin/sh",
+                args: [script.path],
+                timeout: 5,
+                autoReconnect: false,
+            ),
+        )
+
+        do {
+            try await client.connect()
+            let mcpTool = try #require(await client.tools.first)
+            let staticTool = MCPToolAdapter.toAgentTool(from: mcpTool, client: client)
+            let provider = MCPToolProvider(client: client)
+            let dynamicTool = try #require(try await provider.discoverTools().first)
+            let dynamicParameters = dynamicTool.schema.toAgentToolParameters()
+
+            #expect(staticTool.parameters.required == ["settings", "steps"])
+            #expect(dynamicParameters.required == staticTool.parameters.required)
+            let settings = try #require(dynamicParameters.properties["settings"])
+            #expect(settings.required == ["mode"])
+            #expect(settings.properties?["mode"]?.enumValues == ["safe", "fast"])
+            let stepItems = try #require(dynamicParameters.properties["steps"]?.items)
+            #expect(stepItems.type == "object")
+            #expect(stepItems.required == ["label"])
+            #expect(stepItems.properties?["label"]?.minLength == 1)
+            #expect(stepItems.properties?["label"]?.maxLength == 12)
+            #expect(stepItems.required == staticTool.parameters.properties["steps"]?.items?.required)
+
+            await client.disconnect()
+            try FileManager.default.removeItem(at: directory)
+        } catch {
+            await client.disconnect()
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
     }
 
     @Test
@@ -71,6 +169,16 @@ struct MCPToolAdapterTests {
         #expect(converted.properties?["unknown"]?.type == .string)
         #expect(converted.properties?["unknown"]?.description == "Parameter")
         #expect(converted.properties?["untypedArray"]?.items?.type == .string)
+
+        let invalidRoot = MCPToolSchemaBridge.dynamicSchema(from: .object([
+            "type": .string("array"),
+            "items": .object(["type": .string("string")]),
+        ]))
+        #expect(invalidRoot.type == .array)
+        #expect(invalidRoot.toAgentToolParameters().type == "array")
+        #expect(throws: TachikomaError.self) {
+            _ = try toolParametersToJSON(invalidRoot.toAgentToolParameters())
+        }
     }
 
     @Test
@@ -227,4 +335,30 @@ struct MCPToolAdapterTests {
             Issue.record("Expected image content")
         }
     }
+
+    private static let schemaServerScript = #"""
+    while IFS= read -r line; do
+      id=$(printf '%s\n' "$line" | /usr/bin/sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+      case "$line" in
+        *'"method":"initialize"'*)
+          response='{"jsonrpc":"2.0","id":'
+          response=$response"$id"
+          response=$response',"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},'
+          response=$response'"serverInfo":{"name":"schema-fixture","version":"1.0"}}}'
+          printf '%s\n' "$response"
+          ;;
+        *tools*list*)
+          response='{"jsonrpc":"2.0","id":'
+          response=$response"$id"
+          response=$response',"result":{"tools":[{"name":"run_plan","description":"Run a plan","inputSchema":{'
+          response=$response'"type":"object","properties":{"settings":{"type":"object","properties":{'
+          response=$response'"mode":{"type":"string","enum":["safe","fast"]}},"required":["mode"]},'
+          response=$response'"steps":{"type":"array","items":{"type":"object","description":"One step",'
+          response=$response'"properties":{"label":{"type":"string","minLength":1,"maxLength":12}},'
+          response=$response'"required":["label"]}}},"required":["settings","steps"]}}]}}'
+          printf '%s\n' "$response"
+          ;;
+      esac
+    done
+    """#
 }

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -217,6 +217,114 @@ struct ProviderEndToEndTests {
         }
     }
 
+    @Test
+    func `All provider families preserve canonical nested tool schemas`() async throws {
+        let providerRequest = Self.schemaParityRequest
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let schema = try #require(tools.first?["parameters"] as? [String: Any])
+            try self.expectSchemaParity(schema)
+            return NetworkMocking.jsonResponse(
+                for: request,
+                data: Self.openAIResponsesPayload(text: "OpenAI schema ok"),
+            )
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("sk-live-openai", for: .openai)
+            }
+            let provider = try OpenAIResponsesProvider(model: .gpt5Mini, configuration: config)
+            _ = try await provider.generateText(request: providerRequest)
+        }
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let function = try #require(tools.first?["function"] as? [String: Any])
+            try self.expectSchemaParity(#require(function["parameters"] as? [String: Any]))
+            return NetworkMocking.jsonResponse(
+                for: request,
+                data: Self.chatCompletionPayload(text: "Compatible schema ok"),
+            )
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("live-compatible", for: "openai_compatible")
+            }
+            let provider = try OpenAICompatibleProvider(
+                modelId: "schema-model",
+                baseURL: "https://compatible.test",
+                configuration: config,
+            )
+            _ = try await provider.generateText(request: providerRequest)
+        }
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            try self.expectSchemaParity(#require(tools.first?["input_schema"] as? [String: Any]))
+            return NetworkMocking.jsonResponse(for: request, data: Self.anthropicPayload(text: "Anthropic schema ok"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("live-anthropic", for: .anthropic)
+            }
+            let provider = try AnthropicProvider(model: .sonnet46, configuration: config)
+            _ = try await provider.generateText(request: providerRequest)
+        }
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let declarations = try #require(tools.first?["functionDeclarations"] as? [[String: Any]])
+            try self.expectSchemaParity(#require(declarations.first?["parameters"] as? [String: Any]))
+            return NetworkMocking.streamResponse(for: request, data: Self.googleStreamPayload(text: "Google schema ok"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("google-live", for: .google)
+            }
+            let provider = try GoogleProvider(model: .gemini25Flash, configuration: config)
+            _ = try await provider.generateText(request: providerRequest)
+        }
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let function = try #require(tools.first?["function"] as? [String: Any])
+            try self.expectSchemaParity(#require(function["parameters"] as? [String: Any]))
+            return NetworkMocking.jsonResponse(for: request, data: Self.ollamaPayload(text: "Ollama schema ok"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setBaseURL("http://localhost:11434", for: .ollama)
+            }
+            let provider = try OllamaProvider(model: .llama33, configuration: config)
+            _ = try await provider.generateText(request: providerRequest)
+        }
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let function = try #require(tools.first?["function"] as? [String: Any])
+            try self.expectSchemaParity(#require(function["parameters"] as? [String: Any]))
+            return NetworkMocking.jsonResponse(
+                for: request,
+                data: Self.chatCompletionPayload(text: "LM Studio schema ok"),
+            )
+        } operation: {
+            let provider = LMStudioProvider(
+                baseURL: "http://localhost:1234/v1",
+                modelId: "local",
+                sessionConfiguration: Self.mockedSessionConfiguration(),
+            )
+            _ = try await provider.generateText(request: providerRequest)
+        }
+    }
+
     // MARK: - OpenAI-compatible providers
 
     @Test
@@ -1496,6 +1604,116 @@ struct ProviderEndToEndTests {
         ProviderRequest(
             messages: [ModelMessage(role: .user, content: [.text("Hello there")])],
         )
+    }
+
+    private static var schemaParityRequest: ProviderRequest {
+        let tool = AgentTool(
+            name: "run_plan",
+            description: "Run a constrained plan",
+            parameters: AgentToolParameters(
+                properties: [
+                    "settings": AgentToolParameterProperty(
+                        name: "settings",
+                        type: .object,
+                        description: "Execution settings",
+                        properties: [
+                            "mode": AgentToolParameterProperty(
+                                name: "mode",
+                                type: .string,
+                                description: "Execution mode",
+                                enumValues: ["safe", "fast"],
+                                format: "mode-name",
+                                minLength: 4,
+                                maxLength: 4,
+                            ),
+                            "retries": AgentToolParameterProperty(
+                                name: "retries",
+                                type: .integer,
+                                description: "Retry count",
+                                minimum: 0,
+                                maximum: 3,
+                            ),
+                        ],
+                        required: ["mode"],
+                    ),
+                    "steps": AgentToolParameterProperty(
+                        name: "steps",
+                        type: .array,
+                        description: "Plan steps",
+                        items: AgentToolParameterItems(
+                            type: "object",
+                            description: "One step",
+                            properties: [
+                                "label": AgentToolParameterProperty(
+                                    name: "label",
+                                    type: .string,
+                                    description: "Step label",
+                                ),
+                            ],
+                            required: ["label"],
+                        ),
+                    ),
+                    "matrix": AgentToolParameterProperty(
+                        name: "matrix",
+                        type: .array,
+                        description: "Rows",
+                        items: AgentToolParameterItems(
+                            type: "array",
+                            description: "Row",
+                            items: AgentToolParameterItems(
+                                type: "integer",
+                                description: "Cell",
+                                minimum: 0,
+                                maximum: 9,
+                            ),
+                        ),
+                    ),
+                ],
+                required: ["settings", "steps", "matrix"],
+            ),
+        ) { _ in
+            AnyAgentToolValue(string: "unused")
+        }
+        return ProviderRequest(
+            messages: [.user("Run it")],
+            tools: [tool],
+            settings: .init(maxTokens: 32),
+        )
+    }
+
+    private func expectSchemaParity(_ schema: [String: Any]) throws {
+        #expect(schema["type"] as? String == "object")
+        #expect(schema["required"] as? [String] == ["settings", "steps", "matrix"])
+        let properties = try #require(schema["properties"] as? [String: Any])
+
+        let settings = try #require(properties["settings"] as? [String: Any])
+        #expect(settings["type"] as? String == "object")
+        #expect(settings["required"] as? [String] == ["mode"])
+        let settingProperties = try #require(settings["properties"] as? [String: Any])
+        let mode = try #require(settingProperties["mode"] as? [String: Any])
+        #expect(mode["enum"] as? [String] == ["safe", "fast"])
+        #expect(mode["format"] as? String == "mode-name")
+        #expect(mode["minLength"] as? Int == 4)
+        #expect(mode["maxLength"] as? Int == 4)
+        let retries = try #require(settingProperties["retries"] as? [String: Any])
+        #expect(retries["minimum"] as? Double == 0)
+        #expect(retries["maximum"] as? Double == 3)
+
+        let steps = try #require(properties["steps"] as? [String: Any])
+        let items = try #require(steps["items"] as? [String: Any])
+        #expect(items["type"] as? String == "object")
+        #expect(items["description"] as? String == "One step")
+        #expect(items["required"] as? [String] == ["label"])
+        let itemProperties = try #require(items["properties"] as? [String: Any])
+        #expect((itemProperties["label"] as? [String: Any])?["type"] as? String == "string")
+
+        let matrix = try #require(properties["matrix"] as? [String: Any])
+        let row = try #require(matrix["items"] as? [String: Any])
+        #expect(row["type"] as? String == "array")
+        let cell = try #require(row["items"] as? [String: Any])
+        #expect(cell["type"] as? String == "integer")
+        #expect(cell["minimum"] as? Double == 0)
+        #expect(cell["maximum"] as? Double == 9)
     }
 
     private static func makeConfiguration(_ builder: (TachikomaConfiguration) -> Void) -> TachikomaConfiguration {

--- a/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
+++ b/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
@@ -135,7 +135,6 @@ struct AgentToolSchemaSerializationTests {
     @Test
     func `Malformed schemas fail before provider serialization`() {
         let malformed: [AgentToolParameters] = [
-            AgentToolParameters(required: ["missing"]),
             AgentToolParameters(
                 properties: [
                     "value": .init(name: "value", type: .string, description: "Value"),
@@ -218,6 +217,23 @@ struct AgentToolSchemaSerializationTests {
         #expect(throws: TachikomaError.self) {
             _ = try dynamicRoot.jsonSchema()
         }
+    }
+
+    @Test
+    func `Default serialization preserves unconstrained required names while Google filtering remains explicit`(
+    ) throws {
+        let parameters = AgentToolParameters(
+            properties: [
+                "query": .init(name: "query", type: .string, description: "Query"),
+            ],
+            required: ["query", "unconstrained"],
+        )
+
+        let compatibilitySchema = try parameters.jsonSchema()
+        #expect(compatibilitySchema["required"] as? [String] == ["query", "unconstrained"])
+
+        let googleSchema = try parameters.jsonSchema(options: [.filterUndeclaredRequired])
+        #expect(googleSchema["required"] as? [String] == ["query"])
     }
 
     @Test

--- a/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
+++ b/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import Testing
+@testable import Tachikoma
+
+struct AgentToolSchemaSerializationTests {
+    @Test
+    func `Original public initializer function references remain source compatible`() {
+        let propertyInitializer: (
+            String,
+            AgentToolParameterProperty.ParameterType,
+            String,
+            [String]?,
+            AgentToolParameterItems?,
+        )
+            -> AgentToolParameterProperty = AgentToolParameterProperty.init(
+                name:type:description:enumValues:items:
+            )
+        let itemInitializer: (String, String?) -> AgentToolParameterItems = AgentToolParameterItems.init(
+            type:description:
+        )
+        let dynamicItemInitializer: (
+            DynamicSchema.SchemaType,
+            String?,
+        )
+            -> DynamicSchema.SchemaItems = DynamicSchema.SchemaItems.init(type:description:)
+
+        #expect(propertyInitializer("name", .string, "Name", nil, nil).name == "name")
+        #expect(itemInitializer("string", "Item").description == "Item")
+        #expect(dynamicItemInitializer(.integer, "Item").type == .integer)
+    }
+
+    @Test
+    func `Dynamic schema conversion and Codable preserve every supported field`() throws {
+        let dynamic = DynamicSchema(
+            type: .object,
+            properties: [
+                "settings": DynamicSchema.SchemaProperty(
+                    type: .object,
+                    description: "Settings",
+                    properties: [
+                        "mode": DynamicSchema.SchemaProperty(
+                            type: .string,
+                            description: "Mode",
+                            enumValues: ["safe", "fast"],
+                            format: "mode-name",
+                            minLength: 4,
+                            maxLength: 4,
+                        ),
+                    ],
+                    required: ["mode"],
+                ),
+                "steps": DynamicSchema.SchemaProperty(
+                    type: .array,
+                    description: "Steps",
+                    items: DynamicSchema.SchemaItems(
+                        type: .object,
+                        description: "Step",
+                        properties: [
+                            "weight": DynamicSchema.SchemaProperty(
+                                type: .number,
+                                description: "Weight",
+                                minimum: 0.25,
+                                maximum: 1,
+                            ),
+                        ],
+                        required: ["weight"],
+                    ),
+                ),
+                "matrix": DynamicSchema.SchemaProperty(
+                    type: .array,
+                    description: "Rows",
+                    items: DynamicSchema.SchemaItems(
+                        type: .array,
+                        description: "Row",
+                        items: DynamicSchema.SchemaItems(
+                            type: .integer,
+                            description: "Cell",
+                            minimum: 0,
+                            maximum: 9,
+                        ),
+                    ),
+                ),
+            ],
+            required: ["settings", "steps", "matrix"],
+        )
+
+        let dynamicData = try JSONEncoder().encode(dynamic)
+        let decodedDynamic = try JSONDecoder().decode(DynamicSchema.self, from: dynamicData)
+        let parameters = decodedDynamic.toAgentToolParameters()
+        let parametersData = try JSONEncoder().encode(parameters)
+        let decodedParameters = try JSONDecoder().decode(AgentToolParameters.self, from: parametersData)
+
+        #expect(decodedParameters.required == ["settings", "steps", "matrix"])
+        let settings = try #require(decodedParameters.properties["settings"])
+        #expect(settings.required == ["mode"])
+        let mode = try #require(settings.properties?["mode"])
+        #expect(mode.enumValues == ["safe", "fast"])
+        #expect(mode.format == "mode-name")
+        #expect(mode.minLength == 4)
+        #expect(mode.maxLength == 4)
+        let stepItems = try #require(decodedParameters.properties["steps"]?.items)
+        #expect(stepItems.type == "object")
+        #expect(stepItems.description == "Step")
+        #expect(stepItems.required == ["weight"])
+        let weight = try #require(stepItems.properties?["weight"])
+        #expect(weight.minimum == 0.25)
+        #expect(weight.maximum == 1)
+        let matrixItems = try #require(decodedParameters.properties["matrix"]?.items)
+        #expect(matrixItems.type == "array")
+        #expect(matrixItems.items?.type == "integer")
+        #expect(matrixItems.items?.minimum == 0)
+        #expect(matrixItems.items?.maximum == 9)
+
+        let schema = try toolParametersToJSON(decodedParameters)
+        let properties = try #require(schema["properties"] as? [String: Any])
+        let encodedSettings = try #require(properties["settings"] as? [String: Any])
+        #expect(encodedSettings["required"] as? [String] == ["mode"])
+        let encodedMode = try #require(
+            (encodedSettings["properties"] as? [String: Any])?["mode"] as? [String: Any],
+        )
+        #expect(encodedMode["enum"] as? [String] == ["safe", "fast"])
+        #expect(encodedMode["format"] as? String == "mode-name")
+        let encodedSteps = try #require(properties["steps"] as? [String: Any])
+        let encodedItems = try #require(encodedSteps["items"] as? [String: Any])
+        #expect(encodedItems["required"] as? [String] == ["weight"])
+        #expect((encodedItems["properties"] as? [String: Any])?["weight"] is [String: Any])
+        let encodedMatrix = try #require(properties["matrix"] as? [String: Any])
+        let encodedRow = try #require(encodedMatrix["items"] as? [String: Any])
+        let encodedCell = try #require(encodedRow["items"] as? [String: Any])
+        #expect(encodedCell["type"] as? String == "integer")
+        #expect(encodedCell["minimum"] as? Double == 0)
+        #expect(encodedCell["maximum"] as? Double == 9)
+    }
+
+    @Test
+    func `Malformed schemas fail before provider serialization`() {
+        let malformed: [AgentToolParameters] = [
+            AgentToolParameters(required: ["missing"]),
+            AgentToolParameters(
+                properties: [
+                    "value": .init(name: "value", type: .string, description: "Value"),
+                ],
+                required: ["value", "value"],
+            ),
+            AgentToolParameters(properties: [
+                "values": .init(
+                    name: "values",
+                    type: .array,
+                    description: "Values",
+                    items: .init(type: "future-type"),
+                ),
+            ]),
+            AgentToolParameters(properties: [
+                "ratio": .init(
+                    name: "ratio",
+                    type: .number,
+                    description: "Ratio",
+                    minimum: .nan,
+                ),
+            ]),
+            AgentToolParameters(properties: [
+                "count": .init(
+                    name: "count",
+                    type: .integer,
+                    description: "Count",
+                    minimum: 5,
+                    maximum: 2,
+                ),
+            ]),
+            AgentToolParameters(properties: [
+                "enabled": .init(
+                    name: "enabled",
+                    type: .boolean,
+                    description: "Enabled",
+                    minLength: 1,
+                ),
+            ]),
+            AgentToolParameters(properties: [
+                "value": .init(
+                    name: "value",
+                    type: .string,
+                    description: "Value",
+                    properties: [:],
+                ),
+            ]),
+            AgentToolParameters(properties: [
+                "mode": .init(
+                    name: "mode",
+                    type: .string,
+                    description: "Mode",
+                    enumValues: [],
+                ),
+            ]),
+            AgentToolParameters(properties: [
+                "mode": .init(
+                    name: "mode",
+                    type: .string,
+                    description: "Mode",
+                    enumValues: ["safe", "safe"],
+                ),
+            ]),
+        ]
+
+        for parameters in malformed {
+            #expect(throws: TachikomaError.self) {
+                _ = try parameters.jsonSchema()
+            }
+        }
+
+        let nonObjectRoot = Data(#"{"type":"array","properties":{},"required":[]}"#.utf8)
+        #expect(throws: TachikomaError.self) {
+            let decoded = try JSONDecoder().decode(AgentToolParameters.self, from: nonObjectRoot)
+            _ = try decoded.jsonSchema()
+        }
+
+        let dynamicRoot = DynamicSchema(type: .array).toAgentToolParameters()
+        #expect(dynamicRoot.type == "array")
+        #expect(throws: TachikomaError.self) {
+            _ = try dynamicRoot.jsonSchema()
+        }
+    }
+
+    @Test
+    func `Provider policies only adjust established required and array fallbacks`() throws {
+        let parameters = AgentToolParameters(
+            properties: [
+                "values": .init(name: "values", type: .array, description: "Values"),
+            ],
+            required: ["missing"],
+        )
+
+        let googleSchema = try parameters.jsonSchema(options: [
+            .filterUndeclaredRequired,
+            .omitEmptyRequired,
+        ])
+        #expect(googleSchema["required"] == nil)
+        let googleProperties = try #require(googleSchema["properties"] as? [String: Any])
+        #expect((googleProperties["values"] as? [String: Any])?["items"] == nil)
+
+        let openAISchema = try AgentToolParameters(
+            properties: parameters.properties,
+            required: [],
+        ).jsonSchema(options: [.defaultStringArrayItems, .omitEmptyRequired])
+        #expect(openAISchema["required"] == nil)
+        let openAIProperties = try #require(openAISchema["properties"] as? [String: Any])
+        let items = try #require((openAIProperties["values"] as? [String: Any])?["items"] as? [String: Any])
+        #expect(items["type"] as? String == "string")
+    }
+}


### PR DESCRIPTION
## Summary

- centralize recursive `AgentToolParameters` JSON-schema serialization across provider and compatibility paths
- preserve nested object properties, required arrays, enums, array items including arrays-of-arrays, and supported scalar constraints
- route OpenAI-compatible, Responses, Anthropic, Google, Ollama, LM Studio, dynamic MCP, and public compatibility serialization through the same fidelity owner
- reject malformed roots, shapes, constraints, and enums before provider emission
- preserve public initializer overloads, function references, Codable keys, and Responses `strict: false`

## Proof

- core/provider suite: 837 tests
- MCP suite: 55 tests
- real spawned stdio MCP discovery
- six provider-family request-parity checks
- Release build
- strict SwiftFormat, SwiftLint, and diff checks
- bounded review fixes for nested arrays and malformed constraints
- final whole-branch P0-P2 review clean at 0.94

No provider capability is invented; unsupported fields remain omitted according to each provider contract.
