### PR TITLE
fix(build): remove unused root Commander dependency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -158,11 +158,10 @@ jobs:
         # Check package structure
         PACKAGE_DUMP="$(swift package dump-package)"
         jq '.' <<< "$PACKAGE_DUMP"
-        jq -e '
-          any(.dependencies[];
-            .sourceControl[0].identity? == "commander" and
-            .sourceControl[0].location.remote[0].urlString == "https://github.com/steipete/Commander.git")
-        ' <<< "$PACKAGE_DUMP" > /dev/null
+        if jq -e 'any(.dependencies[]; .. | .identity? == "commander")' <<< "$PACKAGE_DUMP" > /dev/null; then
+          echo "::error::The root package must not depend on Commander; Agent-CLI owns its standalone dependency."
+          exit 1
+        fi
         swift package describe --type json | jq '.'
         
         # Validate dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
-- Commander now resolves from its declared SwiftPM release in every checkout and CI job, hermetic macOS/Linux tests block merges on failure, and live-provider CI uses its documented compile/runtime gates.
+- The root package no longer declares unused Commander products for its hand-parsed CLIs, avoiding local/remote package-identity conflicts in consumers; hermetic macOS/Linux tests now block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.
 - Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.
 - MCP tool discovery now uses one schema conversion path so static and dynamic tools preserve matching descriptions, enums, array item types, and required fields.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "992714bc117e56e988b1b9d0167f6efd811276f66672fee12f1e937bad1fc3b5",
+  "originHash" : "7264307bbf829a11be3e1d1cfe9453fc6953d2d8a41839c2fd2140c0a7b42d6d",
   "pins" : [
-    {
-      "identity" : "commander",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/steipete/Commander.git",
-      "state" : {
-        "revision" : "bd219c4ee9032fee3e009856f81fcc6ec09a85f4",
-        "version" : "0.2.4"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,6 @@ let package = Package(
             targets: ["TachikomaConfigCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.15.0"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
         .package(url: "https://github.com/apple/swift-configuration", from: "1.2.0"),
@@ -150,10 +149,7 @@ let package = Package(
         // Universal AI CLI executable target
         .executableTarget(
             name: "AICLI",
-            dependencies: [
-                "Tachikoma",
-                .product(name: "Commander", package: "Commander")
-            ],
+            dependencies: ["Tachikoma"],
             path: "Examples/AI-CLI",
             exclude: [
                 "README.md",
@@ -164,10 +160,7 @@ let package = Package(
         // Config/auth helper CLI target
         .executableTarget(
             name: "TachikomaConfigCLI",
-            dependencies: [
-                "Tachikoma",
-                .product(name: "Commander", package: "Commander")
-            ],
+            dependencies: ["Tachikoma"],
             path: "Sources/TachikomaConfigCLI",
             swiftSettings: tachikomaSwiftSettings),
     ],


### PR DESCRIPTION
## Summary

- remove the unused Commander package and product dependencies from Tachikoma's root manifest
- refresh the root lockfile so Commander is no longer part of the transitive package graph
- invert the package-validation contract so Commander cannot silently re-enter the root package
- leave Agent-CLI's separate manifest and real Commander usage unchanged

## Root cause

The root `ai-cli` and `tachikoma` executables hand-parse their arguments and never import Commander, but their target declarations still pulled in the remote package. Consumers such as Peekaboo that own a local Commander package could therefore encounter a local/remote package-identity conflict even though Tachikoma did not use the dependency.

## Proof

- `swift build -c release`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (838 core tests + 57 MCP tests)
- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict`
- root `dump-package` contains no Commander identity; the CI predicate also detects a synthetic Commander dependency
- `actionlint` with ignores limited to existing warnings in untouched workflow scripts
- Autoreview clean with no accepted/actionable findings
- exact-head hosted CI green on macOS 15/Xcode 26.1 and Ubuntu: https://github.com/openclaw/Tachikoma/actions/runs/31773850434
