### PR TITLE
fix(audio): reject invalid deadlines before tool dispatch

### DIFF
--- a/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
+++ b/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
@@ -154,6 +154,19 @@ public actor RealtimeToolExecutor {
             return execution
         }
 
+        guard let timeoutDuration = AudioTimeoutDuration.validated(seconds: timeout) else {
+            let execution = ToolExecution(
+                id: executionId,
+                toolName: toolName,
+                arguments: arguments,
+                result: .timeout,
+                timestamp: startTime,
+                duration: Date().timeIntervalSince(startTime),
+            )
+            self.addToHistory(execution)
+            return execution
+        }
+
         // Execute with timeout
         let task = Task {
             await wrapper.tool.execute(parsedArgs)
@@ -161,12 +174,8 @@ public actor RealtimeToolExecutor {
 
         // Create timeout task
         let timeoutTask = Task {
-            guard let duration = AudioTimeoutDuration.validated(seconds: timeout) else {
-                task.cancel()
-                return
-            }
             do {
-                try await Task.sleep(for: duration)
+                try await Task.sleep(for: timeoutDuration)
             } catch {
                 return
             }

--- a/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
+++ b/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
@@ -22,6 +22,10 @@ struct RealtimeToolExecutorTimeoutTests {
                 self.waiters.append(continuation)
             }
         }
+
+        func didStart() -> Bool {
+            self.started
+        }
     }
 
     private struct HangTool: RealtimeExecutableTool {
@@ -112,5 +116,6 @@ struct RealtimeToolExecutorTimeoutTests {
             Issue.record("Expected invalid deadline to be recorded as timeout, got \(execution.result)")
             return
         }
+        #expect(await probe.didStart() == false)
     }
 }


### PR DESCRIPTION
## Summary

- validate Realtime tool deadlines before creating the executable task
- return and record `.timeout` immediately for zero, negative, non-finite, or overflowing deadlines
- assert that invalid deadlines never enter the registered tool

## Root cause

The validation added in #68 ran inside the concurrent deadline task. The tool task was created first, so an invalid deadline could still begin tool side effects before cancellation; a tool that ignored cancellation could also prevent the call from returning. Moving validation ahead of task creation makes the invalid-input path genuinely fail closed.

## Proof

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter RealtimeToolExecutorTimeoutTests` — 10 cases passed
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` — 913 tests passed
- P0–P2 structured review — no actionable findings

`CHANGELOG.md` remains release-owned; the downstream Peekaboo 4.2.1 dependency note covers #68 and this completion of its fail-closed contract.
