### PR TITLE
test: make timeout and stream timing assertions causal

### DIFF
--- a/Tests/TachikomaTests/Audio/AudioTypesTests.swift
+++ b/Tests/TachikomaTests/Audio/AudioTypesTests.swift
@@ -340,14 +340,21 @@ struct AudioTypesTests {
 
         @Test
         func `AbortSignal timeout functionality`() async throws {
+            let clock = ContinuousClock()
+            let started = clock.now
             let signal = AbortSignal.timeout(0.1) // 100ms timeout
 
-            #expect(signal.cancelled == false)
+            // Observe cancellation itself; the timeout task may start after this test resumes.
+            let deadline = started.advanced(by: .seconds(1))
+            while !signal.cancelled, clock.now < deadline {
+                try await Task.sleep(for: .milliseconds(1))
+            }
 
-            // Wait a bit longer than the timeout
-            try await Task.sleep(nanoseconds: 200_000_000) // 200ms
-
-            #expect(signal.cancelled == true)
+            try #require(signal.cancelled, "Timeout task did not cancel the signal")
+            #expect(started.duration(to: clock.now) >= .milliseconds(100))
+            #expect(throws: TachikomaError.self) {
+                try signal.throwIfCancelled()
+            }
         }
 
         @Test(arguments: [0, -1, .infinity, .nan])

--- a/Tests/TachikomaTests/Core/StreamTransformTests.swift
+++ b/Tests/TachikomaTests/Core/StreamTransformTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Tachikoma
 
