### PR TITLE
fix: reject invalid provider base URLs instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
-- OpenAI Responses, embeddings, and LM Studio now throw `TachikomaError.invalidConfiguration` for empty or malformed custom base URLs instead of crashing on `URL(string:)!`.
 - Stdio MCP child exit now atomically closes the connection, clears cached tools, fails pending requests without waiting for their timeout, rejects later sends, and preserves generation-safe reconnects.
 - The root package no longer declares unused Commander products for its hand-parsed CLIs, avoiding local/remote package-identity conflicts in consumers; hermetic macOS/Linux tests now block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- OpenAI Responses, embeddings, and LM Studio now throw `TachikomaError.invalidConfiguration` for empty or malformed custom base URLs instead of crashing on `URL(string:)!`.
 - Stdio MCP child exit now atomically closes the connection, clears cached tools, fails pending requests without waiting for their timeout, rejects later sends, and preserves generation-safe reconnects.
 - The root package no longer declares unused Commander products for its hand-parsed CLIs, avoiding local/remote package-identity conflicts in consumers; hermetic macOS/Linux tests now block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -872,7 +872,17 @@ struct OpenAICompatibleHelper {
 
     // MARK: - URL Construction
 
-    private static func buildURL(baseURL: String, path: String, queryItems: [URLQueryItem]) throws -> URL {
+    /// Build an endpoint URL from a configurable provider base URL.
+    /// Empty and malformed values throw instead of crashing on `URL(string:)!`.
+    static func endpointURL(baseURL: String?, path: String) throws -> URL {
+        let trimmed = (baseURL ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw TachikomaError.invalidConfiguration("Invalid base URL: <empty>")
+        }
+        return try self.buildURL(baseURL: trimmed, path: path, queryItems: [])
+    }
+
+    static func buildURL(baseURL: String, path: String, queryItems: [URLQueryItem]) throws -> URL {
         guard var components = URLComponents(string: baseURL) else {
             throw TachikomaError.invalidConfiguration("Invalid base URL: \(baseURL)")
         }

--- a/Sources/Tachikoma/Providers/LMStudioProvider.swift
+++ b/Sources/Tachikoma/Providers/LMStudioProvider.swift
@@ -91,7 +91,7 @@ public actor LMStudioProvider: ModelProvider {
     }
 
     public func healthCheck() async throws -> HealthStatus {
-        let url = URL(string: "\(actualBaseURL)/models")!
+        let url = try OpenAICompatibleHelper.endpointURL(baseURL: self.actualBaseURL, path: "/models")
         let (data, _) = try await session.data(from: url)
 
         // Parse models endpoint response
@@ -118,7 +118,7 @@ public actor LMStudioProvider: ModelProvider {
     }
 
     public func listModels() async throws -> [Model] {
-        let url = URL(string: "\(actualBaseURL)/models")!
+        let url = try OpenAICompatibleHelper.endpointURL(baseURL: self.actualBaseURL, path: "/models")
         let (data, _) = try await session.data(from: url)
         let response = try decoder.decode(ModelsResponse.self, from: data)
         return response.data
@@ -129,7 +129,10 @@ public actor LMStudioProvider: ModelProvider {
     public func generateText(request: ProviderRequest) async throws -> ProviderResponse {
         let openAIRequest = try mapToOpenAIRequest(request)
 
-        var urlRequest = URLRequest(url: URL(string: "\(actualBaseURL)/chat/completions")!)
+        var urlRequest = try URLRequest(url: OpenAICompatibleHelper.endpointURL(
+            baseURL: self.actualBaseURL,
+            path: "/chat/completions",
+        ))
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let apiKey {
@@ -148,7 +151,10 @@ public actor LMStudioProvider: ModelProvider {
     public func streamText(request: ProviderRequest) async throws -> AsyncThrowingStream<TextStreamDelta, Error> {
         let openAIRequest = try mapToOpenAIRequest(request, streaming: true)
 
-        var urlRequest = URLRequest(url: URL(string: "\(actualBaseURL)/chat/completions")!)
+        var urlRequest = try URLRequest(url: OpenAICompatibleHelper.endpointURL(
+            baseURL: self.actualBaseURL,
+            path: "/chat/completions",
+        ))
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let apiKey {

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIEmbeddingProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIEmbeddingProvider.swift
@@ -35,7 +35,10 @@ struct OpenAIEmbeddingProvider: EmbeddingProvider, ModelProvider {
             throw TachikomaError.authenticationFailed("OpenAI API key not configured")
         }
 
-        let url = URL(string: "\(baseURL ?? "https://api.openai.com/v1")/embeddings")!
+        let url = try OpenAICompatibleHelper.endpointURL(
+            baseURL: self.baseURL ?? "https://api.openai.com/v1",
+            path: "/embeddings",
+        )
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -103,7 +103,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         let responsesRequest = try self.buildResponsesRequest(request: request)
 
         // Create URL for Responses API endpoint
-        let url = URL(string: "\(self.baseURL!)/responses")!
+        let url = try OpenAICompatibleHelper.endpointURL(baseURL: self.baseURL, path: "/responses")
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         guard case let .platform(auth) = self.transport else {
@@ -180,7 +180,10 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             codex: requestAuthentication.isCodex,
         )
 
-        let url = URL(string: "\(requestAuthentication.baseURL)/responses")!
+        let url = try OpenAICompatibleHelper.endpointURL(
+            baseURL: requestAuthentication.baseURL,
+            path: "/responses",
+        )
         let finalURLRequest: URLRequest = {
             var req = URLRequest(url: url)
             req.httpMethod = "POST"

--- a/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
+++ b/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import Tachikoma
+
+struct InvalidProviderBaseURLTests {
+    /// Space in the host makes `URL(string:)` return nil. Force-unwrap used to crash.
+    private static let malformedBaseURL = "https://exa mple.com"
+
+    @Test
+    func `Responses generate throws on malformed base URL`() async throws {
+        let provider = try self.responsesProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.generateText(request: self.sampleRequest)
+        }
+    }
+
+    @Test
+    func `Responses generate throws on empty base URL`() async throws {
+        let provider = try self.responsesProvider(baseURL: "")
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.generateText(request: self.sampleRequest)
+        }
+    }
+
+    @Test
+    func `Responses stream throws on malformed base URL`() async throws {
+        let provider = try self.responsesProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.streamText(request: self.sampleRequest)
+        }
+    }
+
+    @Test
+    func `Embedding generate throws on malformed base URL`() async {
+        let provider = OpenAIEmbeddingProvider(
+            model: .small3,
+            apiKey: "sk-test",
+            baseURL: Self.malformedBaseURL,
+        )
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.generateEmbedding(request: self.embeddingRequest)
+        }
+    }
+
+    @Test
+    func `Embedding generate throws on empty base URL`() async {
+        let provider = OpenAIEmbeddingProvider(
+            model: .small3,
+            apiKey: "sk-test",
+            baseURL: "",
+        )
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.generateEmbedding(request: self.embeddingRequest)
+        }
+    }
+
+    @Test
+    func `LM Studio health check throws on malformed base URL`() async {
+        let provider = LMStudioProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.healthCheck()
+        }
+    }
+
+    @Test
+    func `LM Studio health check throws on empty base URL`() async {
+        let provider = LMStudioProvider(baseURL: "")
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.healthCheck()
+        }
+    }
+
+    @Test
+    func `LM Studio generate throws on malformed base URL`() async {
+        let provider = LMStudioProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.generateText(request: self.sampleRequest)
+        }
+    }
+
+    private func responsesProvider(baseURL: String) throws -> OpenAIResponsesProvider {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setAPIKey("sk-test", for: .openai)
+        config.setBaseURL(baseURL, for: .openai)
+        return try OpenAIResponsesProvider(model: .gpt5, configuration: config)
+    }
+
+    private var sampleRequest: ProviderRequest {
+        ProviderRequest(
+            messages: [ModelMessage(role: .user, content: [.text("ping")])],
+            settings: .init(maxTokens: 32),
+        )
+    }
+
+    private var embeddingRequest: EmbeddingRequest {
+        EmbeddingRequest(input: .text("hello"), settings: .default)
+    }
+
+    private func expectInvalidBaseURL(_ body: () async throws -> Void) async {
+        do {
+            try await body()
+            Issue.record("Expected TachikomaError.invalidConfiguration for a bad base URL")
+        } catch let error as TachikomaError {
+            guard case let .invalidConfiguration(message) = error else {
+                Issue.record("Expected invalidConfiguration, got \(error)")
+                return
+            }
+            #expect(message.contains("Invalid base URL"))
+        } catch {
+            Issue.record("Expected TachikomaError, got \(error)")
+        }
+    }
+}

--- a/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
+++ b/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
@@ -81,11 +81,29 @@ struct InvalidProviderBaseURLTests {
     }
 
     @Test
+    func `LM Studio list models throws on malformed base URL`() async {
+        let provider = LMStudioProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.listModels()
+        }
+    }
+
+    @Test
     func `LM Studio generate throws on malformed base URL`() async {
         let provider = LMStudioProvider(baseURL: Self.malformedBaseURL)
 
         await self.expectInvalidBaseURL {
             _ = try await provider.generateText(request: self.sampleRequest)
+        }
+    }
+
+    @Test
+    func `LM Studio stream throws on malformed base URL`() async {
+        let provider = LMStudioProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.streamText(request: self.sampleRequest)
         }
     }
 


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses generate/stream, OpenAI embeddings, and LM Studio health/generate force-unwrap `URL(string:)` on a configurable base URL. A space in the host (hand-edited `OPENAI_BASE_URL`, empty-ish custom URL, or `LMStudioProvider(baseURL:)`) makes `URL(string:)` return nil and traps the process:

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

Chat completions already throw `TachikomaError.invalidConfiguration` through `OpenAICompatibleHelper.buildURL`. These three paths did not. Same class as [Peekaboo #488](https://github.com/openclaw/Peekaboo/pull/488).

## Evidence

Live `swift` of the old composition vs the patched throw. Same host string in both runs: `https://exa mple.com`.

Before (force-unwrap, process traps):

```console
$ swift /tmp/url-crash-before.swift
About to unwrap URL(string: "https://exa mple.com/responses")
main/url-crash-before.swift:7: Fatal error: Unexpectedly found nil while unwrapping an Optional value
exit=133
```

After (throw, process stays up; valid default URL still builds):

```console
$ swift /tmp/url-throw-after.swift
THROW base="https://exa mple.com" -> Invalid configuration: Invalid base URL: https://exa mple.com
THROW base="" -> Invalid configuration: Invalid base URL:
OK  base="https://api.openai.com/v1" -> https://api.openai.com/v1/responses
```

After the patch, the same malformed and empty bases on the real providers (`OpenAIResponsesProvider.generateText` / `streamText`, `OpenAIEmbeddingProvider.generateEmbedding`, `LMStudioProvider.healthCheck` / `generateText`) throw `TachikomaError.invalidConfiguration` and do not trap. Focused run:

```console
$ TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter InvalidProviderBaseURLTests
✔ Suite InvalidProviderBaseURLTests passed after 0.004 seconds.
✔ Test run with 8 tests in 1 suite passed after 0.004 seconds.
```

`CHANGELOG.md` is left to the release process.

## Real behavior proof

- **Behavior or issue addressed:** Configurable provider base URLs that `URL(string:)` cannot parse used to crash OpenAI Responses, embeddings, and LM Studio. They now throw `TachikomaError.invalidConfiguration("Invalid base URL: ...")`.
- **Real environment tested:** macOS 15, Apple Swift 6.3.3, clone at `/tmp/oc-impl-tachikoma-url` on `fix/custom-base-url-guard` from `openclaw/Tachikoma` `main` at `41b841a`.
- **Exact steps or command run after this patch:** `swift /tmp/url-crash-before.swift` for the old unwrap; `swift /tmp/url-throw-after.swift` for the throw path; `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter InvalidProviderBaseURLTests` against the patched providers.
- **Evidence after fix:** terminal output above. Malformed host traps on unwrap (`exit=133`) and throws after the patch. Empty base throws. Valid `https://api.openai.com/v1` still builds `.../v1/responses`.
- **Observed result after fix:** Responses generate/stream, embeddings, and LM Studio health/generate reject empty and `https://exa mple.com` with `invalidConfiguration`. They no longer fatalError.
- **What was not tested:** Live OpenAI or LM Studio servers. Valid custom hosts still follow `buildURL` path joining (checked with `https://openai-compatible.example.test/v1/responses`).

## Summary

- Reuse `OpenAICompatibleHelper.buildURL` through a new `endpointURL` helper that also rejects empty/whitespace bases
- Replace `URL(string:)!` in Responses generate/stream, embeddings, and LM Studio models/chat endpoints

Introduced on Responses in [`f3241b40`](https://github.com/openclaw/Tachikoma/commit/f3241b40) ([#40](https://github.com/openclaw/Tachikoma/pull/40), 2026-08-02, 13 days). Embeddings [`cd8e0233`](https://github.com/openclaw/Tachikoma/commit/cd8e0233) and LM Studio [`d6a12d02`](https://github.com/openclaw/Tachikoma/commit/d6a12d02) (2025-08-06, 374 days).
