### PR TITLE
feat(mcp): preserve complete Agent tool schemas

### DIFF
--- a/Sources/Tachikoma/Core/BaseProviders.swift
+++ b/Sources/Tachikoma/Core/BaseProviders.swift
@@ -1071,22 +1071,11 @@ public final class AnthropicProvider: ModelProvider {
 
     private func convertToolToAnthropic(_ tool: AgentTool) throws -> AnthropicTool {
         let schema = try tool.parameters.jsonSchema(options: [.defaultStringArrayItems])
-        guard
-            let type = schema["type"] as? String,
-            let properties = schema["properties"] as? [String: Any],
-            let required = schema["required"] as? [String] else
-        {
-            throw TachikomaError.invalidInput("Failed to encode tool parameters for '\(tool.name)'")
-        }
 
-        return AnthropicTool(
+        return try AnthropicTool(
             name: tool.name,
             description: tool.description,
-            inputSchema: AnthropicInputSchema(
-                type: type,
-                properties: properties,
-                required: required,
-            ),
+            inputSchema: AnthropicInputSchema(schema),
         )
     }
 }

--- a/Sources/Tachikoma/Core/ToolTypes.swift
+++ b/Sources/Tachikoma/Core/ToolTypes.swift
@@ -558,21 +558,41 @@ public struct AgentToolParameters: Sendable, Codable {
     public let type: String
     public let properties: [String: AgentToolParameterProperty]
     public let required: [String]
+    /// The complete source JSON Schema when this tool was adapted from a dynamic provider.
+    ///
+    /// `properties` and `required` remain available for compatibility and local validation. Schema
+    /// serialization prefers this value so composition keywords and provider-specific constraints are
+    /// not lost while crossing the Agent abstraction.
+    public let sourceSchema: AnyAgentToolValue?
 
     public init(properties: [String: AgentToolParameterProperty] = [:], required: [String] = []) {
         self.type = "object"
         self.properties = properties
         self.required = required
+        self.sourceSchema = nil
+    }
+
+    public init(
+        properties: [String: AgentToolParameterProperty],
+        required: [String],
+        sourceSchema: AnyAgentToolValue,
+    ) {
+        self.type = "object"
+        self.properties = properties
+        self.required = required
+        self.sourceSchema = sourceSchema
     }
 
     init(
         type: String,
         properties: [String: AgentToolParameterProperty],
         required: [String],
+        sourceSchema: AnyAgentToolValue? = nil,
     ) {
         self.type = type
         self.properties = properties
         self.required = required
+        self.sourceSchema = sourceSchema
     }
 }
 
@@ -914,6 +934,7 @@ public struct DynamicSchema: Sendable, Codable {
     public let properties: [String: SchemaProperty]?
     public let required: [String]?
     public let items: SchemaItems?
+    public let sourceSchema: AnyAgentToolValue?
 
     public enum SchemaType: String, Sendable, Codable {
         case object
@@ -1080,6 +1101,21 @@ public struct DynamicSchema: Sendable, Codable {
         self.properties = properties
         self.required = required
         self.items = items
+        self.sourceSchema = nil
+    }
+
+    public init(
+        type: SchemaType,
+        properties: [String: SchemaProperty]?,
+        required: [String]?,
+        items: SchemaItems?,
+        sourceSchema: AnyAgentToolValue,
+    ) {
+        self.type = type
+        self.properties = properties
+        self.required = required
+        self.items = items
+        self.sourceSchema = sourceSchema
     }
 
     /// Convert to AgentToolParameters
@@ -1088,6 +1124,7 @@ public struct DynamicSchema: Sendable, Codable {
             type: self.type.rawValue,
             properties: Self.agentProperties(self.properties) ?? [:],
             required: self.required ?? [],
+            sourceSchema: self.sourceSchema,
         )
     }
 

--- a/Sources/Tachikoma/Providers/Anthropic/AnthropicTypes.swift
+++ b/Sources/Tachikoma/Providers/Anthropic/AnthropicTypes.swift
@@ -296,102 +296,18 @@ struct AnthropicTool: Codable {
 }
 
 struct AnthropicInputSchema: Codable {
-    let type: String
-    let properties: [String: Any]
-    let required: [String]
+    let value: AnyAgentToolValue
 
-    init(type: String, properties: [String: Any], required: [String]) {
-        self.type = type
-        self.properties = properties
-        self.required = required
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case type, properties, required
+    init(_ schema: [String: Any]) throws {
+        self.value = try AnyAgentToolValue.fromJSON(schema)
     }
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.type = try container.decode(String.self, forKey: .type)
-        self.required = try container.decode([String].self, forKey: .required)
-
-        if
-            let data = try? container.decode(Data.self, forKey: .properties),
-            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        {
-            self.properties = dict
-        } else {
-            self.properties = [:]
-        }
+        self.value = try AnyAgentToolValue(from: decoder)
     }
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.type, forKey: .type)
-        try container.encode(self.required, forKey: .required)
-
-        // Encode properties directly as JSON object, not as base64 data
-        var propertiesContainer = container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: .properties)
-        try self.encodeAnyDictionary(self.properties, to: &propertiesContainer)
-    }
-
-    private func encodeAnyDictionary(
-        _ dict: [String: Any],
-        to container: inout KeyedEncodingContainer<AnyCodingKey>,
-    ) throws {
-        for (key, value) in dict {
-            let codingKey = AnyCodingKey(stringValue: key)!
-
-            switch value {
-            case let stringValue as String:
-                try container.encode(stringValue, forKey: codingKey)
-            case let intValue as Int:
-                try container.encode(intValue, forKey: codingKey)
-            case let doubleValue as Double:
-                try container.encode(doubleValue, forKey: codingKey)
-            case let boolValue as Bool:
-                try container.encode(boolValue, forKey: codingKey)
-            case let arrayValue as [Any]:
-                // Encode arrays properly as actual arrays, not JSON strings
-                var arrayContainer = container.nestedUnkeyedContainer(forKey: codingKey)
-                for element in arrayValue {
-                    try self.encodeAnyElement(element, to: &arrayContainer)
-                }
-            case let dictValue as [String: Any]:
-                // Encode nested objects properly as nested containers
-                var nestedContainer = container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: codingKey)
-                try self.encodeAnyDictionary(dictValue, to: &nestedContainer)
-            default:
-                // Fallback: convert to string
-                try container.encode(String(describing: value), forKey: codingKey)
-            }
-        }
-    }
-
-    private func encodeAnyElement(_ value: Any, to container: inout UnkeyedEncodingContainer) throws {
-        switch value {
-        case let stringValue as String:
-            try container.encode(stringValue)
-        case let intValue as Int:
-            try container.encode(intValue)
-        case let doubleValue as Double:
-            try container.encode(doubleValue)
-        case let boolValue as Bool:
-            try container.encode(boolValue)
-        case let arrayValue as [Any]:
-            // Nested arrays
-            var nestedContainer = container.nestedUnkeyedContainer()
-            for element in arrayValue {
-                try self.encodeAnyElement(element, to: &nestedContainer)
-            }
-        case let dictValue as [String: Any]:
-            // Dictionary within array
-            var nestedContainer = container.nestedContainer(keyedBy: AnyCodingKey.self)
-            try self.encodeAnyDictionary(dictValue, to: &nestedContainer)
-        default:
-            // Fallback: convert to string
-            try container.encode(String(describing: value))
-        }
+        try self.value.encode(to: encoder)
     }
 }
 

