### PR TITLE
fix(config): preserve automatic file decoding without deprecated APIs

### DIFF
--- a/Sources/Tachikoma/Auth/AuthManager.swift
+++ b/Sources/Tachikoma/Auth/AuthManager.swift
@@ -216,7 +216,13 @@ public struct TKCredentialStore {
         let credentialsPath = self.credentialsPath
         guard FileManager.default.fileExists(atPath: credentialsPath) else { return [:] }
         do {
-            let content = try String(contentsOfFile: credentialsPath)
+            #if canImport(Darwin)
+            // Preserve the legacy reader's malformed UTF-16 handling and read errors.
+            let content = try NSString(contentsOfFile: credentialsPath, usedEncoding: nil) as String
+            #else
+            var encoding = String.Encoding.utf8
+            let content = try String(contentsOfFile: credentialsPath, usedEncoding: &encoding)
+            #endif
             var result: [String: String] = [:]
             for line in content.components(separatedBy: .newlines) {
                 let trimmed = line.trimmingCharacters(in: .whitespaces)

--- a/Sources/Tachikoma/Core/CustomProviders.swift
+++ b/Sources/Tachikoma/Core/CustomProviders.swift
@@ -161,7 +161,13 @@ public final class CustomProviderRegistry: @unchecked Sendable {
         let path = self.profileConfigPath()
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         do {
-            let raw = try String(contentsOfFile: path)
+            #if canImport(Darwin)
+            // Preserve the legacy reader's malformed UTF-16 handling and read errors.
+            let raw = try NSString(contentsOfFile: path, usedEncoding: nil) as String
+            #else
+            var encoding = String.Encoding.utf8
+            let raw = try String(contentsOfFile: path, usedEncoding: &encoding)
+            #endif
             let cleaned = self.stripJSONComments(from: raw)
             let expanded = self.expandEnvironmentVariables(in: cleaned)
             if let data = expanded.data(using: .utf8) {

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -511,7 +511,13 @@ public final class TachikomaMCPClientManager {
         let path = self.profileConfigPath()
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         do {
-            let raw = try String(contentsOfFile: path)
+            #if canImport(Darwin)
+            // Preserve the legacy reader's malformed UTF-16 handling and read errors.
+            let raw = try NSString(contentsOfFile: path, usedEncoding: nil) as String
+            #else
+            var encoding = String.Encoding.utf8
+            let raw = try String(contentsOfFile: path, usedEncoding: &encoding)
+            #endif
             let cleaned = Self.stripJSONComments(from: raw)
             let expanded = Self.expandEnvironmentVariables(in: cleaned)
             if let data = expanded.data(using: .utf8) {

--- a/Tests/TachikomaMCPTests/ProfileFileDecodingTests.swift
+++ b/Tests/TachikomaMCPTests/ProfileFileDecodingTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Tachikoma
+import TachikomaMCP
+import XCTest
+
+/// SwiftPM runs XCTest separately from Swift Testing, isolating the shared profile
+/// path from the core test target's environment-mutating suites.
+@MainActor
+final class ProfileFileDecodingTests: XCTestCase {
+    func testProfileReadersDetectEncoding() async throws {
+        let encodings: [(String.Encoding, [UInt8])] = [
+            (.utf8, []),
+            (.utf8, [0xEF, 0xBB, 0xBF]),
+            (.utf16LittleEndian, [0xFF, 0xFE]),
+            (.utf16BigEndian, [0xFE, 0xFF]),
+        ]
+        for (encoding, bom) in encodings {
+            try await self.withProfile { profile in
+                let value = "café-東京-🦞"
+                let credentials = """
+                TOKEN=first
+                  # ignored comment
+                malformed line
+                EMPTY=
+                TOKEN=\(value)
+                WITH_EQUALS=a=b==
+                """
+                try self.write(credentials, encoding: encoding, bom: bom, to: profile, name: "credentials")
+                try self.write(
+                    self.config(value: value),
+                    encoding: encoding,
+                    bom: bom,
+                    to: profile,
+                    name: "config.json",
+                )
+
+                XCTAssertEqual(TKCredentialStore().load(), ["TOKEN": value, "WITH_EQUALS": "a=b=="])
+                CustomProviderRegistry.shared.loadFromProfile()
+                let provider = try XCTUnwrap(CustomProviderRegistry.shared.get("fixture"))
+                XCTAssertEqual(provider.kind, .anthropic)
+                XCTAssertEqual(provider.baseURL, "https://example.invalid/v1")
+                XCTAssertEqual(provider.apiKey, value)
+                XCTAssertEqual(provider.headers["X-Fixture"], "literal // and /* comments */")
+                XCTAssertEqual(provider.models["alias"], value)
+
+                let manager = self.managerWithDefaults()
+                await manager.initializeFromProfile(connect: false)
+                XCTAssertEqual(manager.listServerNames(), ["fixture"])
+                let server = try XCTUnwrap(manager.getServerConfig(name: "fixture"))
+                XCTAssertEqual(server.command, "never-executed")
+                XCTAssertEqual(server.args, [value])
+                XCTAssertEqual(server.description, value)
+                XCTAssertEqual(server.timeout, 12)
+            }
+        }
+    }
+
+    func testProfileReadFailuresPreserveOwnerFallbacks() async throws {
+        let failures: [(String, Data?)] = [
+            ("missing", nil),
+            ("directory", nil),
+            ("invalid UTF-8", Data([0xC3, 0x28])),
+            ("odd UTF-16", Data([0xFF, 0xFE, 0x61])),
+            ("invalid contents", Data("not a credential or JSON".utf8)),
+            ("empty", Data()),
+        ]
+        for (name, bytes) in failures {
+            try await self.withProfile { profile in
+                try self.write(
+                    self.config(value: "retained"),
+                    encoding: .utf8,
+                    bom: [],
+                    to: profile,
+                    name: "config.json",
+                )
+                CustomProviderRegistry.shared.loadFromProfile()
+                XCTAssertEqual(CustomProviderRegistry.shared.get("fixture")?.apiKey, "retained")
+
+                for filename in ["credentials", "config.json"] {
+                    let url = profile.appendingPathComponent(filename)
+                    if FileManager.default.fileExists(atPath: url.path) {
+                        try FileManager.default.removeItem(at: url)
+                    }
+                    if name == "directory" {
+                        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+                    } else if let bytes {
+                        try bytes.write(to: url)
+                    }
+                }
+
+                XCTAssertEqual(TKCredentialStore().load(), [:], name)
+                CustomProviderRegistry.shared.loadFromProfile()
+                XCTAssertEqual(CustomProviderRegistry.shared.get("fixture")?.apiKey, "retained", name)
+                let manager = self.managerWithDefaults()
+                await manager.initializeFromProfile(connect: false)
+                XCTAssertEqual(manager.listServerNames(), ["disabled", "fixture"], name)
+                XCTAssertEqual(manager.getServerConfig(name: "fixture")?.description, "default", name)
+            }
+        }
+    }
+
+    func testUnpairedUTF16PreservesPlatformBehavior() async throws {
+        try await self.withProfile { profile in
+            // An unpaired surrogate is accepted by Apple's legacy NSString reader,
+            // but rejected by swift-foundation's String reader on Linux.
+            for (filename, text) in [
+                ("credentials", "TOKEN=\u{FFFD}"),
+                ("config.json", self.config(value: "\u{FFFD}")),
+            ] {
+                let bytes = text.utf16.flatMap { codeUnit -> [UInt8] in
+                    let unit: UInt16 = codeUnit == 0xFFFD ? 0xD800 : codeUnit
+                    return [UInt8(truncatingIfNeeded: unit), UInt8(truncatingIfNeeded: unit >> 8)]
+                }
+                try (Data([0xFF, 0xFE]) + Data(bytes)).write(to: profile.appendingPathComponent(filename))
+            }
+
+            CustomProviderRegistry.shared.loadFromProfile()
+            let manager = self.managerWithDefaults()
+            await manager.initializeFromProfile(connect: false)
+            #if canImport(Darwin)
+            XCTAssertEqual(TKCredentialStore().load(), ["TOKEN": "\u{FFFD}"])
+            XCTAssertEqual(CustomProviderRegistry.shared.get("fixture")?.apiKey, "\u{FFFD}")
+            XCTAssertEqual(manager.getServerConfig(name: "fixture")?.description, "\u{FFFD}")
+            #else
+            XCTAssertEqual(TKCredentialStore().load(), [:])
+            XCTAssertTrue(CustomProviderRegistry.shared.list().isEmpty)
+            XCTAssertEqual(manager.getServerConfig(name: "fixture")?.description, "default")
+            #endif
+        }
+    }
+
+    private func withProfile(_ body: (URL) async throws -> Void) async throws {
+        let profile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tachikoma-file-decoding-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
+        let originalProfile = TachikomaConfiguration.profileDirectoryName
+        TachikomaConfiguration.profileDirectoryName = profile.path
+        defer {
+            // Reset the registry using only this fixture, never the restored profile.
+            let configURL = profile.appendingPathComponent("config.json")
+            try? FileManager.default.removeItem(at: configURL)
+            try? Data(#"{"customProviders":{}}"#.utf8).write(to: configURL)
+            CustomProviderRegistry.shared.loadFromProfile()
+            TachikomaConfiguration.profileDirectoryName = originalProfile
+            try? FileManager.default.removeItem(at: profile)
+        }
+        try await body(profile)
+    }
+
+    private func write(
+        _ text: String,
+        encoding: String.Encoding,
+        bom: [UInt8],
+        to profile: URL,
+        name: String,
+    ) throws {
+        let data = try XCTUnwrap(text.data(using: encoding))
+        try (Data(bom) + data).write(to: profile.appendingPathComponent(name))
+    }
+
+    private func managerWithDefaults() -> TachikomaMCPClientManager {
+        let manager = TachikomaMCPClientManager()
+        manager.registerDefaultServers([
+            "fixture": MCPServerConfig(command: "never-executed", timeout: 12, description: "default"),
+            "disabled": MCPServerConfig(command: "never-executed"),
+        ])
+        return manager
+    }
+
+    private func config(value: String) -> String {
+        """
+        {
+          // A shared JSONC profile exercises both configuration readers.
+          "customProviders": {
+            "fixture": {
+              "type": "anthropic",
+              "options": {
+                "baseURL": "https://example.invalid/v1",
+                "apiKey": "\(value)",
+                "headers": { "X-Fixture": "literal // and /* comments */" }
+              },
+              "models": { "alias": { "name": "\(value)" } }
+            }
+          },
+          /* File overrides retain missing fields from the host defaults. */
+          "mcpClients": {
+            "fixture": { "args": ["\(value)"], "description": "\(value)", "timeout": 0 },
+            "disabled": { "enabled": false }
+          }
+        }
+        """
+    }
+}


### PR DESCRIPTION
## Summary

Replace three deprecated automatic file-reading calls in the credential store, custom-provider configuration, and MCP profile loader without changing their decoding or error behavior. This is a narrow prerequisite for warning-free macOS 15-target compilation; it does not change provider schemas, dependencies, lockfiles, versions, or public APIs.

Using UTF-8 explicitly would reject existing UTF-16 profiles. A uniform switch to Swift’s `usedEncoding` overload also changes malformed UTF-16 acceptance and read-error codes on Darwin. The replacement therefore retains the existing NSString behavior on Apple platforms and the existing Swift Foundation path elsewhere.

One shared profile fixture covers all three real loading boundaries: UTF-8/non-ASCII, BOM detection, both UTF-16 byte orders, malformed and missing inputs, parser behavior, retained defaults, and platform-specific unpaired-surrogate behavior. It uses temporary profiles, does not initialize an authentication singleton, and disables MCP connection attempts.

## Verification

All hosted results below target `b80bbe86ee92ff324e7182dca68018565bc8754b`.

- [macOS and Linux CI](https://github.com/openclaw/Tachikoma/actions/runs/33287627400): passed. The macOS parallel runner executed all three named `ProfileFileDecodingTests` cases and the job succeeded; Linux explicitly reports all three passed with zero failures. Swift Testing also completed with 929 tests on macOS and 796 on Linux.
- [CodeQL workflow](https://github.com/openclaw/Tachikoma/actions/runs/33287626665) and the [separate security check](https://github.com/openclaw/Tachikoma/runs/99193542045): passed.
- Xcode 27 compile-only check of `TachikomaMCPTests`, explicitly targeting Intel/macOS 15: passed, with the three source deprecations eliminated.
- Full repository SwiftFormat, strict SwiftLint, and whitespace checks: passed.
- Pure Foundation old/new compatibility control: passed; the UTF-8-only negative control failed the intended cases. This leaf control is separate from the hosted owner-test proof.

The implementation and new tests received scoped P0 code review with no blocking findings. No live-provider proof or release publication is claimed.
