### PR TITLE
chore(deps): refresh Swift transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 - Added first-class Claude Opus 5 support and moved generation-agnostic Claude aliases and defaults to the new flagship.
 - MCP tools can now advertise optional structured-result schemas while existing conformers remain source-compatible.
 
+### Changed
+- Refreshed Swift package pins to EventSource 1.5.1, ServiceLifecycle 2.12.0, and System 1.8.1.
+
 ### Fixed
 - Cancelling a stdio MCP request now clears its continuation and timeout without closing the child, and cancelled initialization no longer retries legacy protocol variants.
 - Stdio MCP child exit now atomically closes the connection, clears cached tools, fails pending requests without waiting for their timeout, rejects later sends, and preserves generation-safe reconnects.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "7264307bbf829a11be3e1d1cfe9453fc6953d2d8a41839c2fd2140c0a7b42d6d",
+  "originHash" : "da55688e0cbf94b42f5dab5f65040a686f7c70af3df4cf0eb00ad83b7a774f42",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "704705c5c51156ede21172a38654d522ce487074",
-        "version" : "1.8.0"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Refresh the SwiftPM lockfile to the latest compatible stable releases without changing the package's public API, direct dependency requirements, or supported Swift version:

- EventSource: 1.4.1 → 1.5.1.
- ServiceLifecycle: 2.11.0 → 2.12.0.
- System: 1.8.0 → 1.8.1.

The lockfile's origin hash now matches the unchanged package manifest. Add an Unreleased changelog entry for the refreshed pins.

All five direct Swift dependencies, the other eleven resolved packages, GitHub Actions references, and the pinned SwiftFormat version were checked against upstream stable tags and are already current. Held upgrades: none. Superseded Dependabot/Renovate PRs: none.

## Validation

Local validation used Apple Swift 6.3.3, SwiftFormat 0.62.1, and SwiftLint 0.65.1:

- `swift package update` completed; a subsequent `swift package resolve` left the lockfile byte-for-byte unchanged.
- Swift package metadata/dependency-graph checks passed, including Swift 6 language mode and no Commander dependency.
- `swiftformat --lint .`: 183 files, none requiring formatting.
- `swiftlint lint --config .swiftlint.yml --strict`: 183 files, zero violations.
- `swift build -c release --jobs 6`: passed without compiler warnings.
- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel --jobs 6`: 923 tests in 110 suites passed.
- All three release CLI binaries were smoke-tested without network calls: `tachikoma` usage, `ai-cli --help`, and `gpt5cli` missing-query usage with its expected exit code 1.
- `git diff --check`: passed.

The [baseline CI run](https://github.com/openclaw/Tachikoma/actions/runs/33101228381) was green. PR CI provides the existing Swift 6.2.1 macOS/Linux validation; credentialed Live Providers tests were not run.
