### PR TITLE
fix(mcp): make stdio requests cancellation-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 
 ### Fixed
+- Cancelling a stdio MCP request now clears its continuation and timeout without closing the child, and cancelled initialization no longer retries legacy protocol variants.
 - Stdio MCP child exit now atomically closes the connection, clears cached tools, fails pending requests without waiting for their timeout, rejects later sends, and preserves generation-safe reconnects.
 - The root package no longer declares unused Commander products for its hand-parsed CLIs, avoiding local/remote package-identity conflicts in consumers; hermetic macOS/Linux tests now block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.

--- a/Sources/TachikomaMCP/Client/MCPClient.swift
+++ b/Sources/TachikomaMCP/Client/MCPClient.swift
@@ -168,28 +168,7 @@ public final class MCPClient: Sendable {
                 clientInfo: ClientInfo(name: "tachikoma-mcp-client", version: "1.0.0"),
                 capabilities: ClientCapabilities(),
             )
-            let initResponse: InitializeResponse
-            do {
-                initResponse = try await transport.sendRequest(method: "initialize", params: initParams)
-            } catch {
-                // Fallback 1: Older protocol version
-                let oldParams = InitializeParams(
-                    protocolVersion: "2024-11-05",
-                    clientInfo: initParams.clientInfo,
-                    capabilities: initParams.capabilities,
-                )
-                do {
-                    initResponse = try await transport.sendRequest(method: "initialize", params: oldParams)
-                } catch {
-                    // Fallback 2: snake_case protocol_version with older version
-                    let snake = InitializeParamsSnake(
-                        protocolVersion: oldParams.protocolVersion,
-                        clientInfo: initParams.clientInfo,
-                        capabilities: initParams.capabilities,
-                    )
-                    initResponse = try await transport.sendRequest(method: "initialize", params: snake)
-                }
-            }
+            let initResponse = try await self.initialize(using: transport, params: initParams)
 
             self.logger.debug("Initialized MCP connection: \(initResponse)")
 
@@ -197,6 +176,8 @@ public final class MCPClient: Sendable {
             // Some servers (like Context7) may not support this notification
             do {
                 try await transport.sendNotification(method: "notifications/initialized", params: EmptyParams())
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 self.logger.debug("Server may not support notifications/initialized: \(error)")
             }
@@ -212,6 +193,39 @@ public final class MCPClient: Sendable {
                 error: (error as? MCPError) ?? .connectionFailed(error.localizedDescription),
             )
             throw error
+        }
+    }
+
+    func initialize(
+        using transport: any MCPTransport,
+        params: InitializeParams,
+    ) async throws
+        -> InitializeResponse
+    {
+        do {
+            return try await transport.sendRequest(method: "initialize", params: params)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            let oldParams = InitializeParams(
+                protocolVersion: "2024-11-05",
+                clientInfo: params.clientInfo,
+                capabilities: params.capabilities,
+            )
+            do {
+                return try await transport.sendRequest(method: "initialize", params: oldParams)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                let snake = InitializeParamsSnake(
+                    protocolVersion: oldParams.protocolVersion,
+                    clientInfo: params.clientInfo,
+                    capabilities: params.capabilities,
+                )
+                return try await transport.sendRequest(method: "initialize", params: snake)
+            }
         }
     }
 

--- a/Sources/TachikomaMCP/Client/StdioTransport.swift
+++ b/Sources/TachikomaMCP/Client/StdioTransport.swift
@@ -22,6 +22,17 @@ private struct StdioConnectionCloseResult: Sendable {
     let timeoutTasks: [Task<Void, Never>]
 }
 
