### PR TITLE
chore(deps): refresh Swift packages and CI patch tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Select Xcode 26.1
+      - name: Select Xcode 26.3
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: '26.3'
 
-      - name: Install Swift 6.2.1
+      - name: Install Swift 6.2.4
         if: runner.os == 'Linux'
         uses: SwiftyLab/setup-swift@v1
         with:
-          swift-version: '6.2.1'
+          swift-version: '6.2.4'
 
       - name: Cache Swift Package Manager
         uses: actions/cache@v6
@@ -83,10 +83,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Select Xcode 26.1
+      - name: Select Xcode 26.3
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: '26.3'
 
       - name: Validate package metadata and dependency graph
         run: |
@@ -103,7 +103,7 @@ jobs:
     name: Swift style
     runs-on: macos-15
     env:
-      SWIFTFORMAT_VERSION: 0.62.1
+      SWIFTFORMAT_VERSION: 0.63.0
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/live-providers.yml
+++ b/.github/workflows/live-providers.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
-      - name: Select Xcode 26.1
+      - name: Select Xcode 26.3
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: '26.3'
 
       - name: Require at least one live credential
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [0.4.1] - Unreleased
 
+### Changed
+- Updated Swift Crypto to 4.5.2, ASN.1 to 1.7.2, and NIO to 2.102.0; refreshed CI to Swift 6.2.4 and SwiftFormat 0.63.0 while retaining Swift 6.2 support.
+
 ## [0.4.0] - 2026-08-31
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
         .package(url: "https://github.com/apple/swift-configuration", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.2"),
     ],
     targets: [
         // Core Tachikoma module (no MCP dependencies)

--- a/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
+++ b/Sources/Tachikoma/Core/AnthropicMessageConversion.swift
@@ -66,9 +66,9 @@ enum AnthropicMessageConversion {
                 let content = message.content.compactMap { contentPart -> AnthropicContent? in
                     switch contentPart {
                     case let .text(text):
-                        return .text(AnthropicContent.TextContent(type: "text", text: text))
+                        .text(AnthropicContent.TextContent(type: "text", text: text))
                     case let .image(imageContent):
-                        return .image(AnthropicContent.ImageContent(
+                        .image(AnthropicContent.ImageContent(
                             type: "image",
                             source: AnthropicContent.ImageSource(
                                 type: "base64",
@@ -77,7 +77,7 @@ enum AnthropicMessageConversion {
                             ),
                         ))
                     case .reasoning, .toolCall, .toolResult:
-                        return nil // Skip tool calls and results in user messages
+                        nil // Skip tool calls and results in user messages
                     }
                 }
                 anthropicMessages.append(AnthropicMessage(role: "user", content: content))

--- a/Sources/TachikomaAudio/Realtime/Tools/AgentToolWrapper.swift
+++ b/Sources/TachikomaAudio/Realtime/Tools/AgentToolWrapper.swift
@@ -38,11 +38,11 @@ public struct AgentToolWrapper: RealtimeExecutableTool {
                 // Convert array elements
                 let converted = arr.compactMap { element -> AnyAgentToolValue? in
                     switch element {
-                    case let .string(s): return AnyAgentToolValue(string: s)
-                    case let .number(n): return AnyAgentToolValue(double: n)
-                    case let .integer(i): return AnyAgentToolValue(int: i)
-                    case let .boolean(b): return AnyAgentToolValue(bool: b)
-                    default: return nil
+                    case let .string(s): AnyAgentToolValue(string: s)
+                    case let .number(n): AnyAgentToolValue(double: n)
+                    case let .integer(i): AnyAgentToolValue(int: i)
+                    case let .boolean(b): AnyAgentToolValue(bool: b)
+                    default: nil
                     }
                 }
                 convertedArgs[key] = AnyAgentToolValue(array: converted)

--- a/Sources/TachikomaAudio/Realtime/UI/RealtimeConversationView.swift
+++ b/Sources/TachikomaAudio/Realtime/UI/RealtimeConversationView.swift
@@ -324,15 +324,15 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.inline)
             #endif
-                .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Done") {
-                            self.dismiss()
-                        }
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        self.dismiss()
                     }
                 }
+            }
         }
     }
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,8 @@
 
 This repo is a SwiftPM package (Swift 6.x).
 
+The supported source minimum is Swift 6.2. CI uses the Swift 6.2.4 patch toolchain (Xcode 26.3 on macOS) and SwiftFormat 0.63.0.
+
 ## Dev setup
 
 ```bash


### PR DESCRIPTION
Refresh the Swift dependency pins and CI tools while preserving the Swift 6.2 source minimum and all supported Apple deployment targets.

Crypto moves to 4.5.2, ASN.1 to 1.7.2, and NIO to 2.102.0. These upstream releases retain Swift 6.1 compatibility. The Crypto requirement is updated alongside the lockfile; the other direct dependencies and current Actions versions need no change.

Both CI workflows now use Xcode 26.3, with Swift 6.2.4 on Linux. SwiftFormat moves to 0.63.0; its required source changes only remove redundant returns and adjust conditional-chain indentation. The contribution guide and Unreleased changelog record the updates.

Validation:

- SwiftFormat 0.63.0 and strict SwiftLint 0.65.1: pass.
- Release build with two jobs: pass.
- Full hermetic suite with two test workers: 933 tests pass (866 core, 67 MCP).
- Built release CLI: generation and NDJSON streaming over a real localhost HTTP connection pass; config init emits guidance without writing files.
- Repeated SwiftPM resolution preserves the lockfile; package metadata/dependency contract and actionlint pass.

Local build and tests used Apple Swift 6.4; PR CI verifies the supported Swift 6.2.4 line on macOS and Linux.
