### PR TITLE
fix(mcp): serialize stdio request frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.
 - Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.
 - MCP tool discovery now uses one schema conversion path so static and dynamic tools preserve matching descriptions, enums, array item types, and required fields.
 - Composite dynamic tool providers now recover unchanged bindings after transient discovery failures while keeping real ownership changes fail-closed.

--- a/Sources/TachikomaMCP/Client/StdioTransport.swift
+++ b/Sources/TachikomaMCP/Client/StdioTransport.swift
@@ -79,9 +79,36 @@ private actor StdioTransportState {
     }
 }
 
+/// Serializes complete JSON-line frames onto the stdio request pipe.
+///
+/// A single MCP connection can execute tools concurrently. Keeping payload and delimiter
+/// construction inside this actor prevents request bytes from interleaving across callers.
+actor StdioFrameWriter {
+    private var handle: FileHandle?
+
+    func install(_ handle: FileHandle) {
+        self.handle = handle
+    }
+
+    func removeHandle() {
+        self.handle = nil
+    }
+
+    func write(payload: Data) throws {
+        guard let handle else {
+            throw MCPError.notConnected
+        }
+
+        var frame = payload
+        frame.append(0x0A)
+        try handle.write(contentsOf: frame)
+    }
+}
+
 /// Standard I/O transport for MCP communication
 public final class StdioTransport: MCPTransport {
     private let state = StdioTransportState()
+    private let frameWriter = StdioFrameWriter()
     private let logger = Logger(label: "tachikoma.mcp.stdio")
     private static let _sigpipeHandlerInstalled: Void = {
         signal(SIGPIPE, SIG_IGN)
@@ -174,6 +201,7 @@ public final class StdioTransport: MCPTransport {
 
         await self.state.setProcess(process, input: inputPipe, output: outputPipe, error: errorPipe)
         await self.state.setRequestTimeout(seconds: config.timeout)
+        await self.frameWriter.install(inputPipe.fileHandleForWriting)
 
         self.logger.info("About to start reading output")
         self.stdoutSource = self.makeReadSource(for: outputPipe, isStderr: false)
@@ -192,6 +220,8 @@ public final class StdioTransport: MCPTransport {
         self.stdoutQueue.sync { self.stdoutBuffer.removeAll(keepingCapacity: false) }
         self.stderrQueue.sync { self.stderrBuffer.removeAll(keepingCapacity: false) }
         self.closeDebugHandles()
+
+        await self.frameWriter.removeHandle()
 
         let inputPipe = await state.getInputPipe()
         let outputPipe = await state.getOutputPipe()
@@ -288,13 +318,8 @@ public final class StdioTransport: MCPTransport {
     }
 
     private func send(_ data: Data) async throws {
-        guard let inputPipe = await state.getInputPipe() else {
-            throw MCPError.notConnected
-        }
         // MCP TypeScript SDK uses simple newline-delimited JSON, NOT LSP-style framing
-        // Just send the JSON followed by a newline
-        try inputPipe.fileHandleForWriting.write(contentsOf: data)
-        try inputPipe.fileHandleForWriting.write(contentsOf: "\n".utf8Data())
+        try await self.frameWriter.write(payload: data)
 
         // Log what we sent for debugging
         if let json = String(data: data, encoding: .utf8) {

--- a/Tests/TachikomaMCPTests/StdioFrameWriterTests.swift
+++ b/Tests/TachikomaMCPTests/StdioFrameWriterTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import TachikomaMCP
+
+@Suite("Stdio frame writer")
+struct StdioFrameWriterTests {
+    @Test
+    func `Concurrent sends preserve complete JSON lines`() async throws {
+        let pipe = Pipe()
+        let writer = StdioFrameWriter()
+        await writer.install(pipe.fileHandleForWriting)
+
+        let payloads = (0..<512).map { Data("{\"id\":\($0)}".utf8) }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for payload in payloads {
+                group.addTask {
+                    try await writer.write(payload: payload)
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        await writer.removeHandle()
+        try pipe.fileHandleForWriting.close()
+        let output = pipe.fileHandleForReading.readDataToEndOfFile()
+        let lines = output.split(separator: 0x0A).map(Data.init)
+
+        #expect(output.last == 0x0A)
+        #expect(lines.count == payloads.count)
+        #expect(Set(lines) == Set(payloads))
+    }
+
+    @Test
+    func `Writes fail when no request pipe is installed`() async {
+        let writer = StdioFrameWriter()
+
+        await #expect(throws: MCPError.self) {
+            try await writer.write(payload: Data("{}".utf8))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- serialize every stdio MCP payload and trailing newline through one actor-owned writer
- install and remove the writer handle with the transport lifecycle so disconnected sends still fail closed
- cover 512 concurrent sends with a deterministic complete-frame regression

## Testing

- `swiftformat --lint . --config .swiftformat`
- `swiftlint lint --config .swiftlint.yml --strict`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (895 tests passed)
- `swift build -c release`
- `swift build -Xswiftc -swift-version -Xswiftc 6 -Xswiftc -warn-concurrency`
- P0-P2 Autoreview: clean
