### PR TITLE
feat(mcp): expose optional output schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ### Added
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
+- MCP tools can now advertise optional structured-result schemas while existing conformers remain source-compatible.
 
 ### Fixed
 - Cancelling a stdio MCP request now clears its continuation and timeout without closing the child, and cancelled initialization no longer retries legacy protocol variants.

--- a/Sources/TachikomaMCP/Protocol/MCPTool.swift
+++ b/Sources/TachikomaMCP/Protocol/MCPTool.swift
@@ -13,8 +13,17 @@ public protocol MCPTool: Sendable {
     /// JSON Schema defining the input parameters
     var inputSchema: Value { get }
 
+    /// Optional JSON Schema defining the structured tool result.
+    var outputSchema: Value? { get }
+
     /// Execute the tool with the given arguments
     func execute(arguments: ToolArguments) async throws -> ToolResponse
+}
+
+extension MCPTool {
+    public var outputSchema: Value? {
+        nil
+    }
 }
 
 /// Wrapper for tool arguments received from MCP

--- a/Tests/TachikomaMCPTests/MCPClientTests.swift
+++ b/Tests/TachikomaMCPTests/MCPClientTests.swift
@@ -406,6 +406,22 @@ private struct MockMCPTool: MCPTool {
 
 struct MockToolTests {
     @Test
+    func `MCP tool output schema defaults to nil and preserves existential overrides`() {
+        let defaultTool: any MCPTool = MockMCPTool()
+        let schema = Value.object([
+            "type": .string("object"),
+            "properties": .object([
+                "status": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("status")]),
+        ])
+        let typedTool: any MCPTool = OutputSchemaMCPTool(outputSchema: schema)
+
+        #expect(defaultTool.outputSchema == nil)
+        #expect(typedTool.outputSchema == schema)
+    }
+
+    @Test
     func `Mock tool execution with valid arguments`() async throws {
         let tool = MockMCPTool()
 
@@ -463,5 +479,16 @@ struct MockToolTests {
         } else {
             Issue.record("Expected object schema")
         }
+    }
+}
+
+private struct OutputSchemaMCPTool: MCPTool {
+    let outputSchema: Value?
+    let name = "output_schema"
+    let description = "Advertises a structured result"
+    let inputSchema = Value.object(["type": .string("object")])
+
+    func execute(arguments _: ToolArguments) async throws -> ToolResponse {
+        .text("ok")
     }
 }


### PR DESCRIPTION
## Summary

- add an optional `outputSchema` requirement to `MCPTool`
- keep existing conformers source-compatible through the default `nil` implementation
- prove existential dispatch preserves conformer overrides

This is the minimal upstream seam Peekaboo needs to advertise closed structured MCP result contracts. The pinned Swift MCP SDK already supports output schemas, so no dependency change is required.

## Tests

- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` — 921 tests passed
- SwiftFormat lint — clean
- SwiftLint — clean
- Autoreview P0–P2 — clean