+private enum StdioRequestRegistration: Equatable {
+    case awaitingContinuation
+    case cancelled
+}
+
+private enum StdioRequestRegistrationResult {
+    case added
+    case cancelled
+    case closed
+}
+
 struct StdioTransportDebugSnapshot: Sendable, Equatable {
     let isConnected: Bool
     let pendingRequestCount: Int
@@ -37,6 +48,7 @@ private actor StdioTransportState {
     var outputPipe: Pipe?
     var errorPipe: Pipe?
     var nextId: Int = 1
+    private var requestRegistrations: [Int: StdioRequestRegistration] = [:]
     var pendingRequests: [String: CheckedContinuation<Data, Swift.Error>] = [:]
     var timeoutTasks: [Int: Task<Void, Never>] = [:]
     var requestTimeoutNs: UInt64 = 30_000_000_000 // default 30s
@@ -72,16 +84,50 @@ private actor StdioTransportState {
         return (id, activeGeneration)
     }
 
+    func beginRequestRegistration(id: Int, generation: UInt64) -> Bool {
+        guard self.activeGeneration == generation else { return false }
+        self.requestRegistrations[id] = .awaitingContinuation
+        return true
+    }
+
     func addPendingRequest(
         id: Int,
         generation: UInt64,
         continuation: CheckedContinuation<Data, Swift.Error>,
     )
-        -> Bool
+        -> StdioRequestRegistrationResult
     {
-        guard self.activeGeneration == generation else { return false }
+        guard self.activeGeneration == generation else {
+            self.requestRegistrations.removeValue(forKey: id)
+            return .closed
+        }
+        switch self.requestRegistrations.removeValue(forKey: id) {
+        case .awaitingContinuation:
+            break
+        case .cancelled:
+            return .cancelled
+        case nil:
+            return .closed
+        }
         self.pendingRequests[String(id)] = continuation
-        return true
+        return .added
+    }
+
+    func cancelRequest(
+        id: Int,
+        generation: UInt64,
+    )
+        -> CheckedContinuation<Data, Swift.Error>?
+    {
+        guard self.activeGeneration == generation else { return nil }
+        self.timeoutTasks.removeValue(forKey: id)?.cancel()
+        if let continuation = self.pendingRequests.removeValue(forKey: String(id)) {
+            return continuation
+        }
+        if self.requestRegistrations[id] == .awaitingContinuation {
+            self.requestRegistrations[id] = .cancelled
+        }
+        return nil
     }
 
     func failRequest(
@@ -119,7 +165,7 @@ private actor StdioTransportState {
     }
 
     func addTimeoutTask(id: Int, generation: UInt64, task: Task<Void, Never>) -> Bool {
-        guard self.activeGeneration == generation else {
+        guard self.activeGeneration == generation, self.pendingRequests[String(id)] != nil else {
             task.cancel()
             return false
         }
@@ -154,6 +200,7 @@ private actor StdioTransportState {
         }
 
         self.activeGeneration = nil
+        self.requestRegistrations.removeAll()
         let pendingRequests = Array(self.pendingRequests.values)
         self.pendingRequests.removeAll()
         let timeoutTasks = Array(self.timeoutTasks.values)
@@ -398,41 +445,60 @@ public final class StdioTransport: MCPTransport {
             self.logger.info("[MCP stdio] → initialize payload: \(json)")
         }
 
-        let responseData = try await withCheckedThrowingContinuation { continuation in
-            Task {
-                guard
-                    await self.state.addPendingRequest(
+        guard await self.state.beginRequestRegistration(id: id, generation: generation) else {
+            throw MCPError.transportClosed
+        }
+        let responseData = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                Task {
+                    switch await self.state.addPendingRequest(
                         id: id,
                         generation: generation,
                         continuation: continuation,
-                    ) else
-                {
-                    continuation.resume(throwing: MCPError.transportClosed)
-                    return
-                }
-                let timeoutTask = Task { [logger] in
-                    let ns = await state.requestTimeoutNs
-                    do {
-                        try await Task.sleep(nanoseconds: ns)
-                    } catch {
+                    ) {
+                    case .added:
+                        break
+                    case .cancelled:
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    case .closed:
+                        continuation.resume(throwing: MCPError.transportClosed)
                         return
                     }
-                    if let pending = await state.expireRequest(id: id, generation: generation) {
-                        logger.error("MCP stdio request timed out: method=\(method), id=\(id)")
-                        pending
-                            .resume(throwing: MCPError.executionFailed("Request timed out after \(ns / 1_000_000)ms"))
+                    let timeoutTask = Task { [logger] in
+                        let ns = await state.requestTimeoutNs
+                        do {
+                            try await Task.sleep(nanoseconds: ns)
+                        } catch {
+                            return
+                        }
+                        if let pending = await state.expireRequest(id: id, generation: generation) {
+                            logger.error("MCP stdio request timed out: method=\(method), id=\(id)")
+                            pending
+                                .resume(
+                                    throwing: MCPError.executionFailed(
+                                        "Request timed out after \(ns / 1_000_000)ms",
+                                    ),
+                                )
+                        }
                     }
-                }
-                guard await self.state.addTimeoutTask(id: id, generation: generation, task: timeoutTask) else {
-                    return
-                }
+                    guard await self.state.addTimeoutTask(id: id, generation: generation, task: timeoutTask) else {
+                        return
+                    }
 
-                do {
-                    try await self.send(data, generation: generation)
-                } catch {
-                    if let pending = await self.state.failRequest(id: id, generation: generation) {
-                        pending.resume(throwing: error)
+                    do {
+                        try await self.send(data, generation: generation)
+                    } catch {
+                        if let pending = await self.state.failRequest(id: id, generation: generation) {
+                            pending.resume(throwing: error)
+                        }
                     }
+                }
+            }
+        } onCancel: {
+            Task { [state] in
+                if let pending = await state.cancelRequest(id: id, generation: generation) {
+                    pending.resume(throwing: CancellationError())
                 }
             }
         }

--- a/Tests/TachikomaMCPTests/MCPClientTests.swift
+++ b/Tests/TachikomaMCPTests/MCPClientTests.swift
@@ -54,6 +54,22 @@ struct MCPClientTests {
     }
 
     @Test
+    func `Protocol negotiation never retries cancellation`() async throws {
+        let transport = CancellationTransport()
+        let client = MCPClient(name: "cancelled", config: MCPServerConfig(command: "unused"))
+        let params = InitializeParams(
+            protocolVersion: "2025-03-26",
+            clientInfo: ClientInfo(name: "test", version: "1.0"),
+            capabilities: ClientCapabilities(),
+        )
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await client.initialize(using: transport, params: params)
+        }
+        #expect(transport.requestCount == 1)
+    }
+
+    @Test
     func `MCPError descriptions`() {
         #expect(MCPError.serverDisabled.errorDescription == "MCP server is disabled")
         #expect(MCPError.notConnected.errorDescription == "MCP client is not connected")
@@ -330,6 +346,34 @@ struct MCPClientTests {
         #expect(decoded.count == 42)
         #expect(decoded.active == true)
     }
+}
+
+private final class CancellationTransport: MCPTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _requestCount = 0
+
+    var requestCount: Int {
+        self.lock.withLock { self._requestCount }
+    }
+
+    func connect(config _: MCPServerConfig) async throws {}
+
+    func disconnect() async {}
+
+    func sendRequest<R: Decodable>(
+        method _: String,
+        params _: some Encodable,
+    ) async throws
+        -> R
+    {
+        self.lock.withLock { self._requestCount += 1 }
+        throw CancellationError()
+    }
+
+    func sendNotification(
+        method _: String,
+        params _: some Encodable,
+    ) async throws {}
 }
 
 // MARK: - Mock MCP Tool for Testing

--- a/Tests/TachikomaMCPTests/StdioTransportLifecycleTests.swift
+++ b/Tests/TachikomaMCPTests/StdioTransportLifecycleTests.swift
@@ -84,6 +84,56 @@ struct StdioTransportLifecycleTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
+    func `Caller cancellation removes pending request and keeps live child usable`() async throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tachikoma-stdio-cancel-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let transport = StdioTransport()
+        try await transport.connect(
+            config: MCPServerConfig(
+                command: "/bin/sh",
+                args: ["-c", Self.cancelledRequestServerScript],
+                env: ["REQUEST_MARKER": marker.path],
+                timeout: 5,
+                autoReconnect: false,
+            ),
+        )
+
+        let request = Task {
+            let response: FixtureResponse = try await transport.sendRequest(
+                method: "fixture/cancel",
+                params: EmptyParams(),
+            )
+            return response
+        }
+        for _ in 0..<100 where !FileManager.default.fileExists(atPath: marker.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(FileManager.default.fileExists(atPath: marker.path))
+        #expect(await transport.debugSnapshot.pendingRequestCount == 1)
+
+        let cancelledAt = ContinuousClock.now
+        request.cancel()
+        switch await request.result {
+        case .success:
+            Issue.record("Expected the pending request to be cancelled")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(cancelledAt.duration(to: .now) < .milliseconds(500))
+        #expect(await transport.debugSnapshot == .connectedIdle)
+
+        let response: FixtureResponse = try await transport.sendRequest(
+            method: "fixture/next",
+            params: EmptyParams(),
+        )
+        #expect(response.ok == true)
+        #expect(await transport.debugSnapshot == .connectedIdle)
+        await transport.disconnect()
+        #expect(await transport.debugSnapshot == .disconnected)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
     func `Client clears cached tools after child loss and reconnects with a new session`() async throws {
         let marker = FileManager.default.temporaryDirectory
             .appendingPathComponent("tachikoma-stdio-reconnect-\(UUID().uuidString)")
@@ -219,6 +269,22 @@ struct StdioTransportLifecycleTests {
           exit 0
           ;;
       esac
+    done
+    """#
+
+    private static let cancelledRequestServerScript = #"""
+    first_id=''
+    request_count=0
+    while IFS= read -r line; do
+      request_count=$((request_count + 1))
+      id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+      if [ "$request_count" -eq 1 ]; then
+        first_id=$id
+        printf 'received\n' > "$REQUEST_MARKER"
+        continue
+      fi
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"ok":false}}\n' "$first_id"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}\n' "$id"
     done
     """#
 }


### PR DESCRIPTION
## Summary

- make stdio MCP requests remove and resume their exact pending continuation when the caller cancels
- preserve cancellation through MCP initialization instead of retrying older protocol versions
- cover late responses, connection reuse, and exactly-once initialization attempts

This is the dependency fix needed for Peekaboo to enforce a real end-to-end browser-connect deadline without a cancelled MCP request lingering or falling back to another initialize attempt.

## Tests

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (920 tests)
- Autoreview clean on the rebased exact head

## Follow-up

SSE pending-request cancellation and HTTP cancellation error projection are related existing debt, but are deliberately excluded from this critical-path stdio change.