--- a/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
+++ b/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
@@ -17,6 +17,38 @@ extension AgentToolParameters {
         guard self.type == "object" else {
             throw TachikomaError.invalidInput("Tool parameter schema root must be an object")
         }
+        if let sourceSchema {
+            guard var schema = try sourceSchema.toJSON() as? [String: Any] else {
+                throw TachikomaError.invalidInput("Source tool parameter schema root must be an object")
+            }
+            let permitsObject = switch schema["type"] {
+            case nil:
+                true
+            case let type as String:
+                type == "object"
+            case let types as [String]:
+                types.contains("object")
+            default:
+                false
+            }
+            guard permitsObject else {
+                throw TachikomaError.invalidInput("Source tool parameter schema root must be an object")
+            }
+            schema["type"] = "object"
+            let declaredNames = Self.declaredPropertyNames(in: schema)
+            let required = try Self.serializedRequired(
+                self.required,
+                declaredNames: declaredNames,
+                options: options,
+                path: "required",
+            )
+            if required.isEmpty, options.contains(.omitEmptyRequired) {
+                schema.removeValue(forKey: "required")
+            } else {
+                schema["required"] = required
+            }
+            return Self.applying(options, to: schema)
+        }
         var serializedProperties: [String: Any] = [:]
         for (name, property) in self.properties {
             serializedProperties[name] = try AgentToolSchemaNode(property).jsonSchema(
@@ -39,6 +71,106 @@ extension AgentToolParameters {
             schema["required"] = required
         }
         return schema
+    }
+
+    private static func applying(
+        _ options: AgentToolSchemaSerializationOptions,
+        to schema: [String: Any],
+        inheritedPropertyNames: Set<String> = [],
+    )
+        -> [String: Any]
+    {
+        var schema = schema
+        let visiblePropertyNames = inheritedPropertyNames.union(self.declaredPropertyNames(in: schema))
+        if
+            options.contains(.defaultStringArrayItems),
+            self.isArraySchema(schema),
+            schema["items"] == nil
+        {
+            schema["items"] = ["type": "string"]
+        }
+        if let required = schema["required"] as? [String] {
+            let normalized: [String] = if
+                options.contains(.filterUndeclaredRequired),
+                !visiblePropertyNames.isEmpty
+            {
+                required.filter(visiblePropertyNames.contains)
+            } else {
+                required
+            }
+            if normalized.isEmpty, options.contains(.omitEmptyRequired) {
+                schema.removeValue(forKey: "required")
+            } else {
+                schema["required"] = normalized
+            }
+        }
+
+        for key in ["properties", "patternProperties", "$defs", "definitions"] {
+            guard let children = schema[key] as? [String: Any] else { continue }
+            schema[key] = children.mapValues { value in
+                guard let child = value as? [String: Any] else { return value }
+                return self.applying(options, to: child)
+            }
+        }
+        if let children = schema["dependentSchemas"] as? [String: Any] {
+            schema["dependentSchemas"] = children.mapValues { value in
+                guard let child = value as? [String: Any] else { return value }
+                return self.applying(options, to: child, inheritedPropertyNames: visiblePropertyNames)
+            }
+        }
+        for key in [
+            "additionalProperties",
+            "unevaluatedProperties",
+            "propertyNames",
+            "items",
+            "unevaluatedItems",
+            "contains",
+        ] {
+            guard let child = schema[key] as? [String: Any] else { continue }
+            schema[key] = self.applying(options, to: child)
+        }
+        for key in ["not", "if", "then", "else"] {
+            guard let child = schema[key] as? [String: Any] else { continue }
+            schema[key] = self.applying(
+                options,
+                to: child,
+                inheritedPropertyNames: visiblePropertyNames,
+            )
+        }
+        for key in ["allOf", "anyOf", "oneOf"] {
+            guard let alternatives = schema[key] as? [Any] else { continue }
+            schema[key] = alternatives.map { value in
+                guard let child = value as? [String: Any] else { return value }
+                return self.applying(
+                    options,
+                    to: child,
+                    inheritedPropertyNames: visiblePropertyNames,
+                )
+            }
+        }
+        if let prefixItems = schema["prefixItems"] as? [Any] {
+            schema["prefixItems"] = prefixItems.map { value in
+                guard let child = value as? [String: Any] else { return value }
+                return self.applying(options, to: child)
+            }
+        }
+        return schema
+    }
+
+    private static func declaredPropertyNames(in schema: [String: Any]) -> Set<String> {
+        var names = Set((schema["properties"] as? [String: Any]).map { Array($0.keys) } ?? [])
+        for value in schema["allOf"] as? [Any] ?? [] {
+            guard let child = value as? [String: Any] else { continue }
+            names.formUnion(self.declaredPropertyNames(in: child))
+        }
+        return names
+    }
+
+    private static func isArraySchema(_ schema: [String: Any]) -> Bool {
+        if schema["type"] as? String == "array" {
+            return true
+        }
+        return (schema["type"] as? [String])?.contains("array") == true
     }
 
     private static func serializedRequired(

--- a/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
+++ b/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
@@ -9,6 +9,19 @@ struct AgentToolSchemaSerializationOptions: OptionSet, Sendable {
 }
 
 extension AgentToolParameters {
+    public init(sourceSchema: AnyAgentToolValue) {
+        let schema = sourceSchema.objectValue ?? [:]
+        let properties = schema["properties"]?.objectValue?.compactMap { key, value in
+            Self.property(from: value, name: key).map { (key, $0) }
+        }.reduce(into: [:]) { $0[$1.0] = $1.1 } ?? [:]
+        let required = schema["required"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        self.init(properties: properties, required: required, sourceSchema: sourceSchema)
+    }
+
+    public func schemaValue() throws -> AnyAgentToolValue {
+        try AnyAgentToolValue.fromJSON(self.jsonSchema())
+    }
+
     func jsonSchema(
         options: AgentToolSchemaSerializationOptions = [],
     ) throws
@@ -171,6 +184,50 @@ extension AgentToolParameters {
             return true
         }
         return (schema["type"] as? [String])?.contains("array") == true
+    }
+
+    private static func property(from value: AnyAgentToolValue, name: String) -> AgentToolParameterProperty? {
+        guard
+            let schema = value.objectValue,
+            let rawType = schema["type"]?.stringValue,
+            let type = AgentToolParameterProperty.ParameterType(rawValue: rawType) else { return nil }
+        return AgentToolParameterProperty(
+            name: name,
+            type: type,
+            description: schema["description"]?.stringValue ?? "",
+            enumValues: schema["enum"]?.arrayValue?.compactMap(\.stringValue),
+            items: schema["items"].flatMap(Self.items),
+            properties: schema["properties"]?.objectValue?.compactMap { key, value in
+                Self.property(from: value, name: key).map { (key, $0) }
+            }.reduce(into: [:]) { $0[$1.0] = $1.1 },
+            required: schema["required"]?.arrayValue?.compactMap(\.stringValue),
+            format: schema["format"]?.stringValue,
+            minimum: schema["minimum"]?.doubleValue,
+            maximum: schema["maximum"]?.doubleValue,
+            minLength: schema["minLength"]?.intValue,
+            maxLength: schema["maxLength"]?.intValue,
+        )
+    }
+
+    private static func items(from value: AnyAgentToolValue) -> AgentToolParameterItems? {
+        guard
+            let schema = value.objectValue,
+            let type = schema["type"]?.stringValue else { return nil }
+        return AgentToolParameterItems(
+            type: type,
+            description: schema["description"]?.stringValue,
+            enumValues: schema["enum"]?.arrayValue?.compactMap(\.stringValue),
+            items: schema["items"].flatMap(Self.items),
+            properties: schema["properties"]?.objectValue?.compactMap { key, value in
+                Self.property(from: value, name: key).map { (key, $0) }
+            }.reduce(into: [:]) { $0[$1.0] = $1.1 },
+            required: schema["required"]?.arrayValue?.compactMap(\.stringValue),
+            format: schema["format"]?.stringValue,
+            minimum: schema["minimum"]?.doubleValue,
+            maximum: schema["maximum"]?.doubleValue,
+            minLength: schema["minLength"]?.intValue,
+            maxLength: schema["maxLength"]?.intValue,
+        )
     }
 
     private static func serializedRequired(

--- a/Sources/TachikomaAudio/Realtime/RealtimeEvents.swift
+++ b/Sources/TachikomaAudio/Realtime/RealtimeEvents.swift
@@ -799,7 +799,8 @@ public struct RealtimeTool: Codable, Sendable {
         self.type = try container.decode(String.self, forKey: .type)
         self.name = try container.decode(String.self, forKey: .name)
         self.description = try container.decode(String.self, forKey: .description)
-        self.parameters = try container.decode(AgentToolParameters.self, forKey: .parameters)
+        let sourceSchema = try container.decode(AnyAgentToolValue.self, forKey: .parameters)
+        self.parameters = AgentToolParameters(sourceSchema: sourceSchema)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -807,6 +808,6 @@ public struct RealtimeTool: Codable, Sendable {
         try container.encode(self.type, forKey: .type)
         try container.encode(self.name, forKey: .name)
         try container.encode(self.description, forKey: .description)
-        try container.encode(self.parameters, forKey: .parameters)
+        try container.encode(self.parameters.schemaValue(), forKey: .parameters)
     }
 }

--- a/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolAdapter.swift
@@ -6,7 +6,7 @@ import Tachikoma
 public enum MCPToolAdapter {
     /// Convert an MCP Tool to Tachikoma's AgentTool
     public static func toAgentTool(from mcpTool: Tool, client: MCPClient) -> AgentTool {
-        let parameters = MCPToolSchemaBridge.dynamicSchema(from: mcpTool.inputSchema).toAgentToolParameters()
+        let parameters = MCPToolSchemaBridge.agentParameters(from: mcpTool.inputSchema)
 
         return AgentTool(
             name: mcpTool.name,

--- a/Sources/TachikomaMCP/Bridge/MCPToolSchemaBridge.swift
+++ b/Sources/TachikomaMCP/Bridge/MCPToolSchemaBridge.swift
@@ -1,9 +1,13 @@
 import MCP
 import Tachikoma
 
-enum MCPToolSchemaBridge {
+public enum MCPToolSchemaBridge {
+    public static func agentParameters(from value: Value?) -> AgentToolParameters {
+        self.dynamicSchema(from: value).toAgentToolParameters()
+    }
+
     static func dynamicSchema(from value: Value?) -> DynamicSchema {
-        guard case let .object(schema)? = value else {
+        guard let value, case let .object(schema) = value else {
             return DynamicSchema(type: .object, properties: [:])
         }
 
@@ -25,6 +29,8 @@ enum MCPToolSchemaBridge {
             type: type,
             properties: properties,
             required: Self.stringArray(schema["required"]),
+            items: nil,
+            sourceSchema: value.toAnyAgentToolValue(),
         )
     }
 

--- a/Tests/TachikomaMCPTests/MCPToolAdapterTests.swift
+++ b/Tests/TachikomaMCPTests/MCPToolAdapterTests.swift
@@ -9,11 +9,13 @@ struct MCPToolAdapterTests {
     func `Static and dynamic MCP tools share one schema conversion`() throws {
         let inputSchema = Value.object([
             "type": .string("object"),
+            "additionalProperties": .bool(false),
             "properties": .object([
                 "mode": .object([
                     "type": .string("string"),
                     "description": .string("Execution mode"),
                     "enum": .array([.string("safe"), .string("fast")]),
+                    "default": .string("safe"),
                 ]),
                 "tags": .object([
                     "type": .string("array"),
@@ -59,6 +61,14 @@ struct MCPToolAdapterTests {
                 .string("settings"),
                 .string("matrix"),
             ]),
+            "allOf": .array([
+                .object([
+                    "oneOf": .array([
+                        .object(["required": .array([.string("mode")])]),
+                        .object(["not": .object(["required": .array([.string("mode")])])]),
+                    ]),
+                ]),
+            ]),
         ])
         let mcpTool = MCP.Tool(name: "run", description: "Run work", inputSchema: inputSchema)
         let client = MCPClient(name: "test", config: MCPServerConfig(command: "unused"))
@@ -69,6 +79,14 @@ struct MCPToolAdapterTests {
 
         #expect(staticTool.parameters.required == ["mode", "tags", "settings", "matrix"])
         #expect(dynamicParameters.required == staticTool.parameters.required)
+        #expect(staticTool.parameters.sourceSchema == inputSchema.toAnyAgentToolValue())
+        #expect(dynamicParameters.sourceSchema == staticTool.parameters.sourceSchema)
+        let staticJSON = try toolParametersToJSON(staticTool.parameters)
+        let dynamicJSON = try toolParametersToJSON(dynamicParameters)
+        #expect(staticJSON["required"] as? [String] == ["mode", "tags", "settings", "matrix"])
+        #expect(dynamicJSON["required"] as? [String] == staticJSON["required"] as? [String])
+        #expect(staticJSON["additionalProperties"] as? Bool == false)
+        #expect((staticJSON["allOf"] as? [[String: Any]])?.count == 1)
         #expect(dynamicParameters.properties["mode"]?.type == staticTool.parameters.properties["mode"]?.type)
         #expect(dynamicParameters.properties["mode"]?.description == "Execution mode")
         #expect(dynamicParameters.properties["mode"]?.enumValues == ["safe", "fast"])

--- a/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
+++ b/Tests/TachikomaTests/Providers/ProviderEndToEndTests.swift
@@ -80,6 +80,62 @@ struct ProviderEndToEndTests {
         }
     }
 
+    @Test
+    func `Anthropic provider preserves complete source tool schemas`() async throws {
+        let task = AgentToolParameterProperty(name: "task", type: .string, description: "Task")
+        let sourceSchema = AnyAgentToolValue(object: [
+            "type": AnyAgentToolValue(string: "object"),
+            "additionalProperties": AnyAgentToolValue(bool: false),
+            "properties": AnyAgentToolValue(object: [
+                "task": AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "string"),
+                ]),
+            ]),
+            "required": AnyAgentToolValue(array: [AnyAgentToolValue(string: "task")]),
+            "allOf": AnyAgentToolValue(array: [
+                AnyAgentToolValue(object: [
+                    "not": AnyAgentToolValue(object: [
+                        "required": AnyAgentToolValue(array: [AnyAgentToolValue(string: "forbidden")]),
+                    ]),
+                ]),
+            ]),
+        ])
+        let tool = AgentTool(
+            name: "run",
+            description: "Run task",
+            parameters: AgentToolParameters(
+                properties: ["task": task],
+                required: ["task"],
+                sourceSchema: sourceSchema,
+            ),
+        ) { _ in
+            AnyAgentToolValue(string: "unused")
+        }
+        let request = ProviderRequest(
+            messages: [.user("Run it")],
+            tools: [tool],
+            settings: .init(maxTokens: 32),
+        )
+
+        try await NetworkMocking.withMockedNetwork { request in
+            let body = try #require(self.bodyData(from: request))
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let tools = try #require(json["tools"] as? [[String: Any]])
+            let schema = try #require(tools.first?["input_schema"] as? [String: Any])
+
+            #expect(schema["additionalProperties"] as? Bool == false)
+            #expect((schema["allOf"] as? [[String: Any]])?.count == 1)
+            #expect(schema["required"] as? [String] == ["task"])
+            return NetworkMocking.jsonResponse(for: request, data: Self.anthropicPayload(text: "Done"))
+        } operation: {
+            let config = Self.makeConfiguration { config in
+                config.setAPIKey("live-anthropic", for: .anthropic)
+            }
+            let provider = try AnthropicProvider(model: .sonnet46, configuration: config)
+            _ = try await provider.generateText(request: request)
+        }
+    }
+
     // MARK: - Google Gemini
 
     @Test

--- a/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
+++ b/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
@@ -1,8 +1,59 @@
 import Foundation
+import TachikomaAudio
 import Testing
 @testable import Tachikoma
 
 struct AgentToolSchemaSerializationTests {
+    @Test
+    func `Realtime tools encode preserved source schema without internal storage fields`() throws {
+        let sourceSchema = AnyAgentToolValue(object: [
+            "type": AnyAgentToolValue(string: "object"),
+            "properties": AnyAgentToolValue(object: [
+                "task": AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "string"),
+                    "description": AnyAgentToolValue(string: "Task"),
+                ]),
+                "choice": AnyAgentToolValue(object: [
+                    "oneOf": AnyAgentToolValue(array: [
+                        AnyAgentToolValue(object: ["type": AnyAgentToolValue(string: "string")]),
+                        AnyAgentToolValue(object: ["type": AnyAgentToolValue(string: "integer")]),
+                    ]),
+                ]),
+            ]),
+            "required": AnyAgentToolValue(array: [AnyAgentToolValue(string: "task")]),
+            "oneOf": AnyAgentToolValue(array: [
+                AnyAgentToolValue(object: [
+                    "required": AnyAgentToolValue(array: [AnyAgentToolValue(string: "task")]),
+                ]),
+            ]),
+        ])
+        let parameters = AgentToolParameters(
+            properties: [:],
+            required: ["task"],
+            sourceSchema: sourceSchema,
+        )
+        let tool = RealtimeTool(name: "run", description: "Run", parameters: parameters)
+        let encoded = try JSONEncoder().encode(tool)
+        let object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let schema = try #require(object["parameters"] as? [String: Any])
+
+        #expect(schema["type"] as? String == "object")
+        #expect((schema["oneOf"] as? [[String: Any]])?.count == 1)
+        #expect(schema["sourceSchema"] == nil)
+
+        let decoded = try JSONDecoder().decode(RealtimeTool.self, from: encoded)
+        #expect(decoded.parameters.required == ["task"])
+        #expect(decoded.parameters.properties["task"]?.type == .string)
+        #expect(decoded.parameters.properties["task"]?.description == "Task")
+        #expect(decoded.parameters.properties["choice"] == nil)
+        #expect(decoded.parameters.sourceSchema?.objectValue?["properties"]?.objectValue?["choice"] != nil)
+        let reencoded = try JSONEncoder().encode(decoded)
+        let reencodedObject = try #require(JSONSerialization.jsonObject(with: reencoded) as? [String: Any])
+        let reencodedSchema = try #require(reencodedObject["parameters"] as? [String: Any])
+        #expect((reencodedSchema["oneOf"] as? [[String: Any]])?.count == 1)
+        #expect(reencodedSchema["sourceSchema"] == nil)
+    }
+
     @Test
     func `Original public initializer function references remain source compatible`() {
         let propertyInitializer: (

--- a/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
+++ b/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
@@ -31,6 +31,55 @@ struct AgentToolSchemaSerializationTests {
 
     @Test
     func `Dynamic schema conversion and Codable preserve every supported field`() throws {
+        let sourceSchema = AnyAgentToolValue(object: [
+            "type": AnyAgentToolValue(string: "object"),
+            "properties": AnyAgentToolValue(object: [
+                "config": AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "object"),
+                    "properties": AnyAgentToolValue(object: [:]),
+                    "required": AnyAgentToolValue(array: []),
+                ]),
+                "settings": AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "object"),
+                ]),
+            ]),
+            "additionalProperties": AnyAgentToolValue(object: [
+                "type": AnyAgentToolValue(array: [
+                    AnyAgentToolValue(string: "array"),
+                    AnyAgentToolValue(string: "null"),
+                ]),
+            ]),
+            "allOf": AnyAgentToolValue(array: [
+                AnyAgentToolValue(object: [
+                    "properties": AnyAgentToolValue(object: [
+                        "a": AnyAgentToolValue(object: ["type": AnyAgentToolValue(string: "string")]),
+                    ]),
+                ]),
+                AnyAgentToolValue(object: [
+                    "properties": AnyAgentToolValue(object: [
+                        "b": AnyAgentToolValue(object: ["type": AnyAgentToolValue(string: "string")]),
+                    ]),
+                    "required": AnyAgentToolValue(array: [
+                        AnyAgentToolValue(string: "a"),
+                        AnyAgentToolValue(string: "b"),
+                    ]),
+                ]),
+            ]),
+            "oneOf": AnyAgentToolValue(array: [
+                AnyAgentToolValue(object: [
+                    "properties": AnyAgentToolValue(object: [
+                        "branchValue": AnyAgentToolValue(object: [
+                            "type": AnyAgentToolValue(string: "array"),
+                        ]),
+                    ]),
+                    "required": AnyAgentToolValue(array: [
+                        AnyAgentToolValue(string: "settings"),
+                        AnyAgentToolValue(string: "branchValue"),
+                    ]),
+                ]),
+                AnyAgentToolValue(bool: true),
+            ]),
+        ])
         let dynamic = DynamicSchema(
             type: .object,
             properties: [
@@ -82,6 +131,8 @@ struct AgentToolSchemaSerializationTests {
                 ),
             ],
             required: ["settings", "steps", "matrix"],
+            items: nil,
+            sourceSchema: sourceSchema,
         )
 
         let dynamicData = try JSONEncoder().encode(dynamic)
@@ -90,6 +141,8 @@ struct AgentToolSchemaSerializationTests {
         let parametersData = try JSONEncoder().encode(parameters)
         let decodedParameters = try JSONDecoder().decode(AgentToolParameters.self, from: parametersData)
 
+        #expect(decodedDynamic.sourceSchema == sourceSchema)
+        #expect(decodedParameters.sourceSchema == sourceSchema)
         #expect(decodedParameters.required == ["settings", "steps", "matrix"])
         let settings = try #require(decodedParameters.properties["settings"])
         #expect(settings.required == ["mode"])
@@ -111,7 +164,10 @@ struct AgentToolSchemaSerializationTests {
         #expect(matrixItems.items?.minimum == 0)
         #expect(matrixItems.items?.maximum == 9)
 
-        let schema = try toolParametersToJSON(decodedParameters)
+        let schema = try AgentToolParameters(
+            properties: decodedParameters.properties,
+            required: decodedParameters.required,
+        ).jsonSchema()
         let properties = try #require(schema["properties"] as? [String: Any])
         let encodedSettings = try #require(properties["settings"] as? [String: Any])
         #expect(encodedSettings["required"] as? [String] == ["mode"])
@@ -130,6 +186,36 @@ struct AgentToolSchemaSerializationTests {
         #expect(encodedCell["type"] as? String == "integer")
         #expect(encodedCell["minimum"] as? Double == 0)
         #expect(encodedCell["maximum"] as? Double == 9)
+
+        let preservedSource = try toolParametersToJSON(decodedParameters)
+        #expect(preservedSource["additionalProperties"] is [String: Any])
+        #expect((preservedSource["oneOf"] as? [Any])?.count == 2)
+
+        let providerCompatible = try decodedParameters.jsonSchema(options: [
+            .defaultStringArrayItems,
+            .omitEmptyRequired,
+        ])
+        let compatibleProperties = try #require(providerCompatible["properties"] as? [String: Any])
+        let compatibleConfig = try #require(compatibleProperties["config"] as? [String: Any])
+        #expect(compatibleConfig["required"] == nil)
+        let compatibleAdditional = try #require(providerCompatible["additionalProperties"] as? [String: Any])
+        #expect((compatibleAdditional["items"] as? [String: Any])?["type"] as? String == "string")
+        let compatibleOneOf = try #require(providerCompatible["oneOf"] as? [Any])
+        let compatibleBranch = try #require(compatibleOneOf.first as? [String: Any])
+        let compatibleBranchProperties = try #require(compatibleBranch["properties"] as? [String: Any])
+        let compatibleBranchValue = try #require(compatibleBranchProperties["branchValue"] as? [String: Any])
+        #expect((compatibleBranchValue["items"] as? [String: Any])?["type"] as? String == "string")
+        #expect(compatibleOneOf.last as? Bool == true)
+
+        let filtered = try decodedParameters.jsonSchema(options: [
+            .filterUndeclaredRequired,
+            .omitEmptyRequired,
+        ])
+        let filteredOneOf = try #require(filtered["oneOf"] as? [Any])
+        let filteredBranch = try #require(filteredOneOf.first as? [String: Any])
+        #expect(filteredBranch["required"] as? [String] == ["settings", "branchValue"])
+        let filteredAllOf = try #require(filtered["allOf"] as? [[String: Any]])
+        #expect(filteredAllOf.last?["required"] as? [String] == ["a", "b"])
     }
 
     @Test
@@ -217,6 +303,28 @@ struct AgentToolSchemaSerializationTests {
         #expect(throws: TachikomaError.self) {
             _ = try dynamicRoot.jsonSchema()
         }
+
+        let mismatchedSource = AgentToolParameters(
+            properties: [:],
+            required: [],
+            sourceSchema: AnyAgentToolValue(object: [
+                "type": AnyAgentToolValue(string: "array"),
+            ]),
+        )
+        #expect(throws: TachikomaError.self) {
+            _ = try mismatchedSource.jsonSchema()
+        }
+
+        let mismatchedUnionSource = AgentToolParameters(
+            properties: [:],
+            required: [],
+            sourceSchema: AnyAgentToolValue(object: [
+                "type": AnyAgentToolValue(array: [AnyAgentToolValue(string: "array")]),
+            ]),
+        )
+        #expect(throws: TachikomaError.self) {
+            _ = try mismatchedUnionSource.jsonSchema()
+        }
     }
 
     @Test
@@ -234,6 +342,27 @@ struct AgentToolSchemaSerializationTests {
 
         let googleSchema = try parameters.jsonSchema(options: [.filterUndeclaredRequired])
         #expect(googleSchema["required"] as? [String] == ["query"])
+
+        let composedSource = AnyAgentToolValue(object: [
+            "type": AnyAgentToolValue(string: "object"),
+            "properties": AnyAgentToolValue(object: [
+                "query": AnyAgentToolValue(object: ["type": AnyAgentToolValue(string: "string")]),
+            ]),
+            "allOf": AnyAgentToolValue(array: [
+                AnyAgentToolValue(object: [
+                    "properties": AnyAgentToolValue(object: [
+                        "limit": AnyAgentToolValue(object: ["type": AnyAgentToolValue(string: "integer")]),
+                    ]),
+                ]),
+            ]),
+        ])
+        let composed = AgentToolParameters(
+            properties: parameters.properties,
+            required: ["query", "limit"],
+            sourceSchema: composedSource,
+        )
+        let composedJSON = try composed.jsonSchema(options: [.filterUndeclaredRequired])
+        #expect(composedJSON["required"] as? [String] == ["query", "limit"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve the complete source JSON Schema when MCP tools are adapted to Agent tools, while retaining the existing typed projection for compatibility and local validation
- apply provider-specific required/array normalization recursively without erasing composition semantics
- keep Realtime tool parameters encoded as external JSON Schema and decode representable properties without leaking the internal source-schema storage field
- route static MCP tool adaptation through the same schema bridge used by dynamic discovery
- preserve the complete normalized schema at the Anthropic request boundary instead of rebuilding only type, properties, and required

## Compatibility

Existing public initializers remain source-compatible. Hand-authored Agent tools without a source schema retain their current serialization. Adapted MCP schemas keep their original composition, defaults, closed-object rules, and other constraints through provider serialization.

## Verification

- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict --quiet`
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --filter 'AgentToolSchemaSerializationTests|MCPToolAdapterTests'` (19 tests)
- focused mocked Anthropic request-body regression for root composition and closed-object constraints
- focused P0-P2 autoreview: clean after fixes
