### PR TITLE
fix: reject empty Google stream base URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [0.4.1] - Unreleased
 
+### Fixed
+- Google generation and streaming now reject empty and malformed base URLs; shared endpoint joining preserves percent-encoded proxy paths. Thanks @SebTardif (#85).
+
 ### Changed
 - Updated Swift Crypto to 4.5.2, ASN.1 to 1.7.2, and NIO to 2.102.0; refreshed CI to Swift 6.2.4 and SwiftFormat 0.63.0 while retaining Swift 6.2 support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,8 @@ All notable changes to the Tachikoma project will be documented in this file.
 
 ## [0.4.1] - Unreleased
 
-### Fixed
-- Google generation and streaming now reject empty and malformed base URLs; shared endpoint joining preserves percent-encoded proxy paths. Thanks @SebTardif (#85).
-
 ### Changed
+- Google generation and streaming now reject empty and malformed base URLs; shared endpoint joining preserves percent-encoded proxy paths. Thanks @SebTardif (#85).
 - Updated Swift Crypto to 4.5.2, ASN.1 to 1.7.2, and NIO to 2.102.0; refreshed CI to Swift 6.2.4 and SwiftFormat 0.63.0 while retaining Swift 6.2 support.
 
 ## [0.4.0] - 2026-08-31

--- a/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
+++ b/Sources/Tachikoma/Core/OpenAICompatibleHelper.swift
@@ -887,10 +887,13 @@ struct OpenAICompatibleHelper {
             throw TachikomaError.invalidConfiguration("Invalid base URL: \(baseURL)")
         }
 
-        let basePath = components.path
+        let basePath = components.percentEncodedPath
         let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
         let trimmedBase = basePath.hasSuffix("/") ? String(basePath.dropLast()) : basePath
-        components.path = trimmedBase + normalizedPath
+        var suffix = URLComponents()
+        suffix.path = normalizedPath
+        // Decoding the base path would turn an encoded slash into a route separator.
+        components.percentEncodedPath = trimmedBase + suffix.percentEncodedPath
 
         var mergedQueryItems = components.queryItems ?? []
         mergedQueryItems.append(contentsOf: queryItems)

--- a/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
+++ b/Sources/Tachikoma/Providers/Google/GoogleProvider.swift
@@ -330,24 +330,27 @@ extension GoogleProvider {
     }
 
     private func makeStreamRequest(body: Data) throws -> URLRequest {
-        guard let baseURL else {
-            throw TachikomaError.invalidConfiguration("Google base URL is missing")
-        }
         guard let apiKey else {
             throw TachikomaError.authenticationFailed("GEMINI_API_KEY not found")
         }
 
-        var components = URLComponents(string: "\(baseURL)/models/\(apiModelName):streamGenerateContent")
-        var items = components?.queryItems ?? []
+        let url = try OpenAICompatibleHelper.endpointURL(
+            baseURL: self.baseURL,
+            path: "/models/\(self.apiModelName):streamGenerateContent",
+        )
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw TachikomaError.invalidConfiguration("Invalid Google streaming URL")
+        }
+        var items = components.queryItems ?? []
         items.append(URLQueryItem(name: "alt", value: "sse"))
         items.append(URLQueryItem(name: "key", value: apiKey))
-        components?.queryItems = items
+        components.queryItems = items
 
-        guard let url = components?.url else {
+        guard let streamURL = components.url else {
             throw TachikomaError.invalidConfiguration("Invalid Google streaming URL")
         }
 
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: streamURL)
         request.httpMethod = "POST"
         request.httpBody = body
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
+++ b/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
@@ -107,6 +107,54 @@ struct InvalidProviderBaseURLTests {
         }
     }
 
+    @Test
+    func `Google generate throws on empty base URL`() async throws {
+        let provider = try self.googleProvider(baseURL: "")
+
+        await self.expectInvalidBaseURL {
+            _ = try await provider.generateText(request: self.sampleRequest)
+        }
+    }
+
+    @Test
+    func `Google stream throws on empty base URL`() async throws {
+        let provider = try self.googleProvider(baseURL: "")
+
+        await self.expectInvalidBaseURL {
+            try await self.consumeGoogleStream(provider)
+        }
+    }
+
+    @Test
+    func `Google stream throws on whitespace-only base URL`() async throws {
+        let provider = try self.googleProvider(baseURL: "   ")
+
+        await self.expectInvalidBaseURL {
+            try await self.consumeGoogleStream(provider)
+        }
+    }
+
+    @Test
+    func `Google stream throws on malformed base URL`() async throws {
+        let provider = try self.googleProvider(baseURL: Self.malformedBaseURL)
+
+        await self.expectInvalidBaseURL {
+            try await self.consumeGoogleStream(provider)
+        }
+    }
+
+    private func googleProvider(baseURL: String) throws -> GoogleProvider {
+        let config = TachikomaConfiguration(loadFromEnvironment: false)
+        config.setAPIKey("test-key", for: .google)
+        config.setBaseURL(baseURL, for: .google)
+        return try GoogleProvider(model: .gemini25Flash, configuration: config)
+    }
+
+    private func consumeGoogleStream(_ provider: GoogleProvider) async throws {
+        let stream = try await provider.streamText(request: self.sampleRequest)
+        for try await _ in stream {}
+    }
+
     private func responsesProvider(baseURL: String) throws -> OpenAIResponsesProvider {
         let config = TachikomaConfiguration(loadFromEnvironment: false)
         config.setAPIKey("sk-test", for: .openai)

--- a/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
+++ b/Tests/TachikomaTests/Providers/InvalidProviderBaseURLTests.swift
@@ -150,6 +150,35 @@ struct InvalidProviderBaseURLTests {
         return try GoogleProvider(model: .gemini25Flash, configuration: config)
     }
 
+    @Test(arguments: [
+        ("https://generativelanguage.googleapis.com/v1beta", "/v1beta/models/gemini-2.5-flash:streamGenerateContent"),
+        ("https://proxy.example.test/team%2Fblue/v1/", "/team%2Fblue/v1/models/gemini-2.5-flash:streamGenerateContent"),
+        ("https://proxy.example.test/a%25b/%23route", "/a%25b/%23route/models/gemini-2.5-flash:streamGenerateContent"),
+    ])
+    func `Endpoint URL preserves encoded base path`(baseURL: String, expectedPath: String) throws {
+        let url = try OpenAICompatibleHelper.endpointURL(
+            baseURL: baseURL,
+            path: "/models/gemini-2.5-flash:streamGenerateContent",
+        )
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.percentEncodedPath == expectedPath)
+    }
+
+    @Test
+    func `Endpoint URL encodes suffix and preserves base query`() throws {
+        let url = try OpenAICompatibleHelper.buildURL(
+            baseURL: "https://proxy.example.test/team%2Fblue?tenant=one",
+            path: "models/a b%/#tag",
+            queryItems: [URLQueryItem(name: "alt", value: "sse")],
+        )
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.percentEncodedPath == "/team%2Fblue/models/a%20b%25/%23tag")
+        #expect(components.queryItems == [
+            URLQueryItem(name: "tenant", value: "one"),
+            URLQueryItem(name: "alt", value: "sse"),
+        ])
+    }
+
     private func consumeGoogleStream(_ provider: GoogleProvider) async throws {
         let stream = try await provider.streamText(request: self.sampleRequest)
         for try await _ in stream {}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,8 @@ Some suites rely on live credentials even without `INTEGRATION_TESTS`, e.g. CLI 
 
 ## 5. Troubleshooting tips
 
+Google generation and streaming reject empty, whitespace-only, and malformed configured base URLs with `TachikomaError.invalidConfiguration`. Custom provider base paths retain percent-encoded segments such as `team%2Fblue` when endpoint paths are appended.
+
 - **Missing API key errors**: confirm `source ~/.profile` (or your secrets manager) before launching `swift test`. The helper prints the provider name in the exception message.
 - **Hanging tests**: rerun inside `tmux` and watch `/tmp/tachikoma-swift-test.log` so the log survives a disconnected shell.
 - **Coverage gaps**: run the coverage command above; the report lists the lowest-covered files so you can target new tests.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,6 +45,8 @@ Maintainers can run the same credentialed smoke suite from the manual **Live Pro
 
 ## 3. Provider-specific real workflows
 
+Google generation and streaming reject empty, whitespace-only, and malformed configured base URLs with `TachikomaError.invalidConfiguration`. Custom provider base paths retain percent-encoded segments such as `team%2Fblue` when endpoint paths are appended.
+
 Some suites rely on live credentials even without `INTEGRATION_TESTS`, e.g. CLI workflows or manual reproduction of regressions.
 
 - `Tests/TachikomaTests/GrokDebugTest.swift` only runs fully when `TACHIKOMA_TEST_MODE` is not `mock` *and* a Grok key is set.
@@ -63,8 +65,6 @@ Some suites rely on live credentials even without `INTEGRATION_TESTS`, e.g. CLI 
 | `REPLICATE_PREFERRED_OUTPUT=turbo` | Adds `Prefer: wait=false` to Replicate calls during tests. |
 
 ## 5. Troubleshooting tips
-
-Google generation and streaming reject empty, whitespace-only, and malformed configured base URLs with `TachikomaError.invalidConfiguration`. Custom provider base paths retain percent-encoded segments such as `team%2Fblue` when endpoint paths are appended.
 
 - **Missing API key errors**: confirm `source ~/.profile` (or your secrets manager) before launching `swift test`. The helper prints the provider name in the exception message.
 - **Hanging tests**: rerun inside `tmux` and watch `/tmp/tachikoma-swift-test.log` so the log survives a disconnected shell.


### PR DESCRIPTION
Google generation and streaming accepted explicitly empty base URLs and constructed relative request paths. Use the shared endpoint validator before adding Google query parameters, and repair its URL joining so existing encoded custom proxy paths such as `team%2Fblue` remain intact.

The shared builder now preserves the encoded base and encodes only the appended suffix. Coverage checks invalid Google bases, the default endpoint, encoded slash/percent/hash segments, suffix escaping, and query preservation. The changelog credits @SebTardif.

Validation: the full hermetic suite passed (872 core + 67 MCP tests), both style checks passed, and final branch autoreview is clean through P2. A separate compiled Swift consumer exercised both Google APIs: six real local HTTP requests preserved ordinary/encoded targets and returned parsed SSE text. A separate URLProtocol capture verified the default Google target. Empty, whitespace-only, and malformed bases rejected before network I/O. Detailed commands and output are in the maintainer proof comment; no hosted Gemini call was needed for this URL-construction fix.

CI for the repaired head: https://github.com/openclaw/Tachikoma/actions/runs/33987762315
