### PR TITLE
fix(schema): normalize legacy recursive containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Tachikoma project will be documented in this file.
 - The root package no longer declares unused Commander products for its hand-parsed CLIs, avoiding local/remote package-identity conflicts in consumers; hermetic macOS/Linux tests now block merges on failure, and live-provider CI uses its documented compile/runtime gates.
 - Concurrent stdio MCP requests now serialize complete JSON-line frames so payloads and delimiters cannot interleave across tool calls.
 - Tool schemas now preserve nested object fields, required arrays, enums, array items, and scalar constraints consistently across static/dynamic MCP discovery and every provider serializer, including LM Studio.
+- Provider schema normalization now reaches draft-07 tuple items, additional-item schemas, and schema-valued legacy dependencies.
 - MCP tool discovery now uses one schema conversion path so static and dynamic tools preserve matching descriptions, enums, array item types, and required fields.
 - Composite dynamic tool providers now recover unchanged bindings after transient discovery failures while keeping real ownership changes fail-closed.
 - Dynamic tool aggregation now binds execution to the provider that supplied each schema, invalidates stale plans, avoids repeated discovery on registry execution, and rejects duplicate names instead of dispatching nondeterministically.

--- a/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
+++ b/Sources/Tachikoma/Tools/AgentToolSchemaSerialization.swift
@@ -131,16 +131,30 @@ extension AgentToolParameters {
                 return self.applying(options, to: child, inheritedPropertyNames: visiblePropertyNames)
             }
         }
