### PR TITLE
fix: reject invalid timeouts before UInt64 conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [0.4.1] - Unreleased
 
+### Fixed
+- Generation and MCP health checks now reject negative, non-finite, and overflowing timeouts before starting work instead of crashing; zero retains its immediate-deadline behavior. Thanks @SebTardif (#84).
+
 ### Changed
 - Updated Swift Crypto to 4.5.2, ASN.1 to 1.7.2, and NIO to 2.102.0; refreshed CI to Swift 6.2.4 and SwiftFormat 0.63.0 while retaining Swift 6.2 support.
 

--- a/Sources/Tachikoma/Core/AsyncErgonomics.swift
+++ b/Sources/Tachikoma/Core/AsyncErgonomics.swift
@@ -61,9 +61,9 @@ public struct CancellableTask<Success: Sendable> {
 
 // MARK: - Timeout Functions
 
-// UInt64(timeout * 1e9) traps on non-finite, non-positive, and overflow values.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 enum TimeoutNanoseconds {
+    // UInt64(timeout * 1e9) traps on non-finite, non-positive, and overflow values.
     static let maximumSeconds = Double(UInt64.max / 1_000_000_000)
 
     static func fromSeconds(_ timeout: TimeInterval) throws -> UInt64 {

--- a/Sources/Tachikoma/Core/AsyncErgonomics.swift
+++ b/Sources/Tachikoma/Core/AsyncErgonomics.swift
@@ -61,6 +61,19 @@ public struct CancellableTask<Success: Sendable> {
 
 // MARK: - Timeout Functions
 
+// UInt64(timeout * 1e9) traps on non-finite, non-positive, and overflow values.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+enum TimeoutNanoseconds {
+    static let maximumSeconds = Double(UInt64.max / 1_000_000_000)
+
+    static func fromSeconds(_ timeout: TimeInterval) throws -> UInt64 {
+        guard timeout.isFinite, timeout > 0, timeout <= self.maximumSeconds else {
+            throw TachikomaError.invalidConfiguration("Invalid timeout: \(timeout) seconds")
+        }
+        return UInt64(timeout * 1_000_000_000)
+    }
+}
+
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public func withTimeout<T: Sendable>(
     _ timeout: TimeInterval,
@@ -68,13 +81,14 @@ public func withTimeout<T: Sendable>(
 ) async throws
     -> T
 {
-    try await withThrowingTaskGroup(of: T.self) { group in
+    let timeoutNanoseconds = try TimeoutNanoseconds.fromSeconds(timeout)
+    return try await withThrowingTaskGroup(of: T.self) { group in
         group.addTask {
             try await operation()
         }
 
         group.addTask {
-            try await Task<Never, Never>.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            try await Task<Never, Never>.sleep(nanoseconds: timeoutNanoseconds)
             throw TimeoutError(timeout: timeout)
         }
 

--- a/Sources/Tachikoma/Core/AsyncErgonomics.swift
+++ b/Sources/Tachikoma/Core/AsyncErgonomics.swift
@@ -66,7 +66,7 @@ enum TimeoutNanoseconds {
     static let maximumSeconds = Double(UInt64.max / 1_000_000_000)
 
     static func fromSeconds(_ timeout: TimeInterval) throws -> UInt64 {
-        guard timeout.isFinite, timeout > 0, timeout <= self.maximumSeconds else {
+        guard timeout.isFinite, timeout >= 0, timeout <= self.maximumSeconds else {
             throw TachikomaError.invalidConfiguration("Invalid timeout: \(timeout) seconds")
         }
         return UInt64(timeout * 1_000_000_000)

--- a/Sources/Tachikoma/Core/AsyncErgonomics.swift
+++ b/Sources/Tachikoma/Core/AsyncErgonomics.swift
@@ -63,7 +63,6 @@ public struct CancellableTask<Success: Sendable> {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 enum TimeoutNanoseconds {
-    // UInt64(timeout * 1e9) traps on non-finite, non-positive, and overflow values.
     static let maximumSeconds = Double(UInt64.max / 1_000_000_000)
 
     static func fromSeconds(_ timeout: TimeInterval) throws -> UInt64 {

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -39,6 +39,20 @@ public struct ServerProbeResult: Sendable {
     }
 }
 
+// UInt64(timeoutMs) * 1_000_000 traps on negative Int and overflows Int.max.
+enum ProbeTimeoutNanoseconds {
+    private static let nanosecondsPerMillisecond: UInt64 = 1_000_000
+
+    static func fromMilliseconds(_ timeoutMs: Int) -> UInt64? {
+        guard timeoutMs > 0 else { return nil }
+        let milliseconds = UInt64(timeoutMs)
+        guard milliseconds <= UInt64.max / self.nanosecondsPerMillisecond else {
+            return nil
+        }
+        return milliseconds * self.nanosecondsPerMillisecond
+    }
+}
+
 private enum AutoConnectPolicy {
     private static let overrideLock = MCPOverrideLock(initialState: nil)
     private static let forceEnable =
@@ -301,6 +315,15 @@ public final class TachikomaMCPClientManager {
             )
         }
 
+        guard let timeoutNanoseconds = ProbeTimeoutNanoseconds.fromMilliseconds(timeoutMs) else {
+            return ServerProbeResult(
+                isConnected: false,
+                toolCount: 0,
+                responseTime: Date().timeIntervalSince(start),
+                error: "invalid timeout: \(timeoutMs)ms",
+            )
+        }
+
         // Try to connect with timeout using withTaskGroup for proper cancellation
         let result: (Bool, String?) = await withTaskGroup(of: (Bool, String?).self) { group in
             group.addTask {
@@ -314,7 +337,7 @@ public final class TachikomaMCPClientManager {
 
             group.addTask {
                 do {
-                    try await Task.sleep(nanoseconds: UInt64(timeoutMs) * 1_000_000)
+                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
                     return (false, "timeout after \(timeoutMs)ms")
                 } catch {
                     // Task was cancelled (connection succeeded)

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -40,7 +40,6 @@ public struct ServerProbeResult: Sendable {
 }
 
 enum ProbeTimeoutNanoseconds {
-    // UInt64(timeoutMs) * 1_000_000 traps on negative Int and overflows Int.max.
     private static let nanosecondsPerMillisecond: UInt64 = 1_000_000
 
     static func fromMilliseconds(_ timeoutMs: Int) -> UInt64? {

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -39,8 +39,8 @@ public struct ServerProbeResult: Sendable {
     }
 }
 
-// UInt64(timeoutMs) * 1_000_000 traps on negative Int and overflows Int.max.
 enum ProbeTimeoutNanoseconds {
+    // UInt64(timeoutMs) * 1_000_000 traps on negative Int and overflows Int.max.
     private static let nanosecondsPerMillisecond: UInt64 = 1_000_000
 
     static func fromMilliseconds(_ timeoutMs: Int) -> UInt64? {

--- a/Sources/TachikomaMCP/Client/MCPClientManager.swift
+++ b/Sources/TachikomaMCP/Client/MCPClientManager.swift
@@ -43,7 +43,7 @@ enum ProbeTimeoutNanoseconds {
     private static let nanosecondsPerMillisecond: UInt64 = 1_000_000
 
     static func fromMilliseconds(_ timeoutMs: Int) -> UInt64? {
-        guard timeoutMs > 0 else { return nil }
+        guard timeoutMs >= 0 else { return nil }
         let milliseconds = UInt64(timeoutMs)
         guard milliseconds <= UInt64.max / self.nanosecondsPerMillisecond else {
             return nil

--- a/Tests/TachikomaMCPTests/ProbeTimeoutTests.swift
+++ b/Tests/TachikomaMCPTests/ProbeTimeoutTests.swift
@@ -7,16 +7,17 @@ import Testing
 struct ProbeTimeoutTests {
     @Test
     func `Probe timeout nanoseconds converts finite positive milliseconds`() {
+        #expect(ProbeTimeoutNanoseconds.fromMilliseconds(0) == 0)
         #expect(ProbeTimeoutNanoseconds.fromMilliseconds(1) == 1_000_000)
         #expect(ProbeTimeoutNanoseconds.fromMilliseconds(5000) == 5_000_000_000)
     }
 
-    @Test(arguments: [0, -1, Int.min, Int.max])
+    @Test(arguments: [-1, Int.min, Int.max])
     func `Probe timeout nanoseconds rejects values that trap UInt64`(timeoutMs: Int) {
         #expect(ProbeTimeoutNanoseconds.fromMilliseconds(timeoutMs) == nil)
     }
 
-    @Test(arguments: [0, -1, Int.max])
+    @Test(arguments: [-1, Int.max])
     func `probeServer rejects invalid timeoutMs before sleeping`(timeoutMs: Int) async throws {
         let manager = TachikomaMCPClientManager()
         try await manager.addServer(
@@ -29,5 +30,20 @@ struct ProbeTimeoutTests {
         #expect(result.isConnected == false)
         #expect(result.toolCount == 0)
         #expect(result.error?.contains("invalid timeout") == true)
+    }
+
+    @Test
+    func `probeServer preserves zero as an immediate deadline`() async {
+        let manager = TachikomaMCPClientManager()
+        await manager.initialize(
+            with: ["probe": MCPServerConfig(command: "/tachikoma-nonexistent-command")],
+            connect: false,
+        )
+
+        let result = await manager.probeServer(name: "probe", timeoutMs: 0)
+
+        #expect(result.isConnected == false)
+        #expect(result.error != nil)
+        #expect(result.error?.contains("invalid timeout") == false)
     }
 }

--- a/Tests/TachikomaMCPTests/ProbeTimeoutTests.swift
+++ b/Tests/TachikomaMCPTests/ProbeTimeoutTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import TachikomaMCP
+
+@Suite("MCP probe timeouts")
+@MainActor
+struct ProbeTimeoutTests {
+    @Test
+    func `Probe timeout nanoseconds converts finite positive milliseconds`() {
+        #expect(ProbeTimeoutNanoseconds.fromMilliseconds(1) == 1_000_000)
+        #expect(ProbeTimeoutNanoseconds.fromMilliseconds(5000) == 5_000_000_000)
+    }
+
+    @Test(arguments: [0, -1, Int.min, Int.max])
+    func `Probe timeout nanoseconds rejects values that trap UInt64`(timeoutMs: Int) {
+        #expect(ProbeTimeoutNanoseconds.fromMilliseconds(timeoutMs) == nil)
+    }
+
+    @Test(arguments: [0, -1, Int.max])
+    func `probeServer rejects invalid timeoutMs before sleeping`(timeoutMs: Int) async throws {
+        let manager = TachikomaMCPClientManager()
+        try await manager.addServer(
+            name: "probe",
+            config: MCPServerConfig(command: "never-executed"),
+        )
+
+        let result = await manager.probeServer(name: "probe", timeoutMs: timeoutMs)
+
+        #expect(result.isConnected == false)
+        #expect(result.toolCount == 0)
+        #expect(result.error?.contains("invalid timeout") == true)
+    }
+}

--- a/Tests/TachikomaTests/AsyncErgonomicsTests.swift
+++ b/Tests/TachikomaTests/AsyncErgonomicsTests.swift
@@ -105,13 +105,13 @@ struct AsyncErgonomicsTests {
 
     @Test
     func `Timeout nanoseconds converts finite positive seconds`() throws {
+        #expect(try TimeoutNanoseconds.fromSeconds(0) == 0)
         #expect(try TimeoutNanoseconds.fromSeconds(1) == 1_000_000_000)
         #expect(try TimeoutNanoseconds.fromSeconds(0.5) == 500_000_000)
         #expect(try TimeoutNanoseconds.fromSeconds(TimeoutNanoseconds.maximumSeconds) > 0)
     }
 
     @Test(arguments: [
-        0,
         -1,
         .infinity,
         -.infinity,
@@ -135,7 +135,6 @@ struct AsyncErgonomicsTests {
     }
 
     @Test(arguments: [
-        0,
         -1,
         .infinity,
         -.infinity,
@@ -163,6 +162,19 @@ struct AsyncErgonomicsTests {
         }
 
         #expect(await probe.didStart() == false)
+    }
+
+    @Test
+    func `With timeout preserves zero as an immediate deadline`() async throws {
+        do {
+            _ = try await withTimeout(0) {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                return "Should timeout"
+            }
+            Issue.record("Should have timed out")
+        } catch let error as TimeoutError {
+            #expect(error.timeout == 0)
+        }
     }
 
     @Test

--- a/Tests/TachikomaTests/AsyncErgonomicsTests.swift
+++ b/Tests/TachikomaTests/AsyncErgonomicsTests.swift
@@ -104,6 +104,68 @@ struct AsyncErgonomicsTests {
     }
 
     @Test
+    func `Timeout nanoseconds converts finite positive seconds`() throws {
+        #expect(try TimeoutNanoseconds.fromSeconds(1) == 1_000_000_000)
+        #expect(try TimeoutNanoseconds.fromSeconds(0.5) == 500_000_000)
+        #expect(try TimeoutNanoseconds.fromSeconds(TimeoutNanoseconds.maximumSeconds) > 0)
+    }
+
+    @Test(arguments: [
+        0,
+        -1,
+        .infinity,
+        -.infinity,
+        .nan,
+        TimeoutNanoseconds.maximumSeconds.nextUp,
+        .greatestFiniteMagnitude,
+    ])
+    func `Timeout nanoseconds rejects values that trap UInt64`(timeout: TimeInterval) {
+        do {
+            _ = try TimeoutNanoseconds.fromSeconds(timeout)
+            Issue.record("Should have rejected timeout \(timeout)")
+        } catch let error as TachikomaError {
+            guard case let .invalidConfiguration(message) = error else {
+                Issue.record("Expected invalidConfiguration, got \(error)")
+                return
+            }
+            #expect(message.contains("Invalid timeout"))
+        } catch {
+            Issue.record("Expected TachikomaError, got \(error)")
+        }
+    }
+
+    @Test(arguments: [
+        0,
+        -1,
+        .infinity,
+        -.infinity,
+        .nan,
+        TimeoutNanoseconds.maximumSeconds.nextUp,
+        .greatestFiniteMagnitude,
+    ])
+    func `With timeout rejects invalid values before starting work`(timeout: TimeInterval) async {
+        let probe = TimeoutStartProbe()
+
+        do {
+            _ = try await withTimeout(timeout) {
+                await probe.markStarted()
+                return "should not run"
+            }
+            Issue.record("Should have rejected timeout \(timeout)")
+        } catch let error as TachikomaError {
+            guard case let .invalidConfiguration(message) = error else {
+                Issue.record("Expected invalidConfiguration, got \(error)")
+                return
+            }
+            #expect(message.contains("Invalid timeout"))
+        } catch {
+            Issue.record("Expected TachikomaError, got \(error)")
+        }
+
+        #expect(await probe.didStart() == false)
+    }
+
+    @Test
     func `Async stream collect basic`() async throws {
         let stream = AsyncThrowingStream<Int, Error> { continuation in
             continuation.yield(1)
@@ -147,5 +209,17 @@ struct AsyncErgonomicsTests {
 
         // The long task should have been cancelled
         #expect(flag.cancelled == true)
+    }
+}
+
+private actor TimeoutStartProbe {
+    private var started = false
+
+    func markStarted() {
+        self.started = true
+    }
+
+    func didStart() -> Bool {
+        self.started
     }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,8 @@ Some suites rely on live credentials even without `INTEGRATION_TESTS`, e.g. CLI 
 
 ## 5. Troubleshooting tips
 
+Generation timeouts use seconds; MCP health-check timeouts use milliseconds. Zero remains an immediate deadline that races the operation. Negative, non-finite, and overflowing durations are rejected before starting the timed operation. An already-connected MCP server returns its cached health without starting a timer.
+
 - **Missing API key errors**: confirm `source ~/.profile` (or your secrets manager) before launching `swift test`. The helper prints the provider name in the exception message.
 - **Hanging tests**: rerun inside `tmux` and watch `/tmp/tachikoma-swift-test.log` so the log survives a disconnected shell.
 - **Coverage gaps**: run the coverage command above; the report lists the lowest-covered files so you can target new tests.


### PR DESCRIPTION
Invalid generation and MCP probe timeouts can crash the process during conversion to UInt64 nanoseconds. Validate negative, non-finite, and overflowing durations before starting timed work, while preserving zero as an immediate deadline and the existing already-connected MCP fast path.

Regression coverage checks rejection before work, valid conversions, and zero-duration generation/probe behavior. This repairs the zero-timeout compatibility concern in the original proposal. The changelog credits @SebTardif.

Validation: the full hermetic suite passed (870 core + 71 MCP tests), SwiftFormat and strict SwiftLint passed, and independent branch autoreview is clean through P2. A separate compiled Swift consumer exercised the public timeout and MCP APIs, proving invalid inputs reject before work and valid/zero durations retain their behavior. Main's negative-timeout crash was reproduced in Swift. Detailed commands and runtime output are in the maintainer proof comment.

CI for the repaired head: https://github.com/openclaw/Tachikoma/actions/runs/33987405772
