### PR TITLE
fix: reject invalid realtime base URLs instead of crashing

### DIFF
--- a/Sources/TachikomaAudio/Realtime/RealtimeSession.swift
+++ b/Sources/TachikomaAudio/Realtime/RealtimeSession.swift
@@ -76,17 +76,23 @@ public final class RealtimeSession {
             throw TachikomaError.invalidConfiguration("Already connected or connecting")
         }
 
-        self.state = .connecting
+        let trimmedBaseURL = self.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBaseURL.isEmpty else {
+            throw TachikomaError.invalidConfiguration("Invalid base URL: <empty>")
+        }
 
-        // Build connection URL with model parameter
-        var urlComponents = URLComponents(string: baseURL)!
+        guard var urlComponents = URLComponents(string: trimmedBaseURL) else {
+            throw TachikomaError.invalidConfiguration("Invalid base URL: \(self.baseURL)")
+        }
         urlComponents.queryItems = [
             URLQueryItem(name: "model", value: self.configuration.model),
         ]
 
         guard let url = urlComponents.url else {
-            throw TachikomaError.invalidConfiguration("Invalid URL")
+            throw TachikomaError.invalidConfiguration("Invalid base URL: \(self.baseURL)")
         }
+
+        self.state = .connecting
 
         // Build headers
         let headers = [

--- a/Tests/TachikomaTests/Audio/RealtimeSessionBaseURLTests.swift
+++ b/Tests/TachikomaTests/Audio/RealtimeSessionBaseURLTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import Tachikoma
+@testable import TachikomaAudio
+
+@Suite("Realtime session base URL")
+@MainActor
+struct RealtimeSessionBaseURLTests {
+    /// Space in the host makes `URLComponents(string:)` return nil. Force-unwrap used to crash.
+    private static let malformedBaseURL = "https://exa mple.com"
+
+    @Test
+    func `connect throws on malformed base URL`() async {
+        let session = RealtimeSession(
+            apiKey: "sk-test",
+            baseURL: Self.malformedBaseURL,
+            transport: NeverConnectTransport(),
+        )
+
+        await self.expectInvalidBaseURL {
+            try await session.connect()
+        }
+    }
+
+    @Test
+    func `connect throws on empty base URL`() async {
+        let session = RealtimeSession(
+            apiKey: "sk-test",
+            baseURL: "",
+            transport: NeverConnectTransport(),
+        )
+
+        await self.expectInvalidBaseURL {
+            try await session.connect()
+        }
+    }
+
+    @Test
+    func `connect throws on whitespace-only base URL`() async {
+        let session = RealtimeSession(
+            apiKey: "sk-test",
+            baseURL: "   ",
+            transport: NeverConnectTransport(),
+        )
+
+        await self.expectInvalidBaseURL {
+            try await session.connect()
+        }
+    }
+
+    @Test
+    func `connect still reaches transport for a well-formed websocket URL`() async {
+        let session = RealtimeSession(
+            apiKey: "sk-test",
+            baseURL: "wss://api.openai.com/v1/realtime",
+            transport: NeverConnectTransport(),
+        )
+
+        do {
+            try await session.connect()
+            Issue.record("Expected the transport to be invoked after URL validation")
+        } catch let error as TachikomaError {
+            guard case let .apiError(message) = error else {
+                Issue.record("Expected transport apiError, got \(error)")
+                return
+            }
+            #expect(message.contains("transport connect invoked"))
+        } catch {
+            Issue.record("Expected TachikomaError, got \(error)")
+        }
+    }
+
+    private func expectInvalidBaseURL(_ body: () async throws -> Void) async {
+        do {
+            try await body()
+            Issue.record("Expected TachikomaError.invalidConfiguration for a bad base URL")
+        } catch let error as TachikomaError {
+            guard case let .invalidConfiguration(message) = error else {
+                Issue.record("Expected invalidConfiguration, got \(error)")
+                return
+            }
+            #expect(message.contains("Invalid base URL"))
+        } catch {
+            Issue.record("Expected TachikomaError, got \(error)")
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+private final class NeverConnectTransport: RealtimeTransport, @unchecked Sendable {
+    func connect(url _: URL, headers _: [String: String]) async throws {
+        throw TachikomaError.apiError("transport connect invoked")
+    }
+
+    func send(_: Data) async throws {}
+
+    func receive() -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    func disconnect() async {}
+
+    var isConnected: Bool {
+        false
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

`RealtimeSession.connect()` force-unwraps `URLComponents(string: baseURL)` on a public, configurable websocket base. A space in the host (or any other string Foundation cannot parse) makes `URLComponents(string:)` return nil and traps the process:

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

This is the leftover sibling of [#67](https://github.com/openclaw/Tachikoma/pull/67), which already rejected empty and malformed bases on OpenAI Responses, embeddings, and LM Studio. Chat already throws through `OpenAICompatibleHelper.buildURL`. Realtime connect did not. Empty and whitespace bases do not trap (`URLComponents(string: "")` succeeds), but they become a relative `?model=...` URL and then attempt a websocket connect. Those must be rejected before that join.

`OpenAICompatibleHelper.endpointURL` is internal to the Tachikoma module and joins an HTTP path, so the audio target uses a local guard that throws the same `TachikomaError.invalidConfiguration` type.

## Why This Change Was Made

#67 closed the provider HTTP force-unwraps. `RealtimeSession.connect()` still used `URLComponents(string: baseURL)!` on the same class of configurable URL. The crash has been in the realtime path since [`e725fc85adc8`](https://github.com/openclaw/Tachikoma/commit/e725fc85adc880d373559c514f0f2b91b95b68bb) (2025-08-06). Same class as [Peekaboo #488](https://github.com/openclaw/Peekaboo/pull/488).

## User Impact

A mis-typed or empty realtime `baseURL` now throws `TachikomaError.invalidConfiguration` instead of killing the process. The default `wss://api.openai.com/v1/realtime` is unchanged. Callers that already `try await session.connect()` can handle the error. Invalid URLs no longer leave the session stuck in `.connecting`.

## Evidence

Live `swift` of the old unwrap vs the patched throw. Same host string in both runs: `https://exa mple.com`.

Before (force-unwrap, process traps):

```console
$ swift /tmp/realtime-url-crash-before.swift
About to unwrap URLComponents(string: "https://exa mple.com")
main/realtime-url-crash-before.swift:5: Fatal error: Unexpectedly found nil while unwrapping an Optional value
exit=133
```

Unfixed `RealtimeSession.connect()` hits the same unwrap:

```console
$ TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter RealtimeSessionBaseURLTests
TachikomaAudio/RealtimeSession.swift:82: Fatal error: Unexpectedly found nil while unwrapping an Optional value
error: Process 'swiftpm-testing-helper' exited with unexpected signal code 5
```

After (throw, process stays up; valid default websocket URL still builds):

```console
$ swift /tmp/realtime-url-throw-after.swift
THROW base="https://exa mple.com" -> Invalid configuration: Invalid base URL: https://exa mple.com
THROW base="" -> Invalid configuration: Invalid base URL: <empty>
THROW base="   " -> Invalid configuration: Invalid base URL: <empty>
OK    base="wss://api.openai.com/v1/realtime" -> wss://api.openai.com/v1/realtime?model=gpt-realtime
```

After the patch, `RealtimeSession.connect()` with `""`, `"   "`, and `https://exa mple.com` throws `TachikomaError.invalidConfiguration` and does not trap. A well-formed `wss://api.openai.com/v1/realtime` still reaches the transport:

```console
$ TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter RealtimeSessionBaseURLTests
✔ Test "connect throws on malformed base URL" passed after 0.001 seconds.
✔ Test "connect throws on empty base URL" passed after 0.001 seconds.
✔ Test "connect throws on whitespace-only base URL" passed after 0.001 seconds.
✔ Test "connect still reaches transport for a well-formed websocket URL" passed after 0.001 seconds.
✔ Suite "Realtime session base URL" passed after 0.001 seconds.
✔ Test run with 4 tests in 1 suite passed after 0.001 seconds.
```

`CHANGELOG.md` is left to the release process.

## Real behavior proof

- **Behavior or issue addressed:** `RealtimeSession.connect()` force-unwrapped `URLComponents(string: baseURL)`. Empty, whitespace, and malformed configurable bases now throw `TachikomaError.invalidConfiguration` instead of trapping, matching the provider URL guard from [#67](https://github.com/openclaw/Tachikoma/pull/67).
- **Real environment tested:** macOS 26.6.1, Apple Swift 6.3.3, full clone at `/tmp/pr-tachikoma-realtime` on `fix/realtime-base-url-guard` from `openclaw/Tachikoma` `main` at `1d29a87`.
- **Exact steps or command run after this patch:** `swift /tmp/realtime-url-crash-before.swift` for the old unwrap; `swift /tmp/realtime-url-throw-after.swift` for the throw path; `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter RealtimeSessionBaseURLTests` against patched `RealtimeSession.connect()`.
- **Evidence after fix:** terminal output above. Malformed host traps on unwrap (`exit=133`, signal 5 on the unfixed session) and throws after the patch. Empty and whitespace bases throw `<empty>`. Valid `wss://api.openai.com/v1/realtime` still builds `...?model=gpt-realtime`.
- **Observed result after fix:** `RealtimeSession.connect()` rejects empty, whitespace, and `https://exa mple.com` with `invalidConfiguration`. It no longer fatalError. A well-formed websocket base still reaches the transport.
- **What was not tested:** Live OpenAI Realtime websocket with a real API key. Other hardcoded audio HTTP URLs (transcription, TTS) were left unchanged because they are not configurable bases.

## Summary

- Replace `URLComponents(string: baseURL)!` in `RealtimeSession.connect()` with a local empty/whitespace/nil-components guard
- Throw `TachikomaError.invalidConfiguration("Invalid base URL: ...")` before setting `.connecting`
- Keep the default `wss://api.openai.com/v1/realtime` path unchanged

## Maintainer integration verification (2026-08-30)

[Standalone production-session proof and full verification output](https://github.com/openclaw/Tachikoma/pull/71#issuecomment-5474477177) now cover the previously missing default-transport path at this PR head, `2f58dacb91d6d08a8da61a1d468bbaf5b84c6fb7`.

An independent SwiftPM consumer importing `TachikomaAudio` constructs `RealtimeSession` with its default WebSocket transport. Current main traps on the malformed host (SIGTRAP, shell exit 133). This PR rejects malformed, empty, and whitespace-only bases twice on each session with `TachikomaError.invalidConfiguration`, preserves `.disconnected`, and exits 0 with network access denied. No authenticated OpenAI connection was attempted.

All 919 tests passed locally (857 core/audio/agent tests and 62 MCP tests); SwiftFormat and strict SwiftLint passed. Codex autoreview returned scoped-clean with no findings in its default P0 blocking scope. The maintainer recommendation is LAND; the orchestrator retains the merge decision.
