### PR TITLE
fix(mcp): fail closed on stdio child loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Stdio MCP child exit now atomically closes the connection, clears cached tools, fails pending requests without waiting for their timeout, rejects later sends, and preserves generation-safe reconnects.
 - The root package no longer declares unused Commander products for its hand-parsed CLIs, avoiding local/remote package-identity conflicts in consumers; hermetic macOS/Linux tests now block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.
 - Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.

--- a/Sources/TachikomaMCP/Client/MCPClient.swift
+++ b/Sources/TachikomaMCP/Client/MCPClient.swift
@@ -60,23 +60,53 @@ public struct MCPServerConfig: Sendable, Codable {
 /// Actor to manage mutable state for Sendable conformance
 private actor MCPClientState {
     var transport: (any MCPTransport)?
+    var connectionID: UUID?
     var tools: [Tool] = []
     var isConnected: Bool = false
+    var connectionError: MCPError?
 
-    func setTransport(_ transport: (any MCPTransport)?) {
+    func beginConnection(id: UUID, transport: any MCPTransport) -> (any MCPTransport)? {
+        let previousTransport = self.transport
+        self.connectionID = id
         self.transport = transport
+        self.tools = []
+        self.isConnected = false
+        self.connectionError = nil
+        return previousTransport
     }
 
-    func getTransport() -> (any MCPTransport)? {
-        self.transport
-    }
-
-    func setConnected(_ connected: Bool) {
-        self.isConnected = connected
-    }
-
-    func setTools(_ tools: [Tool]) {
+    func completeConnection(id: UUID, tools: [Tool]) -> Bool {
+        guard self.connectionID == id else { return false }
         self.tools = tools
+        self.isConnected = true
+        self.connectionError = nil
+        return true
+    }
+
+    func connectionClosed(id: UUID, error: MCPError) {
+        guard self.connectionID == id else { return }
+        self.connectionID = nil
+        self.transport = nil
+        self.tools = []
+        self.isConnected = false
+        self.connectionError = error
+    }
+
+    func takeConnection() -> (any MCPTransport)? {
+        let previousTransport = self.transport
+        self.connectionID = nil
+        self.transport = nil
+        self.tools = []
+        self.isConnected = false
+        self.connectionError = nil
+        return previousTransport
+    }
+
+    func transportForRequest() throws -> any MCPTransport {
+        guard self.isConnected, let transport else {
+            throw self.connectionError ?? MCPError.notConnected
+        }
+        return transport
     }
 }
 
@@ -108,10 +138,13 @@ public final class MCPClient: Sendable {
         self.logger.info("Connecting to MCP server '\(self.name)'")
 
         // Create appropriate transport based on config
+        let connectionID = UUID()
         let transport: any MCPTransport
         switch self.config.transport.lowercased() {
         case "stdio":
-            transport = StdioTransport()
+            transport = StdioTransport { [state] error in
+                await state.connectionClosed(id: connectionID, error: error)
+            }
         case "sse":
             transport = SSETransport()
         case "http":
@@ -120,65 +153,75 @@ public final class MCPClient: Sendable {
             throw MCPError.unsupportedTransport(self.config.transport)
         }
 
-        await self.state.setTransport(transport)
+        let previousTransport = await self.state.beginConnection(id: connectionID, transport: transport)
+        if let previousTransport {
+            await previousTransport.disconnect()
+        }
 
-        // Connect transport
-        try await transport.connect(config: self.config)
-
-        // Initialize MCP handshake
-        let initParams = InitializeParams(
-            protocolVersion: "2025-03-26",
-            clientInfo: ClientInfo(name: "tachikoma-mcp-client", version: "1.0.0"),
-            capabilities: ClientCapabilities(),
-        )
-        let initResponse: InitializeResponse
         do {
-            initResponse = try await transport.sendRequest(method: "initialize", params: initParams)
-        } catch {
-            // Fallback 1: Older protocol version
-            let oldParams = InitializeParams(
-                protocolVersion: "2024-11-05",
-                clientInfo: initParams.clientInfo,
-                capabilities: initParams.capabilities,
+            // Connect transport
+            try await transport.connect(config: self.config)
+
+            // Initialize MCP handshake
+            let initParams = InitializeParams(
+                protocolVersion: "2025-03-26",
+                clientInfo: ClientInfo(name: "tachikoma-mcp-client", version: "1.0.0"),
+                capabilities: ClientCapabilities(),
             )
+            let initResponse: InitializeResponse
             do {
-                initResponse = try await transport.sendRequest(method: "initialize", params: oldParams)
+                initResponse = try await transport.sendRequest(method: "initialize", params: initParams)
             } catch {
-                // Fallback 2: snake_case protocol_version with older version
-                let snake = InitializeParamsSnake(
-                    protocolVersion: oldParams.protocolVersion,
+                // Fallback 1: Older protocol version
+                let oldParams = InitializeParams(
+                    protocolVersion: "2024-11-05",
                     clientInfo: initParams.clientInfo,
                     capabilities: initParams.capabilities,
                 )
-                initResponse = try await transport.sendRequest(method: "initialize", params: snake)
+                do {
+                    initResponse = try await transport.sendRequest(method: "initialize", params: oldParams)
+                } catch {
+                    // Fallback 2: snake_case protocol_version with older version
+                    let snake = InitializeParamsSnake(
+                        protocolVersion: oldParams.protocolVersion,
+                        clientInfo: initParams.clientInfo,
+                        capabilities: initParams.capabilities,
+                    )
+                    initResponse = try await transport.sendRequest(method: "initialize", params: snake)
+                }
             }
-        }
 
-        self.logger.debug("Initialized MCP connection: \(initResponse)")
+            self.logger.debug("Initialized MCP connection: \(initResponse)")
 
-        // Send initialized notification (per spec name)
-        // Some servers (like Context7) may not support this notification
-        do {
-            try await transport.sendNotification(method: "notifications/initialized", params: EmptyParams())
+            // Send initialized notification (per spec name)
+            // Some servers (like Context7) may not support this notification
+            do {
+                try await transport.sendNotification(method: "notifications/initialized", params: EmptyParams())
+            } catch {
+                self.logger.debug("Server may not support notifications/initialized: \(error)")
+            }
+
+            let tools = try await self.discoverTools(using: transport)
+            guard await self.state.completeConnection(id: connectionID, tools: tools) else {
+                throw MCPError.transportClosed
+            }
         } catch {
-            self.logger.debug("Server may not support notifications/initialized: \(error)")
+            await transport.disconnect()
+            await self.state.connectionClosed(
+                id: connectionID,
+                error: (error as? MCPError) ?? .connectionFailed(error.localizedDescription),
+            )
+            throw error
         }
-
-        // Discover tools
-        await self.discoverTools()
-
-        await self.state.setConnected(true)
     }
 
     /// Disconnect from the MCP server
     public func disconnect() async {
         // Disconnect from the MCP server
         self.logger.info("Disconnecting from MCP server '\(self.name)'")
-        if let transport = await state.getTransport() {
+        if let transport = await state.takeConnection() {
             await transport.disconnect()
         }
-        await self.state.setConnected(false)
-        await self.state.setTools([])
     }
 
     /// Check if the client is connected
@@ -196,23 +239,13 @@ public final class MCPClient: Sendable {
     }
 
     /// Discover available tools from the server
-    private func discoverTools() async {
-        // Discover available tools from the server
-        do {
-            guard let transport = await state.getTransport() else {
-                throw MCPError.notConnected
-            }
-
-            let response: ToolsListResponse = try await transport.sendRequest(
-                method: "tools/list",
-                params: EmptyParams(),
-            )
-
-            await self.state.setTools(response.tools)
-            self.logger.info("Discovered \(response.tools.count) tools from '\(self.name)'")
-        } catch {
-            self.logger.error("Failed to discover tools: \(error)")
-        }
+    private func discoverTools(using transport: any MCPTransport) async throws -> [Tool] {
+        let response: ToolsListResponse = try await transport.sendRequest(
+            method: "tools/list",
+            params: EmptyParams(),
+        )
+        self.logger.info("Discovered \(response.tools.count) tools from '\(self.name)'")
+        return response.tools
     }
 
     /// Execute a tool by name
@@ -226,13 +259,7 @@ public final class MCPClient: Sendable {
 
     private func executeTool(name: String, arguments: Value) async throws -> ToolResponse {
         // Execute a tool by name
-        guard let transport = await state.getTransport() else {
-            throw MCPError.notConnected
-        }
-
-        guard await self.isConnected else {
-            throw MCPError.notConnected
-        }
+        let transport = try await state.transportForRequest()
 
         // Send tool execution request
         let response: CallTool.Result = try await transport.sendRequest(
@@ -310,10 +337,11 @@ struct ToolCallParams: Codable {
 
 // MARK: - Errors
 
-public enum MCPError: LocalizedError {
+public enum MCPError: LocalizedError, Equatable {
     case serverDisabled
     case unsupportedTransport(String)
     case notConnected
+    case transportClosed
     case invalidResponse
     case connectionFailed(String)
     case executionFailed(String)
@@ -326,6 +354,8 @@ public enum MCPError: LocalizedError {
             "Unsupported transport: \(transport)"
         case .notConnected:
             "MCP client is not connected"
+        case .transportClosed:
+            "MCP transport closed"
         case .invalidResponse:
             "Invalid response from MCP server"
         case let .connectionFailed(reason):

--- a/Sources/TachikomaMCP/Client/StdioTransport.swift
+++ b/Sources/TachikomaMCP/Client/StdioTransport.swift
@@ -8,8 +8,30 @@ import Logging
 import MCP
 import Tachikoma
 
+private struct StdioConnectionResources: Sendable {
+    let process: Process?
+    let inputPipe: Pipe?
+    let outputPipe: Pipe?
+    let errorPipe: Pipe?
+}
+
+private struct StdioConnectionCloseResult: Sendable {
+    let closed: Bool
+    let resources: StdioConnectionResources?
+    let pendingRequests: [CheckedContinuation<Data, Swift.Error>]
+    let timeoutTasks: [Task<Void, Never>]
+}
+
+struct StdioTransportDebugSnapshot: Sendable, Equatable {
+    let isConnected: Bool
+    let pendingRequestCount: Int
+    let timeoutTaskCount: Int
+}
+
 /// Actor to manage mutable state for Sendable conformance
 private actor StdioTransportState {
+    private var generation: UInt64 = 0
+    private var activeGeneration: UInt64?
     var process: Process?
     var inputPipe: Pipe?
     var outputPipe: Pipe?
@@ -19,63 +41,148 @@ private actor StdioTransportState {
     var timeoutTasks: [Int: Task<Void, Never>] = [:]
     var requestTimeoutNs: UInt64 = 30_000_000_000 // default 30s
 
-    func setProcess(_ process: Process?, input: Pipe?, output: Pipe?, error: Pipe?) {
+    func beginConnection(timeout: TimeInterval) -> UInt64 {
+        self.generation &+= 1
+        self.activeGeneration = self.generation
+        self.requestTimeoutNs = UInt64((timeout > 0 ? timeout : 30) * 1_000_000_000)
+        return self.generation
+    }
+
+    func installResources(
+        process: Process,
+        input: Pipe,
+        output: Pipe,
+        error: Pipe,
+        generation: UInt64,
+    )
+        -> Bool
+    {
+        guard self.activeGeneration == generation else { return false }
         self.process = process
         self.inputPipe = input
         self.outputPipe = output
         self.errorPipe = error
+        return true
     }
 
-    func getNextId() -> Int {
+    func reserveRequest() -> (id: Int, generation: UInt64)? {
+        guard let activeGeneration else { return nil }
         let id = self.nextId
         self.nextId += 1
-        return id
+        return (id, activeGeneration)
     }
 
-    func addPendingRequest(id: Int, continuation: CheckedContinuation<Data, Swift.Error>) {
+    func addPendingRequest(
+        id: Int,
+        generation: UInt64,
+        continuation: CheckedContinuation<Data, Swift.Error>,
+    )
+        -> Bool
+    {
+        guard self.activeGeneration == generation else { return false }
         self.pendingRequests[String(id)] = continuation
+        return true
     }
 
-    func removePendingRequest(id: Int) -> CheckedContinuation<Data, Swift.Error>? {
-        self.pendingRequests.removeValue(forKey: String(id))
+    func failRequest(
+        id: Int,
+        generation: UInt64,
+    )
+        -> CheckedContinuation<Data, Swift.Error>?
+    {
+        guard self.activeGeneration == generation else { return nil }
+        self.timeoutTasks.removeValue(forKey: id)?.cancel()
+        return self.pendingRequests.removeValue(forKey: String(id))
     }
 
-    func removePendingRequestByStringId(_ id: String) -> CheckedContinuation<Data, Swift.Error>? {
-        self.pendingRequests.removeValue(forKey: id)
+    func takePendingResponse(
+        id: String,
+        numericID: Int,
+        generation: UInt64,
+    )
+        -> CheckedContinuation<Data, Swift.Error>?
+    {
+        guard self.activeGeneration == generation else { return nil }
+        self.timeoutTasks.removeValue(forKey: numericID)?.cancel()
+        return self.pendingRequests.removeValue(forKey: id)
     }
 
-    func setRequestTimeout(seconds: TimeInterval) {
-        let ns = seconds > 0 ? seconds * 1_000_000_000 : 30_000_000_000
-        self.requestTimeoutNs = UInt64(ns)
+    func expireRequest(
+        id: Int,
+        generation: UInt64,
+    )
+        -> CheckedContinuation<Data, Swift.Error>?
+    {
+        guard self.activeGeneration == generation else { return nil }
+        self.timeoutTasks.removeValue(forKey: id)
+        return self.pendingRequests.removeValue(forKey: String(id))
     }
 
-    func addTimeoutTask(id: Int, task: Task<Void, Never>) {
-        self.timeoutTasks[id] = task
-    }
-
-    func cancelTimeoutTask(id: Int) {
-        if let task = timeoutTasks.removeValue(forKey: id) {
+    func addTimeoutTask(id: Int, generation: UInt64, task: Task<Void, Never>) -> Bool {
+        guard self.activeGeneration == generation else {
             task.cancel()
+            return false
         }
+        self.timeoutTasks[id] = task
+        return true
     }
 
-    func cancelAllRequests() {
-        for (_, continuation) in self.pendingRequests {
-            continuation.resume(throwing: MCPError.notConnected)
+    func currentGeneration() -> UInt64? {
+        self.activeGeneration
+    }
+
+    func isActive(generation: UInt64) -> Bool {
+        self.activeGeneration == generation
+    }
+
+    func closeConnection(generation: UInt64? = nil) -> StdioConnectionCloseResult {
+        if let generation, generation != self.activeGeneration {
+            return StdioConnectionCloseResult(
+                closed: false,
+                resources: nil,
+                pendingRequests: [],
+                timeoutTasks: [],
+            )
         }
+        guard self.activeGeneration != nil else {
+            return StdioConnectionCloseResult(
+                closed: false,
+                resources: nil,
+                pendingRequests: [],
+                timeoutTasks: [],
+            )
+        }
+
+        self.activeGeneration = nil
+        let pendingRequests = Array(self.pendingRequests.values)
         self.pendingRequests.removeAll()
+        let timeoutTasks = Array(self.timeoutTasks.values)
+        self.timeoutTasks.removeAll()
+
+        let resources = StdioConnectionResources(
+            process: self.process,
+            inputPipe: self.inputPipe,
+            outputPipe: self.outputPipe,
+            errorPipe: self.errorPipe,
+        )
+        self.process = nil
+        self.inputPipe = nil
+        self.outputPipe = nil
+        self.errorPipe = nil
+        return StdioConnectionCloseResult(
+            closed: true,
+            resources: resources,
+            pendingRequests: pendingRequests,
+            timeoutTasks: timeoutTasks,
+        )
     }
 
-    func getInputPipe() -> Pipe? {
-        self.inputPipe
-    }
-
-    func getOutputPipe() -> Pipe? {
-        self.outputPipe
-    }
-
-    func getErrorPipe() -> Pipe? {
-        self.errorPipe
+    func debugSnapshot() -> StdioTransportDebugSnapshot {
+        StdioTransportDebugSnapshot(
+            isConnected: self.activeGeneration != nil,
+            pendingRequestCount: self.pendingRequests.count,
+            timeoutTaskCount: self.timeoutTasks.count,
+        )
     }
 }
 
@@ -85,18 +192,24 @@ private actor StdioTransportState {
 /// construction inside this actor prevents request bytes from interleaving across callers.
 actor StdioFrameWriter {
     private var handle: FileHandle?
+    private var generation: UInt64?
 
-    func install(_ handle: FileHandle) {
+    func install(_ handle: FileHandle, generation: UInt64) {
         self.handle = handle
+        self.generation = generation
     }
 
-    func removeHandle() {
+    func removeHandle(generation: UInt64? = nil) {
+        if let generation, generation != self.generation {
+            return
+        }
         self.handle = nil
+        self.generation = nil
     }
 
-    func write(payload: Data) throws {
-        guard let handle else {
-            throw MCPError.notConnected
+    func write(payload: Data, generation: UInt64) throws {
+        guard generation == self.generation, let handle else {
+            throw MCPError.transportClosed
         }
 
         var frame = payload
@@ -109,6 +222,7 @@ actor StdioFrameWriter {
 public final class StdioTransport: MCPTransport {
     private let state = StdioTransportState()
     private let frameWriter = StdioFrameWriter()
+    private let connectionClosed: @Sendable (MCPError) async -> Void
     private let logger = Logger(label: "tachikoma.mcp.stdio")
     private static let _sigpipeHandlerInstalled: Void = {
         signal(SIGPIPE, SIG_IGN)
@@ -119,19 +233,26 @@ public final class StdioTransport: MCPTransport {
     private let debugQueue = DispatchQueue(label: "tachikoma.mcp.stdio.debug")
     private let stdoutQueue = DispatchQueue(label: "tachikoma.mcp.stdio.stdout")
     private let stderrQueue = DispatchQueue(label: "tachikoma.mcp.stdio.stderr")
+    private let sourceLock = NSLock()
     private var stdoutSource: DispatchSourceRead?
     private var stderrSource: DispatchSourceRead?
     private var stdoutBuffer = Data()
     private var stderrBuffer = Data()
 
-    public init() {
+    public convenience init() {
+        self.init { _ in }
+    }
+
+    init(onConnectionClosed: @escaping @Sendable (MCPError) async -> Void) {
         Self._sigpipeHandlerInstalled
+        self.connectionClosed = onConnectionClosed
         self.debugStdoutHandle = Self.makeDebugHandle(for: "MCP_STDIO_STDOUT")
         self.debugStderrHandle = Self.makeDebugHandle(for: "MCP_STDIO_STDERR")
     }
 
     public func connect(config: MCPServerConfig) async throws {
         self.logger.info("Starting stdio transport with command: \(config.command)")
+        await self.disconnect()
 
         let process = Process()
         let inputPipe = Pipe()
@@ -187,55 +308,65 @@ public final class StdioTransport: MCPTransport {
 
         // Set environment - always inherit current environment and merge custom vars
         process.environment = ProcessInfo.processInfo.environment.merging(config.env) { _, new in new }
+        let generation = await self.state.beginConnection(timeout: config.timeout)
+        process.terminationHandler = { [weak self] _ in
+            Task {
+                await self?.closeConnection(generation: generation, terminateProcess: false)
+            }
+        }
 
         // Start process
         do {
             try process.run()
         } catch {
-            throw MCPError.connectionFailed("Failed to start process: \(error)")
+            let connectionError = MCPError.connectionFailed("Failed to start process: \(error)")
+            await self.closeConnection(
+                generation: generation,
+                error: connectionError,
+                terminateProcess: false,
+            )
+            throw connectionError
         }
 
         // Close parent's write ends for stdout/stderr so EOF is detected promptly
         try? outputPipe.fileHandleForWriting.close()
         try? errorPipe.fileHandleForWriting.close()
 
-        await self.state.setProcess(process, input: inputPipe, output: outputPipe, error: errorPipe)
-        await self.state.setRequestTimeout(seconds: config.timeout)
-        await self.frameWriter.install(inputPipe.fileHandleForWriting)
+        guard
+            await self.state.installResources(
+                process: process,
+                input: inputPipe,
+                output: outputPipe,
+                error: errorPipe,
+                generation: generation,
+            ) else
+        {
+            self.closePipe(inputPipe)
+            self.closePipe(outputPipe)
+            self.closePipe(errorPipe)
+            self.terminateProcess(process)
+            throw MCPError.transportClosed
+        }
+        await self.frameWriter.install(inputPipe.fileHandleForWriting, generation: generation)
+        guard await self.state.isActive(generation: generation) else {
+            await self.frameWriter.removeHandle(generation: generation)
+            throw MCPError.transportClosed
+        }
 
         self.logger.info("About to start reading output")
-        self.stdoutSource = self.makeReadSource(for: outputPipe, isStderr: false)
-        self.stderrSource = self.makeReadSource(for: errorPipe, isStderr: true)
+        let stdoutSource = self.makeReadSource(for: outputPipe, isStderr: false, generation: generation)
+        let stderrSource = self.makeReadSource(for: errorPipe, isStderr: true, generation: generation)
+        self.sourceLock.withLock {
+            self.stdoutSource = stdoutSource
+            self.stderrSource = stderrSource
+        }
 
         self.logger.info("Stdio transport connected")
     }
 
     public func disconnect() async {
         self.logger.info("Disconnecting stdio transport")
-
-        self.stdoutSource?.cancel()
-        self.stderrSource?.cancel()
-        self.stdoutSource = nil
-        self.stderrSource = nil
-        self.stdoutQueue.sync { self.stdoutBuffer.removeAll(keepingCapacity: false) }
-        self.stderrQueue.sync { self.stderrBuffer.removeAll(keepingCapacity: false) }
-        self.closeDebugHandles()
-
-        await self.frameWriter.removeHandle()
-
-        let inputPipe = await state.getInputPipe()
-        let outputPipe = await state.getOutputPipe()
-        let errorPipe = await state.getErrorPipe()
-        let process = await state.process
-
-        self.closePipe(inputPipe)
-        self.closePipe(outputPipe)
-        self.closePipe(errorPipe)
-
-        self.terminateProcess(process)
-
-        await self.state.setProcess(nil, input: nil, output: nil, error: nil)
-        await self.state.cancelAllRequests()
+        await self.closeConnection(error: .transportClosed, terminateProcess: true)
     }
 
     deinit {
@@ -248,7 +379,11 @@ public final class StdioTransport: MCPTransport {
     ) async throws
         -> R
     {
-        let id = await state.getNextId()
+        guard let request = await state.reserveRequest() else {
+            throw MCPError.transportClosed
+        }
+        let id = request.id
+        let generation = request.generation
 
         // Create JSON-RPC request with canonical key order
         var dict: [String: Any] = [:]
@@ -265,24 +400,39 @@ public final class StdioTransport: MCPTransport {
 
         let responseData = try await withCheckedThrowingContinuation { continuation in
             Task {
-                await self.state.addPendingRequest(id: id, continuation: continuation)
+                guard
+                    await self.state.addPendingRequest(
+                        id: id,
+                        generation: generation,
+                        continuation: continuation,
+                    ) else
+                {
+                    continuation.resume(throwing: MCPError.transportClosed)
+                    return
+                }
                 let timeoutTask = Task { [logger] in
                     let ns = await state.requestTimeoutNs
-                    try? await Task.sleep(nanoseconds: ns)
-                    if let pending = await state.removePendingRequest(id: id) {
+                    do {
+                        try await Task.sleep(nanoseconds: ns)
+                    } catch {
+                        return
+                    }
+                    if let pending = await state.expireRequest(id: id, generation: generation) {
                         logger.error("MCP stdio request timed out: method=\(method), id=\(id)")
                         pending
                             .resume(throwing: MCPError.executionFailed("Request timed out after \(ns / 1_000_000)ms"))
                     }
                 }
-                await state.addTimeoutTask(id: id, task: timeoutTask)
+                guard await self.state.addTimeoutTask(id: id, generation: generation, task: timeoutTask) else {
+                    return
+                }
 
                 do {
-                    try await self.send(data)
+                    try await self.send(data, generation: generation)
                 } catch {
-                    _ = await self.state.removePendingRequest(id: id)
-                    await self.state.cancelTimeoutTask(id: id)
-                    continuation.resume(throwing: error)
+                    if let pending = await self.state.failRequest(id: id, generation: generation) {
+                        pending.resume(throwing: error)
+                    }
                 }
             }
         }
@@ -318,8 +468,18 @@ public final class StdioTransport: MCPTransport {
     }
 
     private func send(_ data: Data) async throws {
+        guard let generation = await self.state.currentGeneration() else {
+            throw MCPError.transportClosed
+        }
+        try await self.send(data, generation: generation)
+    }
+
+    private func send(_ data: Data, generation: UInt64) async throws {
+        guard await self.state.isActive(generation: generation) else {
+            throw MCPError.transportClosed
+        }
         // MCP TypeScript SDK uses simple newline-delimited JSON, NOT LSP-style framing
-        try await self.frameWriter.write(payload: data)
+        try await self.frameWriter.write(payload: data, generation: generation)
 
         // Log what we sent for debugging
         if let json = String(data: data, encoding: .utf8) {
@@ -327,7 +487,13 @@ public final class StdioTransport: MCPTransport {
         }
     }
 
-    private func makeReadSource(for pipe: Pipe, isStderr: Bool) -> DispatchSourceRead? {
+    private func makeReadSource(
+        for pipe: Pipe,
+        isStderr: Bool,
+        generation: UInt64,
+    )
+        -> DispatchSourceRead?
+    {
         let fileHandle = pipe.fileHandleForReading
         let fd = fileHandle.fileDescriptor
         let currentFlags = fcntl(fd, F_GETFL)
@@ -344,12 +510,17 @@ public final class StdioTransport: MCPTransport {
                 let count = read(fd, &buffer, buffer.count)
                 if count > 0 {
                     let data = Data(buffer[0..<count])
-                    self.handleBytes(data, isStderr: isStderr)
+                    self.handleBytes(data, isStderr: isStderr, generation: generation)
                     continue
                 }
                 if count == 0 {
                     self.logger.debug("[MCP stdio] \(isStderr ? "stderr" : "stdout") pipe closed")
                     source.cancel()
+                    if !isStderr {
+                        Task {
+                            await self.closeConnection(generation: generation, terminateProcess: true)
+                        }
+                    }
                     break
                 }
                 if errno == EAGAIN || errno == EWOULDBLOCK {
@@ -357,6 +528,11 @@ public final class StdioTransport: MCPTransport {
                 }
                 self.logger.error("[MCP stdio] Read error: \(String(cString: strerror(errno)))")
                 source.cancel()
+                if !isStderr {
+                    Task {
+                        await self.closeConnection(generation: generation, terminateProcess: true)
+                    }
+                }
                 break
             }
         }
@@ -364,7 +540,7 @@ public final class StdioTransport: MCPTransport {
         return source
     }
 
-    private func handleBytes(_ chunk: Data, isStderr: Bool) {
+    private func handleBytes(_ chunk: Data, isStderr: Bool, generation: UInt64) {
         guard !chunk.isEmpty else { return }
         if isStderr {
             self.stderrBuffer.append(chunk)
@@ -373,11 +549,15 @@ public final class StdioTransport: MCPTransport {
         } else {
             self.stdoutBuffer.append(chunk)
             self.writeDebug(chunk, handle: self.debugStdoutHandle)
-            self.consumeBuffer(&self.stdoutBuffer, isStderr: false)
+            self.consumeBuffer(&self.stdoutBuffer, isStderr: false, generation: generation)
         }
     }
 
-    private func consumeBuffer(_ buffer: inout Data, isStderr: Bool) {
+    private func consumeBuffer(
+        _ buffer: inout Data,
+        isStderr: Bool,
+        generation: UInt64? = nil,
+    ) {
         if isStderr {
             while let line = Self.consumeLine(from: &buffer) {
                 guard !line.isEmpty else { continue }
@@ -392,7 +572,9 @@ public final class StdioTransport: MCPTransport {
             if let json = String(data: framed, encoding: .utf8) {
                 self.logger.debug("[MCP stdio] ← framed: \(json)")
             }
-            Task { await self.handleResponse(framed) }
+            if let generation {
+                Task { await self.handleResponse(framed, generation: generation) }
+            }
         }
 
         while let line = Self.consumeLine(from: &buffer) {
@@ -400,7 +582,9 @@ public final class StdioTransport: MCPTransport {
             if let json = String(data: line, encoding: .utf8) {
                 self.logger.debug("[MCP stdio] ← received: \(json)")
             }
-            Task { await self.handleResponse(line) }
+            if let generation {
+                Task { await self.handleResponse(line, generation: generation) }
+            }
         }
     }
 
@@ -462,14 +646,19 @@ public final class StdioTransport: MCPTransport {
         return Data(body)
     }
 
-    private func handleResponse(_ data: Data) async {
+    private func handleResponse(_ data: Data, generation: UInt64) async {
         // Try to parse as a response with ID
         if
             let response = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let id = response["id"] as? Int
         {
-            if let continuation = await state.removePendingRequest(id: id) {
-                await self.state.cancelTimeoutTask(id: id)
+            if
+                let continuation = await state.takePendingResponse(
+                    id: String(id),
+                    numericID: id,
+                    generation: generation,
+                )
+            {
                 continuation.resume(returning: data)
             }
         } else if
@@ -477,12 +666,14 @@ public final class StdioTransport: MCPTransport {
             let idString = response["id"] as? String,
             let idInt = Int(idString)
         {
-            if let contByString = await state.removePendingRequestByStringId(idString) {
-                await self.state.cancelTimeoutTask(id: idInt)
-                contByString.resume(returning: data)
-            } else if let contByInt = await state.removePendingRequest(id: idInt) {
-                await self.state.cancelTimeoutTask(id: idInt)
-                contByInt.resume(returning: data)
+            if
+                let continuation = await state.takePendingResponse(
+                    id: idString,
+                    numericID: idInt,
+                    generation: generation,
+                )
+            {
+                continuation.resume(returning: data)
             }
         } else if
             let response = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -491,6 +682,51 @@ public final class StdioTransport: MCPTransport {
             // Some servers return null id for notifications; ignore
         }
         // Otherwise it might be a notification or other message
+    }
+
+    var debugSnapshot: StdioTransportDebugSnapshot {
+        get async {
+            await self.state.debugSnapshot()
+        }
+    }
+
+    private func closeConnection(
+        generation: UInt64? = nil,
+        error: MCPError = .transportClosed,
+        terminateProcess: Bool,
+    ) async {
+        let closeResult = await self.state.closeConnection(generation: generation)
+        guard closeResult.closed else { return }
+
+        await self.frameWriter.removeHandle(generation: generation)
+        await self.connectionClosed(error)
+        closeResult.timeoutTasks.forEach { $0.cancel() }
+        closeResult.pendingRequests.forEach { $0.resume(throwing: error) }
+        self.cancelReadSources()
+        self.stdoutQueue.sync { self.stdoutBuffer.removeAll(keepingCapacity: false) }
+        self.stderrQueue.sync { self.stderrBuffer.removeAll(keepingCapacity: false) }
+        self.closeDebugHandles()
+
+        if let resources = closeResult.resources {
+            self.closePipe(resources.inputPipe)
+            self.closePipe(resources.outputPipe)
+            self.closePipe(resources.errorPipe)
+            if terminateProcess {
+                self.terminateProcess(resources.process)
+            }
+        }
+    }
+
+    private func cancelReadSources() {
+        let sources = self.sourceLock.withLock { () -> (DispatchSourceRead?, DispatchSourceRead?) in
+            defer {
+                self.stdoutSource = nil
+                self.stderrSource = nil
+            }
+            return (self.stdoutSource, self.stderrSource)
+        }
+        sources.0?.cancel()
+        sources.1?.cancel()
     }
 
     private func closePipe(_ pipe: Pipe?) {

--- a/Tests/TachikomaMCPTests/MCPClientTests.swift
+++ b/Tests/TachikomaMCPTests/MCPClientTests.swift
@@ -57,6 +57,7 @@ struct MCPClientTests {
     func `MCPError descriptions`() {
         #expect(MCPError.serverDisabled.errorDescription == "MCP server is disabled")
         #expect(MCPError.notConnected.errorDescription == "MCP client is not connected")
+        #expect(MCPError.transportClosed.errorDescription == "MCP transport closed")
         #expect(MCPError.invalidResponse.errorDescription == "Invalid response from MCP server")
         #expect(MCPError.unsupportedTransport("test").errorDescription == "Unsupported transport: test")
         #expect(MCPError.connectionFailed("timeout").errorDescription == "Connection failed: timeout")

--- a/Tests/TachikomaMCPTests/StdioFrameWriterTests.swift
+++ b/Tests/TachikomaMCPTests/StdioFrameWriterTests.swift
@@ -8,13 +8,14 @@ struct StdioFrameWriterTests {
     func `Concurrent sends preserve complete JSON lines`() async throws {
         let pipe = Pipe()
         let writer = StdioFrameWriter()
-        await writer.install(pipe.fileHandleForWriting)
+        let generation: UInt64 = 42
+        await writer.install(pipe.fileHandleForWriting, generation: generation)
 
         let payloads = (0..<512).map { Data("{\"id\":\($0)}".utf8) }
         try await withThrowingTaskGroup(of: Void.self) { group in
             for payload in payloads {
                 group.addTask {
-                    try await writer.write(payload: payload)
+                    try await writer.write(payload: payload, generation: generation)
                 }
             }
             try await group.waitForAll()
@@ -38,7 +39,28 @@ struct StdioFrameWriterTests {
         let writer = StdioFrameWriter()
 
         await #expect(throws: MCPError.self) {
-            try await writer.write(payload: Data("{}".utf8))
+            try await writer.write(payload: Data("{}".utf8), generation: 42)
         }
+    }
+
+    @Test
+    func `Superseded generation cannot write into replacement pipe`() async throws {
+        let firstPipe = Pipe()
+        let secondPipe = Pipe()
+        let writer = StdioFrameWriter()
+        await writer.install(firstPipe.fileHandleForWriting, generation: 1)
+        await writer.install(secondPipe.fileHandleForWriting, generation: 2)
+
+        await #expect(throws: MCPError.transportClosed) {
+            try await writer.write(payload: Data("old".utf8), generation: 1)
+        }
+        try await writer.write(payload: Data("new".utf8), generation: 2)
+
+        await writer.removeHandle(generation: 1)
+        try await writer.write(payload: Data("current".utf8), generation: 2)
+        await writer.removeHandle(generation: 2)
+        try secondPipe.fileHandleForWriting.close()
+        let output = secondPipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(bytes: output, encoding: .utf8) == "new\ncurrent\n")
     }
 }

--- a/Tests/TachikomaMCPTests/StdioTransportLifecycleTests.swift
+++ b/Tests/TachikomaMCPTests/StdioTransportLifecycleTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+@testable import TachikomaMCP
+
+@Suite("Stdio transport lifecycle", .serialized)
+struct StdioTransportLifecycleTests {
+    @Test(.timeLimit(.minutes(1)))
+    func `Child EOF fails concurrent pending requests and clears timeout state once`() async throws {
+        let closeCounter = CloseCounter()
+        let transport = StdioTransport { error in
+            await closeCounter.record(error)
+        }
+        try await transport.connect(config: Self.exitAfterRequestCountConfig(count: 12, timeout: 5))
+
+        let started = ContinuousClock.now
+        let errors = await withTaskGroup(of: MCPError?.self, returning: [MCPError?].self) { group in
+            for _ in 0..<12 {
+                group.addTask {
+                    do {
+                        let _: FixtureResponse = try await transport.sendRequest(
+                            method: "fixture/pending",
+                            params: EmptyParams(),
+                        )
+                        return nil
+                    } catch let error as MCPError {
+                        return error
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+
+            var results: [MCPError?] = []
+            for await result in group {
+                results.append(result)
+            }
+            return results
+        }
+
+        #expect(started.duration(to: .now) < .seconds(1))
+        #expect(errors.count == 12)
+        #expect(errors.allSatisfy { $0 == .transportClosed })
+        #expect(await transport.debugSnapshot == .disconnected)
+        #expect(await closeCounter.snapshot == [.transportClosed])
+
+        let refusedAt = ContinuousClock.now
+        await #expect(throws: MCPError.transportClosed) {
+            let _: FixtureResponse = try await transport.sendRequest(
+                method: "fixture/late",
+                params: EmptyParams(),
+            )
+        }
+        await #expect(throws: MCPError.transportClosed) {
+            try await transport.sendNotification(
+                method: "notifications/late",
+                params: EmptyParams(),
+            )
+        }
+        #expect(refusedAt.duration(to: .now) < .milliseconds(500))
+
+        try await Task.sleep(for: .milliseconds(250))
+        #expect(await transport.debugSnapshot == .disconnected)
+        #expect(await closeCounter.snapshot == [.transportClosed])
+        await transport.disconnect()
+        await transport.disconnect()
+        #expect(await closeCounter.snapshot == [.transportClosed])
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Request timeout removes its task without disconnecting live child`() async throws {
+        let transport = StdioTransport()
+        try await transport.connect(config: Self.sleepingServerConfig(timeout: 0.05))
+
+        await #expect(throws: MCPError.self) {
+            let _: FixtureResponse = try await transport.sendRequest(
+                method: "fixture/timeout",
+                params: EmptyParams(),
+            )
+        }
+
+        #expect(await transport.debugSnapshot == .connectedIdle)
+        await transport.disconnect()
+        #expect(await transport.debugSnapshot == .disconnected)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Client clears cached tools after child loss and reconnects with a new session`() async throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tachikoma-stdio-reconnect-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let client = MCPClient(
+            name: "stdio-reconnect",
+            config: MCPServerConfig(
+                command: "/bin/sh",
+                args: ["-c", Self.reconnectingMCPServerScript],
+                env: ["MARKER_PATH": marker.path],
+                timeout: 5,
+                autoReconnect: false,
+            ),
+        )
+
+        try await client.connect()
+        #expect(await client.isConnected)
+        #expect(await client.tools.map(\.name) == ["fixture_tool"])
+
+        await #expect(throws: MCPError.transportClosed) {
+            _ = try await client.executeTool(name: "fixture_tool", arguments: [:])
+        }
+        #expect(await !(client.isConnected))
+        #expect(await client.tools.isEmpty)
+
+        let refusedAt = ContinuousClock.now
+        await #expect(throws: MCPError.transportClosed) {
+            _ = try await client.executeTool(name: "fixture_tool", arguments: [:])
+        }
+        #expect(refusedAt.duration(to: .now) < .milliseconds(500))
+
+        try await client.connect()
+        #expect(await client.isConnected)
+        #expect(await client.tools.map(\.name) == ["fixture_tool"])
+        let response = try await client.executeTool(name: "fixture_tool", arguments: [:])
+        #expect(!response.isError)
+
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(await client.isConnected)
+        #expect(await client.tools.map(\.name) == ["fixture_tool"])
+        await client.disconnect()
+        await client.disconnect()
+        #expect(await !(client.isConnected))
+        #expect(await client.tools.isEmpty)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Client never publishes connected state when child exits during tool discovery`() async throws {
+        let client = MCPClient(
+            name: "stdio-discovery-eof",
+            config: MCPServerConfig(
+                command: "/bin/sh",
+                args: ["-c", Self.discoveryEOFServerScript],
+                timeout: 5,
+                autoReconnect: false,
+            ),
+        )
+
+        await #expect(throws: MCPError.transportClosed) {
+            try await client.connect()
+        }
+        #expect(await !(client.isConnected))
+        #expect(await client.tools.isEmpty)
+        await #expect(throws: MCPError.transportClosed) {
+            _ = try await client.executeTool(name: "missing", arguments: [:])
+        }
+        await client.disconnect()
+    }
+
+    private static func exitAfterRequestCountConfig(count: Int, timeout: TimeInterval) -> MCPServerConfig {
+        let reads = Array(repeating: "IFS= read -r line || exit 0", count: count).joined(separator: "\n")
+        return MCPServerConfig(
+            command: "/bin/sh",
+            args: ["-c", "\(reads)\nexit 0"],
+            timeout: timeout,
+            autoReconnect: false,
+        )
+    }
+
+    private static func sleepingServerConfig(timeout: TimeInterval) -> MCPServerConfig {
+        MCPServerConfig(
+            command: "/bin/sh",
+            args: ["-c", "IFS= read -r line || exit 0\nsleep 5"],
+            timeout: timeout,
+            autoReconnect: false,
+        )
+    }
+
+    private static let reconnectingMCPServerScript = #"""
+    while IFS= read -r line; do
+      id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+      case "$line" in
+        *'"method":"initialize"'*)
+          response='{"jsonrpc":"2.0","id":'
+          response=$response"$id"
+          response=$response',"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},'
+          response=$response'"serverInfo":{"name":"fixture","version":"1.0"}}}'
+          printf '%s\n' "$response"
+          ;;
+        *tools*list*)
+          response='{"jsonrpc":"2.0","id":'
+          response=$response"$id"
+          response=$response',"result":{"tools":[{"name":"fixture_tool","description":"Fixture",'
+          response=$response'"inputSchema":{"type":"object"}}]}}'
+          printf '%s\n' "$response"
+          ;;
+        *tools*call*)
+          if [ ! -e "$MARKER_PATH" ]; then
+            : > "$MARKER_PATH"
+            exit 0
+          fi
+          response='{"jsonrpc":"2.0","id":'
+          response=$response"$id"
+          response=$response',"result":{"content":[{"type":"text","text":"ok"}],"isError":false}}'
+          printf '%s\n' "$response"
+          ;;
+      esac
+    done
+    """#
+
+    private static let discoveryEOFServerScript = #"""
+    while IFS= read -r line; do
+      id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+      case "$line" in
+        *'"method":"initialize"'*)
+          response='{"jsonrpc":"2.0","id":'
+          response=$response"$id"
+          response=$response',"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},'
+          response=$response'"serverInfo":{"name":"fixture","version":"1.0"}}}'
+          printf '%s\n' "$response"
+          ;;
+        *tools*list*)
+          exit 0
+          ;;
+      esac
+    done
+    """#
+}
+
+private struct FixtureResponse: Decodable {
+    let ok: Bool?
+}
+
+private actor CloseCounter {
+    private var errors: [MCPError] = []
+
+    func record(_ error: MCPError) {
+        self.errors.append(error)
+    }
+
+    var snapshot: [MCPError] {
+        self.errors
+    }
+}
+
+extension StdioTransportDebugSnapshot {
+    fileprivate static let disconnected = StdioTransportDebugSnapshot(
+        isConnected: false,
+        pendingRequestCount: 0,
+        timeoutTaskCount: 0,
+    )
+    fileprivate static let connectedIdle = StdioTransportDebugSnapshot(
+        isConnected: true,
+        pendingRequestCount: 0,
+        timeoutTaskCount: 0,
+    )
+}


### PR DESCRIPTION
## Summary

- make stdio MCP connection lifecycle generation-owned so child exit or stdout EOF atomically closes the active generation
- clear `MCPClient` connectivity and cached tools on unexpected closure, fail every pending request immediately with typed `transportClosed`, and refuse later requests or notifications before writing
- cancel and remove request timeout tasks exactly once while preventing late responses or old-child callbacks from affecting a replacement session
- preserve the serialized JSON-line frame writer, make explicit disconnect idempotent, and require tool discovery to succeed before publishing a connected client
- add deterministic child-exit, 12-request concurrent drain, timeout cleanup, superseded-frame, discovery-EOF, reconnect, and no-late-invalidation regressions

## Proof

- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` — 837 core + 62 MCP tests passed
- focused MCP client/adapter/frame/lifecycle suites — 38 tests passed
- `swift build -c release`
- `swift package resolve` with no `Package.resolved` drift
- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict` — 0 violations
- structured autoreview clean with no actionable findings
