### PR TITLE
fix(audio): preserve realtime tool completion order

### DIFF
--- a/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
+++ b/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
@@ -167,64 +167,46 @@ public actor RealtimeToolExecutor {
             return execution
         }
 
-        // Execute with timeout
-        let task = Task {
-            await wrapper.tool.execute(parsedArgs)
+        let completion = RealtimeToolCompletionRace()
+        let task = Task<Void, Never> {
+            let result = await wrapper.tool.execute(parsedArgs)
+            completion.resolve(.tool(result))
         }
 
-        // Create timeout task
-        let timeoutTask = Task {
+        let timeoutTask = Task<Void, Never> {
             do {
                 try await Task.sleep(for: timeoutDuration)
             } catch {
                 return
             }
-            task.cancel()
+            completion.resolve(.deadline)
         }
 
-        // Wait for result
-        let result = await withTaskCancellationHandler {
-            let executionResult = await task.value
-            timeoutTask.cancel()
-            await timeoutTask.value
-            return executionResult
+        let outcome = await withTaskCancellationHandler {
+            await completion.value()
         } onCancel: {
-            task.cancel()
-            timeoutTask.cancel()
+            completion.resolve(.callerCancellation)
+        }
+        task.cancel()
+        timeoutTask.cancel()
+        await task.value
+        await timeoutTask.value
+
+        let executionResult: ToolExecution.ExecutionResult
+        switch outcome {
+        case let .tool(result):
+            executionResult = .success(result)
+        case .deadline:
+            executionResult = .timeout
+        case .callerCancellation:
+            executionResult = .failure("cancelled")
         }
 
-        if Task.isCancelled {
-            let execution = ToolExecution(
-                id: executionId,
-                toolName: toolName,
-                arguments: arguments,
-                result: .failure("cancelled"),
-                timestamp: startTime,
-                duration: Date().timeIntervalSince(startTime),
-            )
-            self.addToHistory(execution)
-            return execution
-        }
-
-        if task.isCancelled {
-            let execution = ToolExecution(
-                id: executionId,
-                toolName: toolName,
-                arguments: arguments,
-                result: .timeout,
-                timestamp: startTime,
-                duration: Date().timeIntervalSince(startTime),
-            )
-            self.addToHistory(execution)
-            return execution
-        }
-
-        // Success
         let execution = ToolExecution(
             id: executionId,
             toolName: toolName,
             arguments: arguments,
-            result: .success(result),
+            result: executionResult,
             timestamp: startTime,
             duration: Date().timeIntervalSince(startTime),
         )
@@ -366,6 +348,48 @@ public actor RealtimeToolExecutor {
         }
 
         return arguments
+    }
+}
+
+private final class RealtimeToolCompletionRace: @unchecked Sendable {
+    enum Outcome: Sendable {
+        case tool(String)
+        case deadline
+        case callerCancellation
+    }
+
+    private let lock = NSLock()
+    private var outcome: Outcome?
+    private var continuation: CheckedContinuation<Outcome, Never>?
+
+    @discardableResult
+    func resolve(_ outcome: Outcome) -> Bool {
+        self.lock.lock()
+        guard self.outcome == nil else {
+            self.lock.unlock()
+            return false
+        }
+
+        self.outcome = outcome
+        let continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        continuation?.resume(returning: outcome)
+        return true
+    }
+
+    func value() async -> Outcome {
+        await withCheckedContinuation { continuation in
+            self.lock.lock()
+            if let outcome = self.outcome {
+                self.lock.unlock()
+                continuation.resume(returning: outcome)
+                return
+            }
+
+            self.continuation = continuation
+            self.lock.unlock()
+        }
     }
 }
 

--- a/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
+++ b/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
@@ -200,14 +200,13 @@ public actor RealtimeToolExecutor {
             task.cancel()
         }
 
-        let executionResult: ToolExecution.ExecutionResult
-        switch outcome {
+        let executionResult: ToolExecution.ExecutionResult = switch outcome {
         case let .tool(result):
-            executionResult = .success(result)
+            .success(result)
         case .deadline:
-            executionResult = .timeout
+            .timeout
         case .callerCancellation:
-            executionResult = .failure("cancelled")
+            .failure("cancelled")
         }
 
         let execution = ToolExecution(

--- a/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
+++ b/Sources/TachikomaAudio/Realtime/Tools/RealtimeToolExecutor.swift
@@ -11,6 +11,7 @@ public actor RealtimeToolExecutor {
     private var tools: [String: RealtimeToolWrapper] = [:]
     private var executionHistory: [ToolExecution] = []
     private let maxHistorySize = 100
+    private let inFlightTasks = RealtimeToolTaskRegistry()
 
     // MARK: - Types
 
@@ -168,10 +169,13 @@ public actor RealtimeToolExecutor {
         }
 
         let completion = RealtimeToolCompletionRace()
+        let taskRegistry = self.inFlightTasks
         let task = Task<Void, Never> {
+            defer { taskRegistry.finish(executionId) }
             let result = await wrapper.tool.execute(parsedArgs)
             completion.resolve(.tool(result))
         }
+        taskRegistry.register(task, id: executionId)
 
         let timeoutTask = Task<Void, Never> {
             do {
@@ -187,10 +191,14 @@ public actor RealtimeToolExecutor {
         } onCancel: {
             completion.resolve(.callerCancellation)
         }
-        task.cancel()
         timeoutTask.cancel()
-        await task.value
         await timeoutTask.value
+        switch outcome {
+        case .tool:
+            await task.value
+        case .deadline, .callerCancellation:
+            task.cancel()
+        }
 
         let executionResult: ToolExecution.ExecutionResult
         switch outcome {
@@ -212,6 +220,10 @@ public actor RealtimeToolExecutor {
         )
         self.addToHistory(execution)
         return execution
+    }
+
+    func pendingToolTaskCount() -> Int {
+        self.inFlightTasks.count
     }
 
     /// Execute a tool and return just the result string
@@ -390,6 +402,34 @@ private final class RealtimeToolCompletionRace: @unchecked Sendable {
             self.continuation = continuation
             self.lock.unlock()
         }
+    }
+}
+
+private final class RealtimeToolTaskRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var finishedBeforeRegistration: Set<String> = []
+
+    var count: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.tasks.count
+    }
+
+    func register(_ task: Task<Void, Never>, id: String) {
+        self.lock.lock()
+        if self.finishedBeforeRegistration.remove(id) == nil {
+            self.tasks[id] = task
+        }
+        self.lock.unlock()
+    }
+
+    func finish(_ id: String) {
+        self.lock.lock()
+        if self.tasks.removeValue(forKey: id) == nil {
+            self.finishedBeforeRegistration.insert(id)
+        }
+        self.lock.unlock()
     }
 }
 

--- a/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
+++ b/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Tachikoma
-import TachikomaAudio
+@testable import TachikomaAudio
 import Testing
 
 @Suite("Realtime tool executor timeouts")
@@ -156,7 +156,7 @@ struct RealtimeToolExecutorTimeoutTests {
     }
 
     @Test
-    func `Deadline winner survives later caller cancellation during cleanup`() async {
+    func `Deadline returns while delayed cleanup remains owned`() async {
         let probe = ToolProbe()
         let executor = RealtimeToolExecutor()
         await executor.register(SlowCancellationTool(probe: probe))
@@ -165,14 +165,54 @@ struct RealtimeToolExecutorTimeoutTests {
         }
 
         await probe.waitUntilCancellationObserved()
-        work.cancel()
-        await probe.releaseCleanup()
-        let execution = await work.value
-
-        guard case .timeout = execution.result else {
-            Issue.record("Expected the first deadline winner to remain a timeout, got \(execution.result)")
+        guard let execution = await Self.waitForExecution(executor) else {
+            await probe.releaseCleanup()
+            _ = await work.value
+            Issue.record("Expected the elapsed deadline to return before delayed tool cleanup")
             return
         }
+
+        if case .timeout = execution.result {
+            // Expected.
+        } else {
+            Issue.record("Expected elapsed deadline to remain a timeout, got \(execution.result)")
+        }
+        #expect(await executor.pendingToolTaskCount() == 1)
+        _ = await work.value
+
+        await probe.releaseCleanup()
+        #expect(await Self.waitForPendingTaskDrain(executor))
+    }
+
+    @Test
+    func `Caller cancellation returns while delayed cleanup remains owned`() async {
+        let probe = ToolProbe()
+        let executor = RealtimeToolExecutor()
+        await executor.register(SlowCancellationTool(probe: probe))
+        let work = Task {
+            await executor.execute(toolName: "slow-cancellation", arguments: "{}", timeout: 30)
+        }
+
+        await probe.waitUntilStarted()
+        work.cancel()
+        await probe.waitUntilCancellationObserved()
+        guard let execution = await Self.waitForExecution(executor) else {
+            await probe.releaseCleanup()
+            _ = await work.value
+            Issue.record("Expected caller cancellation to return before delayed tool cleanup")
+            return
+        }
+
+        if case let .failure(message) = execution.result {
+            #expect(message == "cancelled")
+        } else {
+            Issue.record("Expected caller cancellation failure, got \(execution.result)")
+        }
+        #expect(await executor.pendingToolTaskCount() == 1)
+        _ = await work.value
+
+        await probe.releaseCleanup()
+        #expect(await Self.waitForPendingTaskDrain(executor))
     }
 
     @Test(arguments: [0, -1, .infinity, .nan, Double(Int64.max / 2).nextUp, .greatestFiniteMagnitude])
@@ -188,5 +228,32 @@ struct RealtimeToolExecutorTimeoutTests {
             return
         }
         #expect(await probe.didStart() == false)
+    }
+
+    private static func waitForExecution(
+        _ executor: RealtimeToolExecutor,
+    ) async -> RealtimeToolExecutor.ToolExecution?
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while clock.now < deadline {
+            if let execution = await executor.getHistory(limit: 1).last {
+                return execution
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return nil
+    }
+
+    private static func waitForPendingTaskDrain(_ executor: RealtimeToolExecutor) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while clock.now < deadline {
+            if await executor.pendingToolTaskCount() == 0 {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
     }
 }

--- a/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
+++ b/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Tachikoma
-@testable import TachikomaAudio
 import Testing
+@testable import TachikomaAudio
 
 @Suite("Realtime tool executor timeouts")
 struct RealtimeToolExecutorTimeoutTests {
@@ -232,7 +232,8 @@ struct RealtimeToolExecutorTimeoutTests {
 
     private static func waitForExecution(
         _ executor: RealtimeToolExecutor,
-    ) async -> RealtimeToolExecutor.ToolExecution?
+    ) async
+        -> RealtimeToolExecutor.ToolExecution?
     {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(1))

--- a/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
+++ b/Tests/TachikomaTests/Audio/RealtimeToolExecutorTimeoutTests.swift
@@ -8,6 +8,10 @@ struct RealtimeToolExecutorTimeoutTests {
     private actor ToolProbe {
         private var started = false
         private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var cancellationObserved = false
+        private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
+        private var cleanupReleased = false
+        private var cleanupWaiters: [CheckedContinuation<Void, Never>] = []
 
         func markStarted() {
             self.started = true
@@ -25,6 +29,34 @@ struct RealtimeToolExecutorTimeoutTests {
 
         func didStart() -> Bool {
             self.started
+        }
+
+        func markCancellationObserved() {
+            self.cancellationObserved = true
+            let waiters = self.cancellationWaiters
+            self.cancellationWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        func waitUntilCancellationObserved() async {
+            guard !self.cancellationObserved else { return }
+            await withCheckedContinuation { continuation in
+                self.cancellationWaiters.append(continuation)
+            }
+        }
+
+        func waitForCleanupRelease() async {
+            guard !self.cleanupReleased else { return }
+            await withCheckedContinuation { continuation in
+                self.cleanupWaiters.append(continuation)
+            }
+        }
+
+        func releaseCleanup() {
+            self.cleanupReleased = true
+            let waiters = self.cleanupWaiters
+            self.cleanupWaiters.removeAll()
+            waiters.forEach { $0.resume() }
         }
     }
 
@@ -54,6 +86,25 @@ struct RealtimeToolExecutorTimeoutTests {
 
         func execute(_: RealtimeToolArguments) async -> String {
             "done"
+        }
+    }
+
+    private struct SlowCancellationTool: RealtimeExecutableTool {
+        let probe: ToolProbe
+        let metadata = RealtimeToolExecutor.ToolMetadata(
+            name: "slow-cancellation",
+            description: "Pauses cleanup after observing cancellation",
+            parameters: AgentToolParameters(properties: [:], required: []),
+        )
+
+        func execute(_: RealtimeToolArguments) async -> String {
+            await self.probe.markStarted()
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            await self.probe.markCancellationObserved()
+            await self.probe.waitForCleanupRelease()
+            return "done"
         }
     }
 
@@ -100,6 +151,26 @@ struct RealtimeToolExecutorTimeoutTests {
 
         guard case .timeout = execution.result else {
             Issue.record("Expected elapsed deadline to be recorded as timeout, got \(execution.result)")
+            return
+        }
+    }
+
+    @Test
+    func `Deadline winner survives later caller cancellation during cleanup`() async {
+        let probe = ToolProbe()
+        let executor = RealtimeToolExecutor()
+        await executor.register(SlowCancellationTool(probe: probe))
+        let work = Task {
+            await executor.execute(toolName: "slow-cancellation", arguments: "{}", timeout: 0.02)
+        }
+
+        await probe.waitUntilCancellationObserved()
+        work.cancel()
+        await probe.releaseCleanup()
+        let execution = await work.value
+
+        guard case .timeout = execution.result else {
+            Issue.record("Expected the first deadline winner to remain a timeout, got \(execution.result)")
             return
         }
     }


### PR DESCRIPTION
## Summary

- record the first of tool completion, elapsed deadline, or caller cancellation in one lock-serialized outcome
- return timeout and caller cancellation without waiting for a cancellation-insensitive tool, while an executor-owned registry retains the exact late task until it exits
- cover completion-before-registration, bounded deadline/caller return, delayed cleanup ownership, and eventual registry drain deterministically

## Root cause

Tachikoma #68 separated caller cancellation from elapsed deadlines, and #69 moved invalid-deadline validation before executable task creation. Final classification still read mutable task cancellation flags after cleanup. A later caller cancellation could therefore overwrite an earlier deadline, while a deadline racing a completed tool could overwrite a successful result.

The executor now classifies exclusively from the first published outcome. Cleanup changes task state but cannot change that result. Because `RealtimeExecutableTool` has no cooperative-cancellation contract, deadline and caller-cancel paths no longer await the tool indefinitely; the registry keeps late cleanup explicitly owned without an untracked fire-and-forget watcher.

## Proof

- focused Realtime tool executor suite — 6 tests passed, including 11 parameterized cases
- full mock/no-API `swift test --parallel` — passed
- scoped SwiftFormat lint — clean
- scoped strict SwiftLint — 0 violations
- first-winner P0–P2 structured review — clean at confidence 0.98
- bounded ownership P0–P2 structured review — clean at confidence 0.94
- final combined two-commit P0–P2 structured review — clean at confidence 0.94

Follow-up to #68 and #69.
