### PR TITLE
fix(ci): make dependency and test proof hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Select Xcode 26.1
       if: runner.os == 'macOS'
       run: sudo xcode-select -s /Applications/Xcode_26.1.app || sudo xcode-select -s /Applications/Xcode_26.0.app || sudo xcode-select -s /Applications/Xcode.app
@@ -84,10 +79,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v7
-
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
 
     - name: Select Xcode 26.1
       if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,30 +44,17 @@ jobs:
     - name: Build
       run: swift build -c release --verbose
 
-    - name: Run Tests (Unit Tests Only)
+    - name: Run Hermetic Tests
       run: |
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           # Several test suites mutate process-wide env/profile state.
           swift test --no-parallel --filter TachikomaTests --skip "OpenAIAudioProviderTests" --skip "ProviderEndToEndTests"
         else
-          swift test --filter TachikomaTests
+          swift test --parallel
         fi
       env:
         TACHIKOMA_DISABLE_API_TESTS: "true"
         TACHIKOMA_TEST_MODE: "mock"
-      continue-on-error: true
-
-    - name: Run Package Tests (Full API Testing)
-      run: swift test --verbose
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-        GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-        X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
-        XAI_API_KEY: ${{ secrets.X_AI_API_KEY }}
-      continue-on-error: true
 
   build-examples:
     name: Build Examples on ${{ matrix.os }}
@@ -134,4 +121,3 @@ jobs:
 
     - name: SwiftLint
       run: swiftlint --config .swiftlint.yml --strict
-      continue-on-error: true # Don't fail CI on lint issues initially

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -28,9 +28,6 @@ jobs:
     container: swift:6.2
     steps:
       - uses: actions/checkout@v7
-      - name: Fetch Commander dependency
-        shell: bash
-        run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
       
       - name: Install dependencies
         run: |
@@ -57,9 +54,6 @@ jobs:
     container: swift:6.2
     steps:
       - uses: actions/checkout@v7
-      - name: Fetch Commander dependency
-        shell: bash
-        run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Setup Xcode 26.1
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -73,10 +69,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Setup Xcode 26.1
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -112,10 +104,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v7
-
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
 
     - name: Setup Xcode 26.1
       uses: maxim-lobanov/setup-xcode@v1
@@ -160,10 +148,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -172,6 +156,13 @@ jobs:
     - name: Validate Swift Package Structure
       run: |
         # Check package structure
+        PACKAGE_DUMP="$(swift package dump-package)"
+        jq '.' <<< "$PACKAGE_DUMP"
+        jq -e '
+          any(.dependencies[];
+            .sourceControl[0].identity? == "commander" and
+            .sourceControl[0].location.remote[0].urlString == "https://github.com/steipete/Commander.git")
+        ' <<< "$PACKAGE_DUMP" > /dev/null
         swift package describe --type json | jq '.'
         
         # Validate dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Setup Xcode 26.1
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -77,10 +73,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Setup Swift
       uses: SwiftyLab/setup-swift@v1
       with:
@@ -124,10 +116,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
-
     - name: Setup Xcode 26.1
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -156,10 +144,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v7
-
-    - name: Fetch Commander dependency
-      shell: bash
-      run: git clone --depth 1 https://github.com/steipete/Commander.git ../Commander
 
     - name: Setup Xcode 26.1
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
 
     - name: Run Integration Tests
       env:
+        INTEGRATION_TESTS: "1"
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
@@ -159,9 +160,4 @@ jobs:
         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
         XAI_API_KEY: ${{ secrets.X_AI_API_KEY }}
-      run: |
-        if [[ -n "$OPENAI_API_KEY" && -n "$ANTHROPIC_API_KEY" ]]; then
-          swift test --filter IntegrationTests
-        else
-          echo "Skipping integration tests - API keys not available"
-        fi
+      run: swift test --no-parallel -Xswiftc -DLIVE_PROVIDER_TESTS --filter ProviderIntegrationTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Commander now resolves from its declared SwiftPM release in every checkout and CI job, eliminating ambient sibling-directory overrides.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.
 - Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.
 - MCP tool discovery now uses one schema conversion path so static and dynamic tools preserve matching descriptions, enums, array item types, and required fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
-- Commander now resolves from its declared SwiftPM release in every checkout and CI job, eliminating ambient sibling-directory overrides.
+- Commander now resolves from its declared SwiftPM release in every checkout and CI job, hermetic macOS/Linux tests block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.
 - Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.
 - MCP tool discovery now uses one schema conversion path so static and dynamic tools preserve matching descriptions, enums, array item types, and required fields.

