### PR TITLE
perf(openai): deduplicate Responses tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - SSE transports now own and cancel their background reader, replace it safely on reconnect, and fail pending requests when the stream terminates instead of leaking work until timeout.
 - Audio abort-signal timeouts now handle zero, negative, non-finite, and unrepresentably large durations without trapping.
 - MCP tool arguments now reject non-finite numbers and lossy or overflowing integer conversions instead of truncating or trapping.
-- OpenAI Responses tools now preserve omission-based optional parameters instead of having automatic strict-schema normalization force fabricated argument values.
+- OpenAI Responses tools now preserve omission-based optional parameters and emit one canonical flattened function schema instead of duplicating it in a nested `function` object.
 - OpenAI Responses tool errors now keep their diagnostic output without sending an unsupported `failed` status that caused request-level errors.
 
 ## [0.3.0] - 2026-08-02

--- a/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
+++ b/Sources/Tachikoma/Providers/OpenAI/OpenAIResponsesProvider.swift
@@ -1036,13 +1036,6 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
         // Keep rejecting unknown root arguments without opting into the provider's recursive strict-schema dialect.
         parameters["additionalProperties"] = false
 
-        let function = ResponsesTool.ToolFunction(
-            name: tool.name,
-            description: tool.description,
-            parameters: parameters,
-            inputSchema: nil,
-        )
-
         return ResponsesTool(
             name: tool.name,
             type: "function",
@@ -1053,7 +1046,7 @@ public final class OpenAIResponsesProvider: ModelProvider, ResponseCacheSafetyPr
             // Responses otherwise attempts to normalize omitted strictness into strict mode,
             // where every property becomes required and optionals must explicitly allow null.
             strict: false,
-            function: function,
+            function: nil,
         )
     }
 

--- a/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
+++ b/Tests/TachikomaTests/Providers/OpenAIResponsesProviderTests.swift
@@ -917,7 +917,10 @@ struct OpenAIResponsesProviderTests {
             let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
             let tools = try #require(json?["tools"] as? [[String: Any]])
             let encodedTool = try #require(tools.first)
+            #expect(encodedTool["name"] as? String == "app")
+            #expect(encodedTool["description"] as? String == "Control apps")
             #expect(encodedTool["strict"] as? Bool == false)
+            #expect(encodedTool["function"] == nil)
             let parameters = try #require(encodedTool["parameters"] as? [String: Any])
             let required = try #require(parameters["required"] as? [String])
             #expect(required == ["action"])


### PR DESCRIPTION
## Summary

- remove the redundant nested `function` object from OpenAI Responses function-tool requests
- retain the canonical root `name`, `description`, `parameters`, and `strict` fields
- assert the serialized request shape and consolidate the current Unreleased changelog entry

## Testing

- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter OpenAIResponsesProviderTests`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel`
- `swiftlint lint --config .swiftlint.yml --strict`
- `mint run 'nicklockwood/SwiftFormat@0.62.1' swiftformat --lint .`
- autoreview: clean