+        if let dependencies = schema["dependencies"] as? [String: Any] {
+            schema["dependencies"] = dependencies.mapValues { value in
+                guard let child = value as? [String: Any] else { return value }
+                return self.applying(options, to: child, inheritedPropertyNames: visiblePropertyNames)
+            }
+        }
         for key in [
             "additionalProperties",
             "unevaluatedProperties",
             "propertyNames",
-            "items",
+            "additionalItems",
             "unevaluatedItems",
             "contains",
         ] {
             guard let child = schema[key] as? [String: Any] else { continue }
             schema[key] = self.applying(options, to: child)
+        }
+        if let child = schema["items"] as? [String: Any] {
+            schema["items"] = self.applying(options, to: child)
+        } else if let tupleItems = schema["items"] as? [Any] {
+            schema["items"] = tupleItems.map { value in
+                guard let child = value as? [String: Any] else { return value }
+                return self.applying(options, to: child)
+            }
         }
         for key in ["not", "if", "then", "else"] {
             guard let child = schema[key] as? [String: Any] else { continue }

--- a/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
+++ b/Tests/TachikomaTests/Tools/AgentToolSchemaSerializationTests.swift
@@ -417,6 +417,108 @@ struct AgentToolSchemaSerializationTests {
     }
 
     @Test
+    func `Provider normalization reaches draft seven tuple and dependency schemas without mutating source`() throws {
+        func probeSchema(required: [String]) -> AnyAgentToolValue {
+            AnyAgentToolValue(object: [
+                "type": AnyAgentToolValue(string: "object"),
+                "properties": AnyAgentToolValue(object: [
+                    "values": AnyAgentToolValue(object: [
+                        "type": AnyAgentToolValue(string: "array"),
+                    ]),
+                    "empty": AnyAgentToolValue(object: [
+                        "type": AnyAgentToolValue(string: "object"),
+                        "properties": AnyAgentToolValue(object: [:]),
+                        "required": AnyAgentToolValue(array: []),
+                    ]),
+                ]),
+                "required": AnyAgentToolValue(array: required.map(AnyAgentToolValue.init(string:))),
+            ])
+        }
+
+        let tupleProbe = probeSchema(required: ["values", "missing"])
+        let additionalItemsProbe = probeSchema(required: ["values", "missing"])
+        let dependencyProbe = probeSchema(required: ["trigger", "values", "missing"])
+        let sourceSchema = AnyAgentToolValue(object: [
+            "type": AnyAgentToolValue(string: "object"),
+            "properties": AnyAgentToolValue(object: [
+                "tuple": AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "array"),
+                    "items": AnyAgentToolValue(array: [
+                        tupleProbe,
+                        AnyAgentToolValue(bool: true),
+                        AnyAgentToolValue(bool: false),
+                    ]),
+                    "additionalItems": additionalItemsProbe,
+                ]),
+                "legacy": AnyAgentToolValue(object: [
+                    "type": AnyAgentToolValue(string: "object"),
+                    "properties": AnyAgentToolValue(object: [
+                        "trigger": AnyAgentToolValue(object: [
+                            "type": AnyAgentToolValue(string: "string"),
+                        ]),
+                    ]),
+                    "dependencies": AnyAgentToolValue(object: [
+                        "trigger": dependencyProbe,
+                        "requiredDependency": AnyAgentToolValue(array: [
+                            AnyAgentToolValue(string: "companion"),
+                            AnyAgentToolValue(string: "backup"),
+                        ]),
+                        "allow": AnyAgentToolValue(bool: true),
+                        "deny": AnyAgentToolValue(bool: false),
+                    ]),
+                ]),
+            ]),
+            "required": AnyAgentToolValue(array: [
+                AnyAgentToolValue(string: "tuple"),
+                AnyAgentToolValue(string: "legacy"),
+            ]),
+        ])
+        let parameters = AgentToolParameters(sourceSchema: sourceSchema)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let sourceBeforeNormalization = try encoder.encode(#require(parameters.sourceSchema))
+
+        let normalized = try parameters.jsonSchema(options: [
+            .defaultStringArrayItems,
+            .omitEmptyRequired,
+            .filterUndeclaredRequired,
+        ])
+
+        func expectNormalizedProbe(_ schema: [String: Any], required: [String]) throws {
+            #expect(schema["required"] as? [String] == required)
+            let properties = try #require(schema["properties"] as? [String: Any])
+            let values = try #require(properties["values"] as? [String: Any])
+            #expect((values["items"] as? [String: Any])?["type"] as? String == "string")
+            let empty = try #require(properties["empty"] as? [String: Any])
+            #expect(empty["required"] == nil)
+        }
+
+        let properties = try #require(normalized["properties"] as? [String: Any])
+        let tuple = try #require(properties["tuple"] as? [String: Any])
+        let tupleItems = try #require(tuple["items"] as? [Any])
+        try expectNormalizedProbe(#require(tupleItems.first as? [String: Any]), required: ["values"])
+        #expect(tupleItems[1] as? Bool == true)
+        #expect(tupleItems[2] as? Bool == false)
+        try expectNormalizedProbe(
+            #require(tuple["additionalItems"] as? [String: Any]),
+            required: ["values"],
+        )
+
+        let legacy = try #require(properties["legacy"] as? [String: Any])
+        let dependencies = try #require(legacy["dependencies"] as? [String: Any])
+        try expectNormalizedProbe(
+            #require(dependencies["trigger"] as? [String: Any]),
+            required: ["trigger", "values"],
+        )
+        #expect(dependencies["requiredDependency"] as? [String] == ["companion", "backup"])
+        #expect(dependencies["allow"] as? Bool == true)
+        #expect(dependencies["deny"] as? Bool == false)
+
+        #expect(parameters.sourceSchema == sourceSchema)
+        #expect(try encoder.encode(#require(parameters.sourceSchema)) == sourceBeforeNormalization)
+    }
+
+    @Test
     func `Provider policies only adjust established required and array fallbacks`() throws {
         let parameters = AgentToolParameters(
             properties: [


### PR DESCRIPTION
## Summary

- recurse provider schema normalization through draft-07 tuple `items`
- normalize schema-valued `additionalItems` and legacy `dependencies`
- preserve dependency string arrays, boolean schemas, and the exact source schema

## Why

The typed schema model supports these recursive draft-07 containers, but provider compatibility transforms previously stopped at their boundary. Nested array fallbacks and required-field filtering could therefore be omitted from otherwise supported schemas.

## Tests

- `TACHIKOMA_TEST_MODE=mock TACHIKOMA_DISABLE_API_TESTS=true swift test --parallel` (859 core + 67 MCP tests)
- `swiftformat --lint .`
- `swiftlint lint --config .swiftlint.yml --strict`
- P0-P2 structured review: no findings