@@ -43,38 +44,73 @@ struct StreamTransformTests {
 
     @Test
     func `BufferTransform with time interval`() async throws {
+        var lastFlushStarted = Date()
         let transform = BufferTransform<Int>(bufferSize: 10, flushInterval: 0.1)
+        var pending: [Int] = []
 
-        // Add elements
-        #expect(try await transform.transform(1) == nil)
-        #expect(try await transform.transform(2) == nil)
+        for value in 1...2 {
+            let callStarted = Date()
+            pending.append(value)
+            if let batch = try await transform.transform(value) {
+                // A delayed call may flush, but never before the interval or with missing values.
+                #expect(Date().timeIntervalSince(lastFlushStarted) >= 0.1)
+                #expect(batch == pending)
+                pending = []
+                lastFlushStarted = callStarted
+            }
+        }
 
-        // Wait for interval
         try await Task.sleep(nanoseconds: 150_000_000) // 150ms
 
-        // Next element should trigger flush due to time
-        let batch = try await transform.transform(3)
-        #expect(batch?.count == 3)
-        #expect(batch?.contains(1) == true)
-        #expect(batch?.contains(2) == true)
-        #expect(batch?.contains(3) == true)
+        pending.append(3)
+        #expect(try await transform.transform(3) == pending)
+        #expect(await transform.flush() == nil)
     }
 
     @Test
     func `ThrottleTransform limits rate`() async throws {
         let transform = ThrottleTransform<String>(interval: 0.1)
+        var previousEmissionStarted: Date?
+        var emitted: [String] = []
+
+        for value in ["first", "second", "third"] {
+            let callStarted = Date()
+            if let output = try await transform.transform(value) {
+                if let previousEmissionStarted {
+                    // These bounds enclose the actual emission times, including actor scheduling.
+                    #expect(Date().timeIntervalSince(previousEmissionStarted) >= 0.1)
+                }
+                #expect(output == value)
+                previousEmissionStarted = callStarted
+                emitted.append(output)
+            }
+        }
+
+        #expect(emitted.first == "first")
+    }
+
+    @Test
+    func `ThrottleTransform suppresses until its window reopens`() async throws {
+        // A window that never reopens proves suppression without a scheduling deadline.
+        let transform = ThrottleTransform<String>(interval: .infinity)
 
         // First element passes through
         #expect(try await transform.transform("first") == "first")
 
-        // Immediate second element is throttled
+        // Later elements are throttled regardless of executor delays.
         #expect(try await transform.transform("second") == nil)
+        #expect(try await transform.transform("third") == nil)
+    }
 
-        // Wait for interval
+    @Test
+    func `ThrottleTransform reopens after its interval`() async throws {
+        let transform = ThrottleTransform<String>(interval: 0.1)
+        #expect(try await transform.transform("first") == "first")
+
+        // Start waiting after the first emission, so the next call cannot be too early.
         try await Task.sleep(nanoseconds: 150_000_000) // 150ms
 
-        // Now element should pass through
-        #expect(try await transform.transform("third") == "third")
+        #expect(try await transform.transform("second") == "second")
     }
 
     @Test
@@ -193,37 +229,37 @@ struct StreamTransformTests {
         #expect(batches[2] == [7]) // Remaining element
     }
 
-    @Test
-    func `Stream throttle extension works`() async throws {
+    @Test(arguments: [0.0, Double.infinity])
+    func `Stream throttle extension works`(interval: Double) async throws {
         let stream = AsyncThrowingStream<Int, Error> { continuation in
-            let producer = Task {
-                do {
-                    for i in 1...5 {
-                        continuation.yield(i)
-                        try await Task.sleep(nanoseconds: 10_000_000) // 10ms
-                    }
-                    continuation.finish()
-                } catch is CancellationError {
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
+            for i in 1...5 {
+                continuation.yield(i)
             }
-            continuation.onTermination = { _ in
-                producer.cancel()
-            }
+            continuation.finish()
         }
 
-        let throttled = stream.throttle(interval: 0.03) // 30ms
+        let throttled = stream.throttle(interval: interval)
 
         var results: [Int] = []
         for try await value in throttled {
             results.append(value)
         }
 
-        // Should get fewer elements due to throttling
-        #expect(results.count < 5)
-        #expect(results.contains(1)) // First element always passes
+        // Exact outputs for both boundaries, independent of producer/consumer scheduling.
+        #expect(results == (interval == 0 ? [1, 2, 3, 4, 5] : [1]))
+    }
+
+    @Test
+    func `Stream throttle reopens after its interval`() async throws {
+        let source = ThrottleIntervalSource()
+        let stream = AsyncThrowingStream<Int, any Error> { try await source.next() }
+        var results: [Int] = []
+
+        for try await value in stream.throttle(interval: 0.03) {
+            results.append(value)
+        }
+
+        #expect(results == [1, 2, 3, 4, 5])
     }
 
     @Test
@@ -352,5 +388,19 @@ struct StreamTransformTests {
             "Number: 64", // 8^2
             "Number: 100", // 10^2
         ])
+    }
+}
+
+private actor ThrottleIntervalSource {
+    private var value = 0
+
+    func next() async throws -> Int? {
+        guard self.value < 5 else { return nil }
+        if self.value > 0 {
+            // Unfolding is pulled again only after the previous transform has completed.
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        self.value += 1
+        return self.value
     }
 }


### PR DESCRIPTION
## Summary

Repair scheduler-dependent timing assertions exposed by Peekaboo's complete dependency validation. The cancellation test previously assumed a separately scheduled timeout task would finish within the test's independent sleep; the stream test assumed producer pacing also bounded consumer scheduling. Neither establishes that ordering.

The timeout remains 100 ms. Its test observes actual cancellation with a one-second diagnostic watchdog and checks the elapsed lower bound and cancellation error. Throttle coverage combines exact zero/infinite-window outputs with finite 30/100 ms rate and recovery contracts. The adjacent buffer test checks exact pending batches and legal flush timing even when actor calls are delayed. No production source, interval, clock API, dependency, or default capability changes.

This branch starts from the exact existing Peekaboo dependency pin, `a0f51a675cba6f29862a7a98d6a6ef29b31acf1d`. The durable `maintenance/peekaboo-4.3-timing` ref retains test-only commit `9c153e12de61a8659e85b40f93e91ddce969c652`, whose production `Sources` tree is identical to that pin. Peekaboo can consume only this repair without importing subsequent schema/dependency changes. The eventual upstream merge/rebase commit is distinct from that maintenance revision.

## Executed validation

[Hosted CI](https://github.com/openclaw/Tachikoma/actions/runs/33254687083) passed all four jobs on the PR merge tree combining this head with base `1e29c34db7d5c150225adbb210185d2797a5b17e`:

- macOS: 929 tests in 110 suites passed.
- Linux: 796 tests in 103 suites passed. Existing URLProtocol platform exclusions and Grok debug opt-out remain unchanged; this is not live provider proof.
- Release product builds, locked-dependency checks, and package contracts passed.
- Strict SwiftLint found zero violations in 184 files; SwiftFormat required no changes.

The exact maintenance revision separately compiles all package/test targets with Xcode 27, with no compiler warning headers and an unchanged dependency lockfile. This was compile-only, not local native test execution.

An audited standalone Swift Testing leaf replays the changed test bodies against exact pure owner source slices. All 13 leaf tests passed in 30 ordinary runs, 10 delayed timeout/consumer runs, and 5 delayed-actor runs. Those perturbations reproduced the original failures before the repair. Ten deliberately broken source-copy variants fail the intended assertions, including missing/immediate cancellation, bypassed finite throttling, wrong interval, missing recovery, and premature/disabled timed buffer flushing. The leaf retains the same 16 migration diagnostics as its baseline; it is not the full-package build result.

Isolated Codex review found no actionable P0 findings. [CodeQL Actions and Swift analysis](https://github.com/openclaw/Tachikoma/actions/runs/33254686288) passed, including Swift autobuild; the separate [security check](https://github.com/openclaw/Tachikoma/runs/99106289773) reports no new alerts in changed code. Peekaboo's unfiltered dependency lane must subsequently exercise the exact retained maintenance revision; upstream merge-tree tests do not substitute for that proof.

No full native suite discovery, provider/audio/device operations, or credential access was performed on the personal host. This is test-only work, not a Tachikoma version release.