--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,7 @@
 // swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
-import Foundation
 import PackageDescription
-
-let packageDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-let localCommanderPath = packageDirectory
-    .deletingLastPathComponent()
-    .appendingPathComponent("Commander")
-    .appendingPathComponent("Package.swift")
-let isDependencyCheckout = packageDirectory.deletingLastPathComponent().lastPathComponent == "checkouts"
-let commanderDependency: Package.Dependency = !isDependencyCheckout && FileManager.default.fileExists(atPath: localCommanderPath.path)
-    ? .package(path: "../Commander")
-    : .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4")
 
 let package = Package(
     name: "Tachikoma",
@@ -60,7 +49,7 @@ let package = Package(
             targets: ["TachikomaConfigCLI"]),
     ],
     dependencies: [
-        commanderDependency,
+        .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.15.0"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
         .package(url: "https://github.com/apple/swift-configuration", from: "1.2.0"),

--- a/Tests/TachikomaTests/Providers/Compatible/AzureOpenAIProviderTests.swift
+++ b/Tests/TachikomaTests/Providers/Compatible/AzureOpenAIProviderTests.swift
@@ -4,14 +4,25 @@ import Testing
 @testable import Tachikoma
 
 private final class AzureTestURLProtocol: URLProtocol {
-    private actor Store {
-        private(set) var lastRequest: URLRequest?
+    private final class Store: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lastRequest: URLRequest?
 
         func store(_ request: URLRequest) {
+            self.lock.lock()
+            defer { self.lock.unlock() }
             self.lastRequest = request
         }
 
+        func fetch() -> URLRequest? {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.lastRequest
+        }
+
         func reset() {
+            self.lock.lock()
+            defer { self.lock.unlock() }
             self.lastRequest = nil
         }
     }
@@ -41,10 +52,10 @@ private final class AzureTestURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        Task { [request] in await AzureTestURLProtocol.storeMedia(request) }
+        Self.store.store(self.request)
 
         let response = HTTPURLResponse(
-            url: request.url!,
+            url: self.request.url!,
             statusCode: 200,
             httpVersion: nil,
             headerFields: ["Content-Type": "application/json"],
@@ -57,16 +68,12 @@ private final class AzureTestURLProtocol: URLProtocol {
 
     override func stopLoading() {}
 
-    private static func storeMedia(_ request: URLRequest) async {
-        await self.store.store(request)
+    static func fetchLastRequest() -> URLRequest? {
+        self.store.fetch()
     }
 
-    static func fetchLastRequest() async -> URLRequest? {
-        await self.store.lastRequest
-    }
-
-    static func reset() async {
-        await self.store.reset()
+    static func reset() {
+        self.store.reset()
     }
 }
 
@@ -82,7 +89,7 @@ struct AzureOpenAIProviderTests {
     func `Builds Azure chat URL with api-version and api-key header`() async throws {
         let config = TachikomaConfiguration(loadFromEnvironment: false)
         config.setAPIKey("test-key", for: .azureOpenAI)
-        await AzureTestURLProtocol.reset()
+        AzureTestURLProtocol.reset()
 
         let provider = try AzureOpenAIProvider(
             deploymentId: "gpt-5.5",
@@ -98,7 +105,7 @@ struct AzureOpenAIProviderTests {
 
         #expect(response.text == "hello azure")
 
-        let sentRequest = await AzureTestURLProtocol.fetchLastRequest()
+        let sentRequest = AzureTestURLProtocol.fetchLastRequest()
         #expect(sentRequest?.url?.path == "/openai/deployments/gpt-5.5/chat/completions")
 
         if let components = sentRequest?.url.flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false) }) {
@@ -119,7 +126,7 @@ struct AzureOpenAIProviderTests {
             unsetenv("AZURE_OPENAI_BEARER_TOKEN")
             unsetenv("AZURE_OPENAI_ENDPOINT")
         }
-        await AzureTestURLProtocol.reset()
+        AzureTestURLProtocol.reset()
 
         let provider = try AzureOpenAIProvider(
             deploymentId: "gpt-5-mini",
@@ -133,7 +140,7 @@ struct AzureOpenAIProviderTests {
         let request = ProviderRequest(messages: [ModelMessage(role: .user, content: [.text("hi")])])
         _ = try await provider.generateText(request: request)
 
-        let sentRequest = await AzureTestURLProtocol.fetchLastRequest()
+        let sentRequest = AzureTestURLProtocol.fetchLastRequest()
         #expect(sentRequest?.url?.host == "custom.azure.example.com")
         #expect(
             sentRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer bearer-123",

--- a/Tests/TachikomaTests/Providers/Integration/ProviderIntegrationTests.swift
+++ b/Tests/TachikomaTests/Providers/Integration/ProviderIntegrationTests.swift
@@ -430,7 +430,7 @@ struct ProviderIntegrationTests {
         #expect(normalized.contains("red"))
     }
 
-    @Test
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["TACHIKOMA_INTEGRATION_PROFILE_DIR"]?.isEmpty == false))
     func `OpenAI Codex OAuth - GPT-5_6 Sol Vision Support`() async throws {
         let previousProfileDirectory = TachikomaConfiguration.profileDirectoryName
         if let profileDirectory = ProcessInfo.processInfo.environment["TACHIKOMA_INTEGRATION_PROFILE_DIR"] {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,7 @@ xcrun llvm-cov report \
 - **What runs**: `ProviderIntegrationTests` (OpenAI, Anthropic, Google, Groq, Grok, Mistral) plus any suites that check `ProcessInfo.processInfo.environment` for real keys.
 - **Required env vars**:
   - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` (legacy `GOOGLE_API_KEY`), `MISTRAL_API_KEY`, `GROQ_API_KEY`, `X_AI_API_KEY` / `XAI_API_KEY`, etc.
+  - `TACHIKOMA_INTEGRATION_PROFILE_DIR` enables the Codex OAuth vision smoke test and must name a profile directory containing usable OAuth credentials without a higher-priority OpenAI API key.
 - **Notes**: wields actual HTTP calls and tool invocations, so only run when keys are set and you’re ready to burn quota. Requires the compile-time flag `-DLIVE_PROVIDER_TESTS`; without it the integration suite is excluded from the test build.
 
 ### Example
@@ -53,6 +54,7 @@ Some suites rely on live credentials even without `INTEGRATION_TESTS`, e.g. CLI 
 | `TACHIKOMA_TEST_MODE=mock` | Forces provider factory overrides and mock audio providers; default in CI. |
 | `INTEGRATION_TESTS=1` | Enables the live-provider suite. |
 | `TACHIKOMA_DISABLE_API_TESTS=true` | Hard-disables real providers even if keys are present (useful on shared CI runners). |
+| `TACHIKOMA_INTEGRATION_PROFILE_DIR` | Enables the Codex OAuth vision smoke test against the named credential profile. |
 | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, etc. | Standard per-provider keys pulled by `TestHelpers.resolve` (Gemini also accepts `GOOGLE_API_KEY`). |
 | `OPENROUTER_REFERER`, `OPENROUTER_TITLE` | Optional headers for OpenRouter (defaults provided). |
 | `REPLICATE_PREFERRED_OUTPUT=turbo` | Adds `Prefer: wait=false` to Replicate calls during tests. |


### PR DESCRIPTION
## Summary

- resolve Commander exclusively from its declared SwiftPM release, independent of ambient sibling directories
- remove CI-only sibling clones and assert the manifest still declares the remote dependency
- make the hermetic macOS/Linux suite and SwiftLint blocking, while removing the duplicated soft-fail API test pass
- compile and select `ProviderIntegrationTests` with the documented live-provider gates, including an explicit profile gate for the Codex OAuth vision smoke test

## Root cause

`Package.swift` inspected `../Commander`, so local checkout layout and CI bootstrap clones silently changed the dependency graph. At the same time, the primary test matrix used `continue-on-error`, and the dedicated integration job omitted both gates that compile and enable the live-provider suite.

## Proof

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (838 core tests + 57 MCP tests)
- live-provider compile/selection with all credentials unset: 12 discovered tests, credentialed tests skipped, local Ollama availability probe passed
- Azure request-capture regression: focused suite passed 20/20 stress runs after replacing the racy unstructured observer task
- `actionlint` with ignores limited to pre-existing warnings in untouched workflow scripts
- package-dump assertion proves Commander remains remote while a real sibling checkout is present
- Autoreview clean with no accepted/actionable findings
- exact-head hosted CI green on macOS 15/Xcode 26.1 and Ubuntu: https://github.com/openclaw/Tachikoma/actions/runs/31750838306
