### PR TITLE
fix(auth): secure credential transport

### DIFF
--- a/Sources/Tachikoma/Auth/AuthManager.swift
+++ b/Sources/Tachikoma/Auth/AuthManager.swift
@@ -706,10 +706,13 @@ public final class TKAuthManager: @unchecked Sendable {
     ) async
         -> Result<Void, TKAuthError>
     {
-        guard provider.supportsOAuth else { return .failure(.unsupported) }
+        guard provider.supportsOAuth, let config = self.oauthConfig(for: provider) else {
+            return .failure(.unsupported)
+        }
         let pkce = PKCE()
-        let config = self.oauthConfig(for: provider, pkce: pkce)
-        guard let authorizeURL = config.authorizeURL else { return .failure(.general("Bad authorize URL")) }
+        guard let authorizeURL = config.authorizeURL(pkce: pkce) else {
+            return .failure(.general("Bad authorize URL"))
+        }
 
         #if canImport(AppKit)
         if !noBrowser {
@@ -717,6 +720,8 @@ public final class TKAuthManager: @unchecked Sendable {
         }
         #endif
 
+        // The authorization request intentionally carries the public PKCE challenge and state.
+        // The verifier stays in-process and is sent only to the HTTPS token endpoint.
         print("Open this URL in a browser if it did not open automatically:\n  \(authorizeURL.absoluteString)\n")
         print("After authorizing, paste the resulting code (callback URL, code param, or code#state) here:")
         guard let input = readLine(), !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -728,7 +733,7 @@ public final class TKAuthManager: @unchecked Sendable {
         guard !code.isEmpty else { return .failure(.general("Could not extract code")) }
 
         if !state.isEmpty, state != pkce.state {
-            return .failure(.general("OAuth state mismatch (expected \(pkce.state), got \(state))"))
+            return .failure(.general("OAuth state mismatch"))
         }
 
         if config.requiresStateInTokenExchange, state.isEmpty {
@@ -745,13 +750,13 @@ public final class TKAuthManager: @unchecked Sendable {
         return self.persistOAuthResult(tokenResult, config: config)
     }
 
-    private func oauthConfig(for provider: TKProviderId, pkce: PKCE) -> OAuthConfig {
+    private func oauthConfig(for provider: TKProviderId) -> OAuthConfig? {
         switch provider {
         case .openai:
             OAuthConfig(
                 prefix: "OPENAI",
-                authorize: "https://auth.openai.com/oauth/authorize",
-                token: "https://auth.openai.com/oauth/token",
+                authorizeEndpoint: URL(string: "https://auth.openai.com/oauth/authorize")!,
+                tokenEndpoint: URL(string: "https://auth.openai.com/oauth/token")!,
                 clientId: "app_EMoamEEZ73f0CkXaXp7hrann",
                 scope: "openid profile email offline_access",
                 redirect: "http://localhost:1455/auth/callback",
@@ -762,13 +767,12 @@ public final class TKAuthManager: @unchecked Sendable {
                 ],
                 extraToken: [:],
                 betaHeader: nil,
-                pkce: pkce,
             )
         case .anthropic:
             OAuthConfig(
                 prefix: "ANTHROPIC",
-                authorize: "https://claude.ai/oauth/authorize",
-                token: "https://console.anthropic.com/v1/oauth/token",
+                authorizeEndpoint: URL(string: "https://claude.ai/oauth/authorize")!,
+                tokenEndpoint: URL(string: "https://console.anthropic.com/v1/oauth/token")!,
                 clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
                 scope: "org:create_api_key user:profile user:inference",
                 redirect: "https://console.anthropic.com/oauth/code/callback",
@@ -777,21 +781,9 @@ public final class TKAuthManager: @unchecked Sendable {
                 betaHeader: "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
                 tokenEncoding: .json,
                 requiresStateInTokenExchange: true,
-                pkce: pkce,
             )
         case .grok, .gemini, .openrouter:
-            OAuthConfig(
-                prefix: "",
-                authorize: "",
-                token: "",
-                clientId: "",
-                scope: "",
-                redirect: "",
-                extraAuthorize: [:],
-                extraToken: [:],
-                betaHeader: nil,
-                pkce: pkce,
-            )
+            nil
         }
     }
 
@@ -873,8 +865,8 @@ enum OAuthTokenEncoding {
 
 struct OAuthConfig {
     let prefix: String
-    let authorize: String
-    let token: String
+    let authorizeEndpoint: URL
+    let tokenEndpoint: URL
     let clientId: String
     let scope: String
     let redirect: String
@@ -883,12 +875,11 @@ struct OAuthConfig {
     let betaHeader: String?
     let tokenEncoding: OAuthTokenEncoding
     let requiresStateInTokenExchange: Bool
-    let pkce: PKCE
 
-    init(
+    init?(
         prefix: String,
-        authorize: String,
-        token: String,
+        authorizeEndpoint: URL,
+        tokenEndpoint: URL,
         clientId: String,
         scope: String,
         redirect: String,
@@ -897,11 +888,16 @@ struct OAuthConfig {
         betaHeader: String?,
         tokenEncoding: OAuthTokenEncoding = .formURLEncoded,
         requiresStateInTokenExchange: Bool = false,
-        pkce: PKCE,
     ) {
+        guard
+            authorizeEndpoint.scheme?.lowercased() == "https",
+            tokenEndpoint.scheme?.lowercased() == "https" else
+        {
+            return nil
+        }
         self.prefix = prefix
-        self.authorize = authorize
-        self.token = token
+        self.authorizeEndpoint = authorizeEndpoint
+        self.tokenEndpoint = tokenEndpoint
         self.clientId = clientId
         self.scope = scope
         self.redirect = redirect
@@ -910,19 +906,18 @@ struct OAuthConfig {
         self.betaHeader = betaHeader
         self.tokenEncoding = tokenEncoding
         self.requiresStateInTokenExchange = requiresStateInTokenExchange
-        self.pkce = pkce
     }
 
-    var authorizeURL: URL? {
-        var components = URLComponents(string: self.authorize)
+    func authorizeURL(pkce: PKCE) -> URL? {
+        var components = URLComponents(url: self.authorizeEndpoint, resolvingAgainstBaseURL: false)
         var items: [URLQueryItem] = [
             .init(name: "response_type", value: "code"),
             .init(name: "client_id", value: self.clientId),
             .init(name: "redirect_uri", value: self.redirect),
             .init(name: "scope", value: self.scope),
-            .init(name: "code_challenge", value: self.pkce.challenge),
+            .init(name: "code_challenge", value: pkce.challenge),
             .init(name: "code_challenge_method", value: "S256"),
-            .init(name: "state", value: self.pkce.state),
+            .init(name: "state", value: pkce.state),
         ]
         items.append(contentsOf: self.extraAuthorize.map { URLQueryItem(name: $0.key, value: $0.value) })
         components?.queryItems = items
@@ -952,8 +947,7 @@ enum OAuthTokenExchanger {
     ) async
         -> OAuthTokenResult
     {
-        guard let url = URL(string: config.token) else { return .failure("Bad token URL") }
-        var req = URLRequest(url: url)
+        var req = URLRequest(url: config.tokenEndpoint)
         req.httpMethod = "POST"
         var body: [String: String] = [
             "grant_type": "authorization_code",
@@ -1003,6 +997,10 @@ enum OAuthTokenExchanger {
     ) async
         -> OAuthTokenResult
     {
+        guard urlRequest.url?.scheme?.lowercased() == "https" else {
+            return .failure("OAuth token endpoint must use HTTPS")
+        }
+
         // We continue to accept a loosely typed body here (used by existing refresh flows),
         // but the request is now encoded as standard form data for OAuth token endpoints.
         let stringBody = body.reduce(into: [String: String]()) { result, pair in
@@ -1033,7 +1031,13 @@ public enum TKAuthError: Error, Sendable {
 struct TKProviderValidator {
     let timeoutSeconds: Double
 
-    func validate(provider: TKProviderId, secret: String) async -> TKValidationResult {
+    func validate(
+        provider: TKProviderId,
+        secret: String,
+        session: URLSession? = nil,
+    ) async
+        -> TKValidationResult
+    {
         switch provider {
         case .openai:
             return await self.validateBearer(
@@ -1041,6 +1045,7 @@ struct TKProviderValidator {
                 secret: secret,
                 header: "Authorization",
                 valuePrefix: "Bearer ",
+                session: session,
             )
         case .anthropic:
             var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
@@ -1055,25 +1060,35 @@ struct TKProviderValidator {
                     ["role": "user", "content": "ping"],
                 ],
             ])
-            return await HTTP.perform(request: request, timeoutSeconds: self.timeoutSeconds)
+            return await HTTP.perform(
+                request: request,
+                timeoutSeconds: self.timeoutSeconds,
+                session: session,
+            )
         case .grok:
             return await self.validateBearer(
                 url: "https://api.x.ai/v1/models",
                 secret: secret,
                 header: "Authorization",
                 valuePrefix: "Bearer ",
+                session: session,
             )
         case .gemini:
-            let url = "https://generativelanguage.googleapis.com/v1beta/models?key=\(secret)"
-            var request = URLRequest(url: URL(string: url)!)
+            var request = URLRequest(url: URL(string: "https://generativelanguage.googleapis.com/v1beta/models")!)
             request.httpMethod = "GET"
-            return await HTTP.perform(request: request, timeoutSeconds: self.timeoutSeconds)
+            request.setValue(secret, forHTTPHeaderField: "x-goog-api-key")
+            return await HTTP.perform(
+                request: request,
+                timeoutSeconds: self.timeoutSeconds,
+                session: session,
+            )
         case .openrouter:
             return await self.validateBearer(
                 url: "https://openrouter.ai/api/v1/key",
                 secret: secret,
                 header: "Authorization",
                 valuePrefix: "Bearer ",
+                session: session,
             )
         }
     }
@@ -1083,6 +1098,7 @@ struct TKProviderValidator {
         secret: String,
         header: String,
         valuePrefix: String,
+        session: URLSession?,
     ) async
         -> TKValidationResult
     {
@@ -1090,7 +1106,11 @@ struct TKProviderValidator {
         request.httpMethod = "GET"
         request.setValue(valuePrefix + secret, forHTTPHeaderField: header)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        return await HTTP.perform(request: request, timeoutSeconds: self.timeoutSeconds)
+        return await HTTP.perform(
+            request: request,
+            timeoutSeconds: self.timeoutSeconds,
+            session: session,
+        )
     }
 }
 

--- a/Tests/TachikomaTests/Auth/AuthManagerTests.swift
+++ b/Tests/TachikomaTests/Auth/AuthManagerTests.swift
@@ -596,22 +596,24 @@ struct AuthManagerTests {
     @MainActor
     func `o auth token exchange uses form encoding`() async throws {
         OAuthMockURLProtocol.reset()
-        let config = OAuthConfig(
+        let pkce = PKCE()
+        let authorizeEndpoint = try #require(URL(string: "https://example.com/auth"))
+        let tokenEndpoint = try #require(URL(string: "https://example.com/token"))
+        let config = try #require(OAuthConfig(
             prefix: "TEST",
-            authorize: "https://example.com/auth",
-            token: "https://example.com/token",
+            authorizeEndpoint: authorizeEndpoint,
+            tokenEndpoint: tokenEndpoint,
             clientId: "client-id",
             scope: "scope",
             redirect: "https://example.com/callback",
             extraAuthorize: [:],
             extraToken: [:],
             betaHeader: nil,
-            pkce: PKCE(),
-        )
+        ))
         let result = await OAuthTokenExchanger.exchange(
             config: config,
             code: "abc123",
-            pkce: config.pkce,
+            pkce: pkce,
             timeout: 5,
             session: .oauthMock(),
         )
@@ -632,17 +634,20 @@ struct AuthManagerTests {
         #expect(params["client_id"] == "client-id")
         #expect(params["code"] == "abc123")
         #expect(params["redirect_uri"] == "https://example.com/callback")
-        #expect(params["code_verifier"] == config.pkce.verifier)
+        #expect(params["code_verifier"] == pkce.verifier)
     }
 
     @Test
     @MainActor
     func `o auth token exchange uses JSON encoding and state when required`() async throws {
         OAuthMockURLProtocol.reset()
-        let config = OAuthConfig(
+        let pkce = PKCE()
+        let authorizeEndpoint = try #require(URL(string: "https://example.com/auth"))
+        let tokenEndpoint = try #require(URL(string: "https://example.com/token"))
+        let config = try #require(OAuthConfig(
             prefix: "TEST",
-            authorize: "https://example.com/auth",
-            token: "https://example.com/token",
+            authorizeEndpoint: authorizeEndpoint,
+            tokenEndpoint: tokenEndpoint,
             clientId: "client-id",
             scope: "scope",
             redirect: "https://example.com/callback",
@@ -651,13 +656,12 @@ struct AuthManagerTests {
             betaHeader: nil,
             tokenEncoding: .json,
             requiresStateInTokenExchange: true,
-            pkce: PKCE(),
-        )
+        ))
         let result = await OAuthTokenExchanger.exchange(
             config: config,
             code: "abc123",
             state: "state123",
-            pkce: config.pkce,
+            pkce: pkce,
             timeout: 5,
             session: .oauthMock(),
         )
@@ -681,7 +685,76 @@ struct AuthManagerTests {
         #expect(json["code"] as? String == "abc123")
         #expect(json["state"] as? String == "state123")
         #expect(json["redirect_uri"] as? String == "https://example.com/callback")
-        #expect(json["code_verifier"] as? String == config.pkce.verifier)
+        #expect(json["code_verifier"] as? String == pkce.verifier)
+    }
+
+    @Test
+    func `o auth authorization URL exposes challenge but not verifier`() throws {
+        let pkce = PKCE()
+        let authorizeEndpoint = try #require(URL(string: "https://example.com/auth"))
+        let tokenEndpoint = try #require(URL(string: "https://example.com/token"))
+        let config = try #require(OAuthConfig(
+            prefix: "TEST",
+            authorizeEndpoint: authorizeEndpoint,
+            tokenEndpoint: tokenEndpoint,
+            clientId: "client-id",
+            scope: "scope",
+            redirect: "https://example.com/callback",
+            extraAuthorize: [:],
+            extraToken: [:],
+            betaHeader: nil,
+        ))
+
+        let url = try #require(config.authorizeURL(pkce: pkce))
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let query = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value ?? "") })
+        #expect(query["code_challenge"] == pkce.challenge)
+        #expect(query["state"] == pkce.state)
+        #expect(!url.absoluteString.contains(pkce.verifier))
+    }
+
+    @Test
+    @MainActor
+    func `o auth config rejects cleartext token endpoint`() throws {
+        OAuthMockURLProtocol.reset()
+        let authorizeEndpoint = try #require(URL(string: "https://example.com/auth"))
+        let tokenEndpoint = try #require(URL(string: "http://example.com/token"))
+        let config = OAuthConfig(
+            prefix: "TEST",
+            authorizeEndpoint: authorizeEndpoint,
+            tokenEndpoint: tokenEndpoint,
+            clientId: "client-id",
+            scope: "scope",
+            redirect: "https://example.com/callback",
+            extraAuthorize: [:],
+            extraToken: [:],
+            betaHeader: nil,
+        )
+
+        #expect(config == nil)
+        #expect(OAuthMockURLProtocol.requestCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `gemini validation sends API key in header`() async throws {
+        OAuthMockURLProtocol.reset()
+        let validator = TKProviderValidator(timeoutSeconds: 5)
+
+        let result = await validator.validate(
+            provider: .gemini,
+            secret: "test-gemini-key",
+            session: .oauthMock(),
+        )
+
+        guard case .success = result else {
+            Issue.record("Expected successful mock validation")
+            return
+        }
+        let request = try #require(OAuthMockURLProtocol.lastRequest)
+        #expect(request.url?.absoluteString == "https://generativelanguage.googleapis.com/v1beta/models")
+        #expect(request.value(forHTTPHeaderField: "x-goog-api-key") == "test-gemini-key")
+        #expect(request.url?.query == nil)
     }
 
     private static func openAIJWT(accountID: String, expiration: Date) -> String {


### PR DESCRIPTION
## What Problem This Solves

GitHub's default CodeQL setup reported four high-severity auth findings:

- https://github.com/openclaw/Tachikoma/security/code-scanning/1
- https://github.com/openclaw/Tachikoma/security/code-scanning/2
- https://github.com/openclaw/Tachikoma/security/code-scanning/6
- https://github.com/openclaw/Tachikoma/security/code-scanning/8

OAuth provider metadata and per-login PKCE state shared one object, which tainted both the public authorization URL and token endpoint. The first HTTPS repair validated a token endpoint only after converting its credential-bearing string to a URL; CodeQL correctly identified that as a downstream guard. Gemini validation also embedded its API key in the request URL.

## Why This Change Was Made

- OAuth provider metadata is now independent from per-login PKCE state.
- OAuth endpoints are typed URLs whose config initializer accepts HTTPS only, so request construction cannot receive an unvalidated endpoint.
- The authorization URL receives only the public PKCE challenge and CSRF state; the verifier remains process-local until token exchange.
- OAuth refresh exchanges reject non-HTTPS token endpoints before encoding credentials.
- Unsupported providers no longer produce an empty OAuth configuration.
- Gemini validation sends the key in Google's documented `x-goog-api-key` header and keeps the URL credential-free.

## User Impact

OAuth login behavior is unchanged for supported providers. Credential validation avoids URL-based key exposure, and token exchanges fail closed before sending credentials over cleartext endpoints.

## Evidence

- `swiftformat --lint .`
- `swiftlint lint --strict`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter AuthManagerTests`
  - 22 tests passed
- Focused tests capture the Gemini request, prove the key is header-only, verify PKCE verifier exclusion from the authorization URL, and prove cleartext token endpoints cannot create an OAuth config or request.
- Live secretless Gemini probe reached `https://generativelanguage.googleapis.com/v1beta/models` with `x-goog-api-key` and returned the expected `400 INVALID_ARGUMENT` for a fake key.
- Google contract: https://ai.google.dev/api
- OAuth/PKCE contracts: https://datatracker.ietf.org/doc/html/rfc6749 and https://datatracker.ietf.org/doc/html/rfc7636
- Production LOC: +65/-45 (net +20), justified by the typed HTTPS endpoint security boundary and injectable request proof; tests: +87/-14 (net +73).

- [x] AI-assisted
- [x] I understand the change and verified the touched behavior
